### PR TITLE
Ignore CMake artifacts and stm32f3xx_hal_conf.h in clang-format

### DIFF
--- a/clang-format/fix_formatting.py
+++ b/clang-format/fix_formatting.py
@@ -50,7 +50,9 @@ def runClangFormat():
     EXCLUDE_DIRS = [
         "Middleswares", # STM32CubeMX generated libraries
         "Drivers",      # STM32CubeMX generated libraries
-        "cmake-build-debug"
+        "cmake-build-debug",
+        "CMakeFiles",
+        "stm32f3xx_hal_conf.h",
     ]
 
     # Print the current working directory since the paths are relative


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Ignore some more CMake artifacts that are slowing down `clang-format`. 
- Ignore `stm32f3xx_hal_conf.h` because it doesn't need to be modified by the user and everytime you run `clang-format` on it, it will append an extra `\` like so:
```
-#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \
-                        The real value may vary depending on the variations  \
-                        in voltage and temperature.  */
+#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \ \
+                        \                                                      \
+                        The real value may vary depending on the variations  \ \
+                        \ in voltage and temperature.  */
```

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
