### PR TITLE
Update .gitignore to ignore dot folders and remove incorrectly formatted comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@
 *.iex
 
 # STM32CubeMx
-*.mxproject
+.mxproject
 
 # To explicitly override the above, define any exceptions here; e.g.:
 # !my_customized_scatter_file.sct


### PR DESCRIPTION
### Summary
Remove comments at the end of line in `.gitignore` because a proper comment in `.gitignore` should have a `#` at the **beginning** of the line. Add support in `.gitignore` to ignore dot folders. And fix syntax for ignoring `.mxproject`.

### Testing Done

### Resolved Issues

### Checklist
*Please change `[]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow. I understand that not doing so will waste my reviewer's time.



