### PR TITLE
Possible Cross-OS CMakeLists.txt Fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(FORMULA_E C ASM)
 cmake_minimum_required(VERSION 3.2)
+include(CMakeForceCompiler)
 
 ##############################################
 ###                                        ###
@@ -17,20 +17,6 @@ MACRO(SUBDIRLIST result curdir)
   ENDFOREACH()
   SET(${result} ${dirlist})
 ENDMACRO()
-
-################################################################################
-##                                                                             #
-##                         CODE COMPILATION BEGINS HERE                        #
-##                                                                             #
-##                      Append the list of module directories                  #
-##    WARNING! Ensure module name in the string list matches directory name!   #
-##                                                                             #
-################################################################################
-
-set(MODULES "PDM FSM DCM BMS")
-
-#Create string list
-string(REPLACE " " ";" MODULES ${MODULES})
 
 ##############################################
 ###                                        ###
@@ -63,8 +49,7 @@ endif(BINUTILS_PATH)
 get_filename_component(ARM_TOOLCHAIN_DIR ${BINUTILS_PATH} DIRECTORY)
 set(triple ${TOOLCHAIN_TRIPLE})
 set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}as)
-set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}gcc)
-set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}g++)
+CMAKE_FORCE_C_COMPILER(${TOOLCHAIN_PREFIX}gcc GNU)
 
 set(CMAKE_OBJCOPY ${ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}objcopy CACHE INTERNAL "objcopy tool")
 set(CMAKE_SIZE_UTIL ${ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}size CACHE INTERNAL "size tool")
@@ -77,6 +62,21 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Build/Lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Build/Lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Build)
+
+################################################################################
+##                                                                             #
+##                         CODE COMPILATION BEGINS HERE                        #
+##                                                                             #
+##                      Append the list of module directories                  #
+##    WARNING! Ensure module name in the string list matches directory name!   #
+##                                                                             #
+################################################################################
+project(FORMULA_E C ASM)
+
+set(MODULES "PDM FSM DCM BMS")
+
+#Create string list
+string(REPLACE " " ";" MODULES ${MODULES})
 
 ##############################################
 ###                                        ###
@@ -176,7 +176,7 @@ foreach(MODULE_DIR ${MODULES})
         set(T32 -mthumb)
         set(FLOAT_ABI -mfloat-abi=soft) 
         set(BOARD -DSTM32F302x8) 
-        set(MATH_LIB -DARM_MATH_CM4)   
+        set(MATH_LIB -DARM_MATH_CM4)  
         set(LINKER_SCRIPT STM32F302R8Tx_FLASH.ld)
         set(HAL_BOARD_DIR STM32F3xx)
 


### PR DESCRIPTION
### Summary
Encountered new issues when setting up CI on my Windows partition and added new CMake directives to address this. The major change is to force the compiler to recognize `arm-none-eabi-gcc` as the compiler without running any tests. Am still encountering issues where `make` command will only run without errors from `cmder` or `MinGW` applications, not the traditional Windows terminal.

### Changelist 
* Forced CMake to recognize `arm-none-eabi-gcc` as compiler which seems to be an issue in 

### Testing Done
Built on my own PC, both Windows and Linux partition

### Resolved Issues
Cross-compatibility error

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x ] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [ x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
