### PR TITLE
Combine GPIO Pin and Port into one struct in shared GPIO library

### DIFF
--- a/src/shared/GPIO/Inc/SharedGpio.h
+++ b/src/shared/GPIO/Inc/SharedGpio.h
@@ -33,6 +33,11 @@
  * Typedefs
  ******************************************************************************/
 // clang-format on
+typedef struct
+{
+    uint16_t      pin;
+    GPIO_TypeDef *port;
+} GPIO_PinPort_Struct;
 
 /******************************************************************************
  * Global Variables


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Created helper struct that combines GPIO pin and port. This is useful because `HAL_GPIO_WritePin` requires GPIO pin as well as port.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
