### PR TITLE
Remove unused FSM.cfg

### DIFF
--- a/src/FSM/FSM.cfg
+++ b/src/FSM/FSM.cfg
@@ -1,3 +1,0 @@
-source [find interface/jlink.cfg]
-transport select swd
-source [find target/stm32f3x.cfg]


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Forgot to remove `FSM.cg`. It was replaced by `shared/OpenOCD/stm32f3x.cfg`

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
Not applicable

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
