### PR TITLE
Add PDM board constant and change to c11 standard

### DIFF
--- a/src/PDM/MDK-ARM/PDM.uvprojx
+++ b/src/PDM/MDK-ARM/PDM.uvprojx
@@ -327,7 +327,7 @@
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>6</v6Lang>
+            <v6Lang>5</v6Lang>
             <v6LangP>3</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
@@ -336,7 +336,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls></MiscControls>
-              <Define>USE_HAL_DRIVER,STM32F302x8</Define>
+              <Define>USE_HAL_DRIVER,STM32F302x8, PDM</Define>
               <Undefine></Undefine>
               <IncludePath>../Inc;  ../Drivers/STM32F3xx_HAL_Driver/Inc;  ../Drivers/STM32F3xx_HAL_Driver/Inc/Legacy;  ../Drivers/CMSIS/Device/ST/STM32F3xx/Include;  ../Drivers/CMSIS/Include;  ..\..\shared\STM32-CAN-Code\Inc</IncludePath>
             </VariousControls>


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
- Quickly added the board name (PDM) to the list of -D define constants that get used during compilation
- Change from gnu11 to c11 standard in compiler stetting

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).