### PR TITLE
Remove PI from Constants.h

### DIFF
--- a/src/shared/Constants.h
+++ b/src/shared/Constants.h
@@ -13,7 +13,6 @@
 * Preprocessor Constants
 *******************************************************************************/
 // clang-format off
-#define PI          (float)(3.14159265359)
 // clang-format on
 
 #endif /* CONSTANTS_H */


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
As it turns out, `arm_math.h` already includes a definition for PI. `arm_math.h` is needed whenever floating point calculations are done because it includes `float32_t`. Whenever we need `PI`, we will need floating point calculations which means `arm_math.h` would be included so we should just use the `PI` in `arm_math.h`.
### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[]` to `[x]` when you are ready.*
- [ ] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).