### PR TITLE
 Fix data type for arguments in LPF library

### DIFF
--- a/src/shared/Filters/Inc/SharedFilters.h
+++ b/src/shared/Filters/Inc/SharedFilters.h
@@ -50,12 +50,13 @@
  * @param input Pointer to an array of input samples
  * @param output Pointer to an array of output samples
  * @param sampling_time Sampling time interval for input and output samples
+ *                      in seconds
  * @param rc RC time constant
  */
 void SharedFilters_LowPassFilter(
     float32_t *input,
     float32_t *output,
-    uint32_t   sampling_time,
-    uint32_t   rc);
+    float32_t  sampling_time,
+    float32_t  rc);
 
 #endif /* SHARED_FILTERS_H */

--- a/src/shared/Filters/Src/SharedFilters.c
+++ b/src/shared/Filters/Src/SharedFilters.c
@@ -34,10 +34,10 @@
 void SharedFilters_LowPassFilter(
     float32_t *input,
     float32_t *output,
-    uint32_t   sampling_time,
-    uint32_t   rc)
+    float32_t  sampling_time,
+    float32_t  rc)
 {
-    uint32_t smoothing_factor;
+    float32_t smoothing_factor;
 
     smoothing_factor = sampling_time / (rc + sampling_time);
 


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The arguments for the low pass filter should be `float32_t` instead of `uint32_t`
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
