### PR TITLE
Add comments to confusing adc_index logic

### DIFF
--- a/src/PDM/Src/CurrentSense.c
+++ b/src/PDM/Src/CurrentSense.c
@@ -51,6 +51,9 @@ void CurrentSense_LowPassFilterADCReadings(volatile uint32_t *adc_readings)
 {
     uint8_t adc_channel = CurrentSense_DSELShiftIndex();
     uint8_t final_index = adc_channel + ADC_CHANNEL_COUNT;
+    // adc_index is set to ADC_CHANNEL_COUNT because of the bug described in
+    // NUM_READINGS_PER_ADC_DMA_TRANSFER - that is, we only use the second half
+    // of adc_readings[]
     uint8_t adc_index   = ADC_CHANNEL_COUNT;
     for (; adc_channel < final_index; adc_channel++)
     {


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
Adding comment that will help me refactor the confusing ADC channel enum logic later on. Doesn't really fit in any issue so I'm just going to submit a PR to get it over with.

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).