### PR TITLE
Remove .clang-format for STM32-CAN-Code

### DIFF
--- a/src/shared/STM32-CAN-Code/.clang-format
+++ b/src/shared/STM32-CAN-Code/.clang-format
@@ -1,3 +1,0 @@
-# This prevents clang-format from applying formatting to this folder
-BasedOnStyle: None
-


### PR DESCRIPTION
### Summary
There was a legacy `.clang-format` left inside STM32-CAN-Code that would exempt the folder from clang-format. This was not the intended behaviour so this `.clang-format` is removed

### Testing Done


### Resolved Issues


### Checklist
*Please change `[]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).



