### PR TITLE
Regenerate stm32f3xx_hal_conf.h and stop clang-formatting it

### DIFF
--- a/clang-format/fix_formatting.py
+++ b/clang-format/fix_formatting.py
@@ -43,7 +43,8 @@ def runClangFormat():
     # Ignore auto-generated files
     EXCLUDE_FILES = [
         "CanMsgs.c",
-        "CanMsgs.h"
+        "CanMsgs.h",
+        "stm32f3xx_hal_conf.h",
     ]
 
     # Ignore auto-generated directories
@@ -52,7 +53,6 @@ def runClangFormat():
         "Drivers",      # STM32CubeMX generated libraries
         "cmake-build-debug",
         "CMakeFiles",
-        "stm32f3xx_hal_conf.h",
     ]
 
     # Print the current working directory since the paths are relative

--- a/src/DCM/Inc/stm32f3xx_hal_conf.h
+++ b/src/DCM/Inc/stm32f3xx_hal_conf.h
@@ -1,58 +1,54 @@
 /**
- ******************************************************************************
- * @file    stm32f3xx_hal_conf.h
- * @brief   HAL configuration file.
- ******************************************************************************
- * @attention
- *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
- *
- * Redistribution and use in source and binary forms, with or without
- *modification, are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *notice, this list of conditions and the following disclaimer in the
- *documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************
- */
+  ******************************************************************************
+  * @file    stm32f3xx_hal_conf.h
+  * @brief   HAL configuration file.  
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32F3xx_HAL_CONF_H
 #define __STM32F3xx_HAL_CONF_H
 
 #ifdef __cplusplus
-extern "C"
-{
+ extern "C" {
 #endif
 
-    /* Exported types
-     * ------------------------------------------------------------*/
-    /* Exported constants
-     * --------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
 
-    /* ########################## Module Selection ############################## */
-    /**
-     * @brief This is the list of modules to be used in the HAL driver
-     */
-
-#define HAL_MODULE_ENABLED
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver 
+  */
+  
+#define HAL_MODULE_ENABLED  
 #define HAL_ADC_MODULE_ENABLED
 /*#define HAL_CRYP_MODULE_ENABLED   */
 #define HAL_CAN_MODULE_ENABLED
@@ -94,276 +90,261 @@ extern "C"
 #define HAL_I2C_MODULE_ENABLED
 /* ########################## HSE/HSI Values adaptation ##################### */
 /**
- * @brief Adjust the value of External High Speed oscillator (HSE) used in your
- * application. This value is used by the RCC HAL module to compute the system
- * frequency (when HSE is used as system clock source, directly or through the
- * PLL).
- */
-#if !defined(HSE_VALUE)
-#define HSE_VALUE \
-    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
-#endif                  /* HSE_VALUE */
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).  
+  */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
 
 /**
- * @brief In the following line adjust the External High Speed oscillator (HSE)
- * Startup Timeout value
- */
-#if !defined(HSE_STARTUP_TIMEOUT)
-#define HSE_STARTUP_TIMEOUT \
-    ((uint32_t)100) /*!< Time out for HSE start up, in ms */
-#endif              /* HSE_STARTUP_TIMEOUT */
+  * @brief In the following line adjust the External High Speed oscillator (HSE) Startup 
+  *        Timeout value 
+  */
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
 
 /**
- * @brief Internal High Speed oscillator (HSI) value.
- *        This value is used by the RCC HAL module to compute the system
- * frequency (when HSI is used as system clock source, directly or through the
- * PLL).
- */
-#if !defined(HSI_VALUE)
-#define HSI_VALUE \
-    ((uint32_t)8000000) /*!< Value of the Internal oscillator in Hz*/
-#endif                  /* HSI_VALUE */
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL). 
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)8000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
 
 /**
- * @brief In the following line adjust the Internal High Speed oscillator (HSI)
- * Startup Timeout value
- */
-#if !defined(HSI_STARTUP_TIMEOUT)
-#define HSI_STARTUP_TIMEOUT ((uint32_t)5000) /*!< Time out for HSI start up */
-#endif                                       /* HSI_STARTUP_TIMEOUT */
+  * @brief In the following line adjust the Internal High Speed oscillator (HSI) Startup 
+  *        Timeout value 
+  */
+#if !defined  (HSI_STARTUP_TIMEOUT) 
+ #define HSI_STARTUP_TIMEOUT   ((uint32_t)5000) /*!< Time out for HSI start up */
+#endif /* HSI_STARTUP_TIMEOUT */  
 
 /**
- * @brief Internal Low Speed oscillator (LSI) value.
- */
-#if !defined(LSI_VALUE)
-#define LSI_VALUE ((uint32_t)40000)
-#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \
-                        The real value may vary depending on the variations  \
-                        in voltage and temperature.  */
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE) 
+ #define LSI_VALUE  ((uint32_t)40000)    
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
 /**
- * @brief External Low Speed oscillator (LSE) value.
- */
-#if !defined(LSE_VALUE)
-#define LSE_VALUE \
-    ((uint32_t)32768) /*!< Value of the External Low Speed oscillator in Hz */
-#endif                /* LSE_VALUE */
-
-/**
- * @brief Time out for LSE start up value in ms.
- */
-#if !defined(LSE_STARTUP_TIMEOUT)
-#define LSE_STARTUP_TIMEOUT \
-    ((uint32_t)5000) /*!< Time out for LSE start up, in ms */
-#endif               /* LSE_STARTUP_TIMEOUT */
+  * @brief External Low Speed oscillator (LSE) value.
+  */
+#if !defined  (LSE_VALUE)
+ #define LSE_VALUE  ((uint32_t)32768)    /*!< Value of the External Low Speed oscillator in Hz */
+#endif /* LSE_VALUE */     
 
 /**
- * @brief External clock source for I2S peripheral
- *        This value is used by the I2S HAL module to compute the I2S clock
- * source frequency, this source is inserted directly through I2S_CKIN pad.
- *        - External clock generated through external PLL component on EVAL 303
- * (based on MCO or crystal)
- *        - External clock not generated on EVAL 373
- */
-#if !defined(EXTERNAL_CLOCK_VALUE)
-#define EXTERNAL_CLOCK_VALUE \
-    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz*/
-#endif                  /* EXTERNAL_CLOCK_VALUE */
+  * @brief Time out for LSE start up value in ms.
+  */
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
 
-    /* Tip: To avoid modifying this file each time you need to use different
-       HSE,
-       ===  you can define the HSE value in your toolchain compiler
-       preprocessor. */
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source 
+  *        frequency, this source is inserted directly through I2S_CKIN pad.
+  *        - External clock generated through external PLL component on EVAL 303 (based on MCO or crystal)
+  *        - External clock not generated on EVAL 373
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
 
-    /* ########################### System Configuration ######################### */
-    /**
-     * @brief This is the HAL system configuration section
-     */
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
 
-#define VDD_VALUE ((uint32_t)3300) /*!< Value of VDD in mv */
-#define TICK_INT_PRIORITY \
-    ((uint32_t)0) /*!< tick interrupt priority (lowest by default)  */
-#define USE_RTOS 0
-#define PREFETCH_ENABLE 1
-#define INSTRUCTION_CACHE_ENABLE 0
-#define DATA_CACHE_ENABLE 0
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */     
 
-    /* ########################## Assert Selection ############################## */
-    /**
-     * @brief Uncomment the line below to expanse the "assert_param" macro in
-     * the HAL drivers code
-     */
-    /* #define USE_FULL_ASSERT    1U */
+#define  VDD_VALUE                   ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0)    /*!< tick interrupt priority (lowest by default)  */            
+#define  USE_RTOS                     0
+#define  PREFETCH_ENABLE              1
+#define  INSTRUCTION_CACHE_ENABLE     0
+#define  DATA_CACHE_ENABLE            0
 
-    /* ################## SPI peripheral configuration ########################## */
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1U */
 
-    /* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
-     * Activated: CRC code is present inside driver
-     * Deactivated: CRC code cleaned from driver
-     */
+/* ################## SPI peripheral configuration ########################## */
 
-#define USE_SPI_CRC 0U
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+* Activated: CRC code is present inside driver
+* Deactivated: CRC code cleaned from driver
+*/
 
-    /* Includes
-     * ------------------------------------------------------------------*/
-    /**
-     * @brief Include module's header file
-     */
+#define USE_SPI_CRC                     0U
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file 
+  */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-#include "stm32f3xx_hal_rcc.h"
+ #include "stm32f3xx_hal_rcc.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
 
 #ifdef HAL_EXTI_MODULE_ENABLED
-#include "stm32f3xx_hal_exti.h"
+ #include "stm32f3xx_hal_exti.h"
 #endif /* HAL_EXTI_MODULE_ENABLED */
 
 #ifdef HAL_GPIO_MODULE_ENABLED
-#include "stm32f3xx_hal_gpio.h"
+ #include "stm32f3xx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_DMA_MODULE_ENABLED
-#include "stm32f3xx_hal_dma.h"
+  #include "stm32f3xx_hal_dma.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
-
+   
 #ifdef HAL_CORTEX_MODULE_ENABLED
-#include "stm32f3xx_hal_cortex.h"
+ #include "stm32f3xx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-#include "stm32f3xx_hal_adc.h"
+ #include "stm32f3xx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_CAN_MODULE_ENABLED
-#include "stm32f3xx_hal_can.h"
+ #include "stm32f3xx_hal_can.h"
 #endif /* HAL_CAN_MODULE_ENABLED */
 
 #ifdef HAL_CEC_MODULE_ENABLED
-#include "stm32f3xx_hal_cec.h"
+ #include "stm32f3xx_hal_cec.h"
 #endif /* HAL_CEC_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-#include "stm32f3xx_hal_comp.h"
+ #include "stm32f3xx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-#include "stm32f3xx_hal_crc.h"
+ #include "stm32f3xx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_DAC_MODULE_ENABLED
-#include "stm32f3xx_hal_dac.h"
+ #include "stm32f3xx_hal_dac.h"
 #endif /* HAL_DAC_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-#include "stm32f3xx_hal_flash.h"
+ #include "stm32f3xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_SRAM_MODULE_ENABLED
-#include "stm32f3xx_hal_sram.h"
+  #include "stm32f3xx_hal_sram.h"
 #endif /* HAL_SRAM_MODULE_ENABLED */
 
 #ifdef HAL_NOR_MODULE_ENABLED
-#include "stm32f3xx_hal_nor.h"
+  #include "stm32f3xx_hal_nor.h"
 #endif /* HAL_NOR_MODULE_ENABLED */
 
 #ifdef HAL_NAND_MODULE_ENABLED
-#include "stm32f3xx_hal_nand.h"
+  #include "stm32f3xx_hal_nand.h"
 #endif /* HAL_NAND_MODULE_ENABLED */
 
 #ifdef HAL_PCCARD_MODULE_ENABLED
-#include "stm32f3xx_hal_pccard.h"
-#endif /* HAL_PCCARD_MODULE_ENABLED */
+  #include "stm32f3xx_hal_pccard.h"
+#endif /* HAL_PCCARD_MODULE_ENABLED */ 
 
 #ifdef HAL_HRTIM_MODULE_ENABLED
-#include "stm32f3xx_hal_hrtim.h"
+ #include "stm32f3xx_hal_hrtim.h"
 #endif /* HAL_HRTIM_MODULE_ENABLED */
 
 #ifdef HAL_I2C_MODULE_ENABLED
-#include "stm32f3xx_hal_i2c.h"
+ #include "stm32f3xx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_I2S_MODULE_ENABLED
-#include "stm32f3xx_hal_i2s.h"
+ #include "stm32f3xx_hal_i2s.h"
 #endif /* HAL_I2S_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
-#include "stm32f3xx_hal_irda.h"
+ #include "stm32f3xx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
-#include "stm32f3xx_hal_iwdg.h"
+ #include "stm32f3xx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_OPAMP_MODULE_ENABLED
-#include "stm32f3xx_hal_opamp.h"
+ #include "stm32f3xx_hal_opamp.h"
 #endif /* HAL_OPAMP_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-#include "stm32f3xx_hal_pcd.h"
+ #include "stm32f3xx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
-#include "stm32f3xx_hal_pwr.h"
+ #include "stm32f3xx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
-#include "stm32f3xx_hal_rtc.h"
+ #include "stm32f3xx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SDADC_MODULE_ENABLED
-#include "stm32f3xx_hal_sdadc.h"
+ #include "stm32f3xx_hal_sdadc.h"
 #endif /* HAL_SDADC_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
-#include "stm32f3xx_hal_smartcard.h"
+ #include "stm32f3xx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_SMBUS_MODULE_ENABLED
-#include "stm32f3xx_hal_smbus.h"
+ #include "stm32f3xx_hal_smbus.h"
 #endif /* HAL_SMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPI_MODULE_ENABLED
-#include "stm32f3xx_hal_spi.h"
+ #include "stm32f3xx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
-#include "stm32f3xx_hal_tim.h"
+ #include "stm32f3xx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_TSC_MODULE_ENABLED
-#include "stm32f3xx_hal_tsc.h"
+ #include "stm32f3xx_hal_tsc.h"
 #endif /* HAL_TSC_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
-#include "stm32f3xx_hal_uart.h"
+ #include "stm32f3xx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
-#include "stm32f3xx_hal_usart.h"
+ #include "stm32f3xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
-#include "stm32f3xx_hal_wwdg.h"
+ #include "stm32f3xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
-#ifdef USE_FULL_ASSERT
-    /**
-     * @brief  The assert_param macro is used for function's parameters check.
-     * @param  expr: If expr is false, it calls assert_failed function
-     *         which reports the name of the source file and the source
-     *         line number of the call that failed.
-     *         If expr is true, it returns no value.
-     * @retval None
-     */
-#define assert_param(expr) \
-    ((expr) ? (void)0U : assert_failed((char *)__FILE__, __LINE__))
-    /* Exported functions
-     * ------------------------------------------------------- */
-    void assert_failed(char *file, uint32_t line);
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((char *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(char* file, uint32_t line);
 #else
-#define assert_param(expr) ((void)0U)
-#endif /* USE_FULL_ASSERT */
-
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */    
+    
 #ifdef __cplusplus
 }
 #endif

--- a/src/FSM/Inc/stm32f3xx_hal_conf.h
+++ b/src/FSM/Inc/stm32f3xx_hal_conf.h
@@ -1,58 +1,54 @@
 /**
- ******************************************************************************
- * @file    stm32f3xx_hal_conf.h
- * @brief   HAL configuration file.
- ******************************************************************************
- * @attention
- *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
- *
- * Redistribution and use in source and binary forms, with or without
- *modification, are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *notice, this list of conditions and the following disclaimer in the
- *documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************
- */
+  ******************************************************************************
+  * @file    stm32f3xx_hal_conf.h
+  * @brief   HAL configuration file.  
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32F3xx_HAL_CONF_H
 #define __STM32F3xx_HAL_CONF_H
 
 #ifdef __cplusplus
-extern "C"
-{
+ extern "C" {
 #endif
 
-    /* Exported types
-     * ------------------------------------------------------------*/
-    /* Exported constants
-     * --------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
 
-    /* ########################## Module Selection ############################## */
-    /**
-     * @brief This is the list of modules to be used in the HAL driver
-     */
-
-#define HAL_MODULE_ENABLED
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver 
+  */
+  
+#define HAL_MODULE_ENABLED  
 /*#define HAL_ADC_MODULE_ENABLED   */
 /*#define HAL_CRYP_MODULE_ENABLED   */
 #define HAL_CAN_MODULE_ENABLED
@@ -94,276 +90,261 @@ extern "C"
 #define HAL_I2C_MODULE_ENABLED
 /* ########################## HSE/HSI Values adaptation ##################### */
 /**
- * @brief Adjust the value of External High Speed oscillator (HSE) used in your
- * application. This value is used by the RCC HAL module to compute the system
- * frequency (when HSE is used as system clock source, directly or through the
- * PLL).
- */
-#if !defined(HSE_VALUE)
-#define HSE_VALUE \
-    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
-#endif                  /* HSE_VALUE */
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).  
+  */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
 
 /**
- * @brief In the following line adjust the External High Speed oscillator (HSE)
- * Startup Timeout value
- */
-#if !defined(HSE_STARTUP_TIMEOUT)
-#define HSE_STARTUP_TIMEOUT \
-    ((uint32_t)100) /*!< Time out for HSE start up, in ms */
-#endif              /* HSE_STARTUP_TIMEOUT */
+  * @brief In the following line adjust the External High Speed oscillator (HSE) Startup 
+  *        Timeout value 
+  */
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
 
 /**
- * @brief Internal High Speed oscillator (HSI) value.
- *        This value is used by the RCC HAL module to compute the system
- * frequency (when HSI is used as system clock source, directly or through the
- * PLL).
- */
-#if !defined(HSI_VALUE)
-#define HSI_VALUE \
-    ((uint32_t)8000000) /*!< Value of the Internal oscillator in Hz*/
-#endif                  /* HSI_VALUE */
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL). 
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)8000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
 
 /**
- * @brief In the following line adjust the Internal High Speed oscillator (HSI)
- * Startup Timeout value
- */
-#if !defined(HSI_STARTUP_TIMEOUT)
-#define HSI_STARTUP_TIMEOUT ((uint32_t)5000) /*!< Time out for HSI start up */
-#endif                                       /* HSI_STARTUP_TIMEOUT */
+  * @brief In the following line adjust the Internal High Speed oscillator (HSI) Startup 
+  *        Timeout value 
+  */
+#if !defined  (HSI_STARTUP_TIMEOUT) 
+ #define HSI_STARTUP_TIMEOUT   ((uint32_t)5000) /*!< Time out for HSI start up */
+#endif /* HSI_STARTUP_TIMEOUT */  
 
 /**
- * @brief Internal Low Speed oscillator (LSI) value.
- */
-#if !defined(LSI_VALUE)
-#define LSI_VALUE ((uint32_t)40000)
-#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \
-                        The real value may vary depending on the variations  \
-                        in voltage and temperature.  */
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE) 
+ #define LSI_VALUE  ((uint32_t)40000)    
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
 /**
- * @brief External Low Speed oscillator (LSE) value.
- */
-#if !defined(LSE_VALUE)
-#define LSE_VALUE \
-    ((uint32_t)32768) /*!< Value of the External Low Speed oscillator in Hz */
-#endif                /* LSE_VALUE */
-
-/**
- * @brief Time out for LSE start up value in ms.
- */
-#if !defined(LSE_STARTUP_TIMEOUT)
-#define LSE_STARTUP_TIMEOUT \
-    ((uint32_t)5000) /*!< Time out for LSE start up, in ms */
-#endif               /* LSE_STARTUP_TIMEOUT */
+  * @brief External Low Speed oscillator (LSE) value.
+  */
+#if !defined  (LSE_VALUE)
+ #define LSE_VALUE  ((uint32_t)32768)    /*!< Value of the External Low Speed oscillator in Hz */
+#endif /* LSE_VALUE */     
 
 /**
- * @brief External clock source for I2S peripheral
- *        This value is used by the I2S HAL module to compute the I2S clock
- * source frequency, this source is inserted directly through I2S_CKIN pad.
- *        - External clock generated through external PLL component on EVAL 303
- * (based on MCO or crystal)
- *        - External clock not generated on EVAL 373
- */
-#if !defined(EXTERNAL_CLOCK_VALUE)
-#define EXTERNAL_CLOCK_VALUE \
-    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz*/
-#endif                  /* EXTERNAL_CLOCK_VALUE */
+  * @brief Time out for LSE start up value in ms.
+  */
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
 
-    /* Tip: To avoid modifying this file each time you need to use different
-       HSE,
-       ===  you can define the HSE value in your toolchain compiler
-       preprocessor. */
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source 
+  *        frequency, this source is inserted directly through I2S_CKIN pad.
+  *        - External clock generated through external PLL component on EVAL 303 (based on MCO or crystal)
+  *        - External clock not generated on EVAL 373
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
 
-    /* ########################### System Configuration ######################### */
-    /**
-     * @brief This is the HAL system configuration section
-     */
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
 
-#define VDD_VALUE ((uint32_t)3300) /*!< Value of VDD in mv */
-#define TICK_INT_PRIORITY \
-    ((uint32_t)0) /*!< tick interrupt priority (lowest by default)  */
-#define USE_RTOS 0
-#define PREFETCH_ENABLE 1
-#define INSTRUCTION_CACHE_ENABLE 0
-#define DATA_CACHE_ENABLE 0
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */     
 
-    /* ########################## Assert Selection ############################## */
-    /**
-     * @brief Uncomment the line below to expanse the "assert_param" macro in
-     * the HAL drivers code
-     */
-    /* #define USE_FULL_ASSERT    1U */
+#define  VDD_VALUE                   ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0)    /*!< tick interrupt priority (lowest by default)  */            
+#define  USE_RTOS                     0
+#define  PREFETCH_ENABLE              1
+#define  INSTRUCTION_CACHE_ENABLE     0
+#define  DATA_CACHE_ENABLE            0
 
-    /* ################## SPI peripheral configuration ########################## */
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1U */
 
-    /* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
-     * Activated: CRC code is present inside driver
-     * Deactivated: CRC code cleaned from driver
-     */
+/* ################## SPI peripheral configuration ########################## */
 
-#define USE_SPI_CRC 0U
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+* Activated: CRC code is present inside driver
+* Deactivated: CRC code cleaned from driver
+*/
 
-    /* Includes
-     * ------------------------------------------------------------------*/
-    /**
-     * @brief Include module's header file
-     */
+#define USE_SPI_CRC                     0U
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file 
+  */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-#include "stm32f3xx_hal_rcc.h"
+ #include "stm32f3xx_hal_rcc.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
 
 #ifdef HAL_EXTI_MODULE_ENABLED
-#include "stm32f3xx_hal_exti.h"
+ #include "stm32f3xx_hal_exti.h"
 #endif /* HAL_EXTI_MODULE_ENABLED */
 
 #ifdef HAL_GPIO_MODULE_ENABLED
-#include "stm32f3xx_hal_gpio.h"
+ #include "stm32f3xx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_DMA_MODULE_ENABLED
-#include "stm32f3xx_hal_dma.h"
+  #include "stm32f3xx_hal_dma.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
-
+   
 #ifdef HAL_CORTEX_MODULE_ENABLED
-#include "stm32f3xx_hal_cortex.h"
+ #include "stm32f3xx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-#include "stm32f3xx_hal_adc.h"
+ #include "stm32f3xx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_CAN_MODULE_ENABLED
-#include "stm32f3xx_hal_can.h"
+ #include "stm32f3xx_hal_can.h"
 #endif /* HAL_CAN_MODULE_ENABLED */
 
 #ifdef HAL_CEC_MODULE_ENABLED
-#include "stm32f3xx_hal_cec.h"
+ #include "stm32f3xx_hal_cec.h"
 #endif /* HAL_CEC_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-#include "stm32f3xx_hal_comp.h"
+ #include "stm32f3xx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-#include "stm32f3xx_hal_crc.h"
+ #include "stm32f3xx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_DAC_MODULE_ENABLED
-#include "stm32f3xx_hal_dac.h"
+ #include "stm32f3xx_hal_dac.h"
 #endif /* HAL_DAC_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-#include "stm32f3xx_hal_flash.h"
+ #include "stm32f3xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_SRAM_MODULE_ENABLED
-#include "stm32f3xx_hal_sram.h"
+  #include "stm32f3xx_hal_sram.h"
 #endif /* HAL_SRAM_MODULE_ENABLED */
 
 #ifdef HAL_NOR_MODULE_ENABLED
-#include "stm32f3xx_hal_nor.h"
+  #include "stm32f3xx_hal_nor.h"
 #endif /* HAL_NOR_MODULE_ENABLED */
 
 #ifdef HAL_NAND_MODULE_ENABLED
-#include "stm32f3xx_hal_nand.h"
+  #include "stm32f3xx_hal_nand.h"
 #endif /* HAL_NAND_MODULE_ENABLED */
 
 #ifdef HAL_PCCARD_MODULE_ENABLED
-#include "stm32f3xx_hal_pccard.h"
-#endif /* HAL_PCCARD_MODULE_ENABLED */
+  #include "stm32f3xx_hal_pccard.h"
+#endif /* HAL_PCCARD_MODULE_ENABLED */ 
 
 #ifdef HAL_HRTIM_MODULE_ENABLED
-#include "stm32f3xx_hal_hrtim.h"
+ #include "stm32f3xx_hal_hrtim.h"
 #endif /* HAL_HRTIM_MODULE_ENABLED */
 
 #ifdef HAL_I2C_MODULE_ENABLED
-#include "stm32f3xx_hal_i2c.h"
+ #include "stm32f3xx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_I2S_MODULE_ENABLED
-#include "stm32f3xx_hal_i2s.h"
+ #include "stm32f3xx_hal_i2s.h"
 #endif /* HAL_I2S_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
-#include "stm32f3xx_hal_irda.h"
+ #include "stm32f3xx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
-#include "stm32f3xx_hal_iwdg.h"
+ #include "stm32f3xx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_OPAMP_MODULE_ENABLED
-#include "stm32f3xx_hal_opamp.h"
+ #include "stm32f3xx_hal_opamp.h"
 #endif /* HAL_OPAMP_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-#include "stm32f3xx_hal_pcd.h"
+ #include "stm32f3xx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
-#include "stm32f3xx_hal_pwr.h"
+ #include "stm32f3xx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
-#include "stm32f3xx_hal_rtc.h"
+ #include "stm32f3xx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SDADC_MODULE_ENABLED
-#include "stm32f3xx_hal_sdadc.h"
+ #include "stm32f3xx_hal_sdadc.h"
 #endif /* HAL_SDADC_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
-#include "stm32f3xx_hal_smartcard.h"
+ #include "stm32f3xx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_SMBUS_MODULE_ENABLED
-#include "stm32f3xx_hal_smbus.h"
+ #include "stm32f3xx_hal_smbus.h"
 #endif /* HAL_SMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPI_MODULE_ENABLED
-#include "stm32f3xx_hal_spi.h"
+ #include "stm32f3xx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
-#include "stm32f3xx_hal_tim.h"
+ #include "stm32f3xx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_TSC_MODULE_ENABLED
-#include "stm32f3xx_hal_tsc.h"
+ #include "stm32f3xx_hal_tsc.h"
 #endif /* HAL_TSC_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
-#include "stm32f3xx_hal_uart.h"
+ #include "stm32f3xx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
-#include "stm32f3xx_hal_usart.h"
+ #include "stm32f3xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
-#include "stm32f3xx_hal_wwdg.h"
+ #include "stm32f3xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
-#ifdef USE_FULL_ASSERT
-    /**
-     * @brief  The assert_param macro is used for function's parameters check.
-     * @param  expr: If expr is false, it calls assert_failed function
-     *         which reports the name of the source file and the source
-     *         line number of the call that failed.
-     *         If expr is true, it returns no value.
-     * @retval None
-     */
-#define assert_param(expr) \
-    ((expr) ? (void)0U : assert_failed((char *)__FILE__, __LINE__))
-    /* Exported functions
-     * ------------------------------------------------------- */
-    void assert_failed(char *file, uint32_t line);
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((char *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(char* file, uint32_t line);
 #else
-#define assert_param(expr) ((void)0U)
-#endif /* USE_FULL_ASSERT */
-
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */    
+    
 #ifdef __cplusplus
 }
 #endif

--- a/src/PDM/Inc/stm32f3xx_hal_conf.h
+++ b/src/PDM/Inc/stm32f3xx_hal_conf.h
@@ -1,58 +1,54 @@
 /**
- ******************************************************************************
- * @file    stm32f3xx_hal_conf.h
- * @brief   HAL configuration file.
- ******************************************************************************
- * @attention
- *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
- *
- * Redistribution and use in source and binary forms, with or without
- *modification, are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *notice, this list of conditions and the following disclaimer in the
- *documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************
- */
+  ******************************************************************************
+  * @file    stm32f3xx_hal_conf.h
+  * @brief   HAL configuration file.  
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32F3xx_HAL_CONF_H
 #define __STM32F3xx_HAL_CONF_H
 
 #ifdef __cplusplus
-extern "C"
-{
+ extern "C" {
 #endif
 
-    /* Exported types
-     * ------------------------------------------------------------*/
-    /* Exported constants
-     * --------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
 
-    /* ########################## Module Selection ############################## */
-    /**
-     * @brief This is the list of modules to be used in the HAL driver
-     */
-
-#define HAL_MODULE_ENABLED
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver 
+  */
+  
+#define HAL_MODULE_ENABLED  
 #define HAL_ADC_MODULE_ENABLED
 /*#define HAL_CRYP_MODULE_ENABLED   */
 #define HAL_CAN_MODULE_ENABLED
@@ -94,276 +90,261 @@ extern "C"
 #define HAL_I2C_MODULE_ENABLED
 /* ########################## HSE/HSI Values adaptation ##################### */
 /**
- * @brief Adjust the value of External High Speed oscillator (HSE) used in your
- * application. This value is used by the RCC HAL module to compute the system
- * frequency (when HSE is used as system clock source, directly or through the
- * PLL).
- */
-#if !defined(HSE_VALUE)
-#define HSE_VALUE \
-    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
-#endif                  /* HSE_VALUE */
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).  
+  */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
 
 /**
- * @brief In the following line adjust the External High Speed oscillator (HSE)
- * Startup Timeout value
- */
-#if !defined(HSE_STARTUP_TIMEOUT)
-#define HSE_STARTUP_TIMEOUT \
-    ((uint32_t)100) /*!< Time out for HSE start up, in ms */
-#endif              /* HSE_STARTUP_TIMEOUT */
+  * @brief In the following line adjust the External High Speed oscillator (HSE) Startup 
+  *        Timeout value 
+  */
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
 
 /**
- * @brief Internal High Speed oscillator (HSI) value.
- *        This value is used by the RCC HAL module to compute the system
- * frequency (when HSI is used as system clock source, directly or through the
- * PLL).
- */
-#if !defined(HSI_VALUE)
-#define HSI_VALUE \
-    ((uint32_t)8000000) /*!< Value of the Internal oscillator in Hz*/
-#endif                  /* HSI_VALUE */
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL). 
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)8000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
 
 /**
- * @brief In the following line adjust the Internal High Speed oscillator (HSI)
- * Startup Timeout value
- */
-#if !defined(HSI_STARTUP_TIMEOUT)
-#define HSI_STARTUP_TIMEOUT ((uint32_t)5000) /*!< Time out for HSI start up */
-#endif                                       /* HSI_STARTUP_TIMEOUT */
+  * @brief In the following line adjust the Internal High Speed oscillator (HSI) Startup 
+  *        Timeout value 
+  */
+#if !defined  (HSI_STARTUP_TIMEOUT) 
+ #define HSI_STARTUP_TIMEOUT   ((uint32_t)5000) /*!< Time out for HSI start up */
+#endif /* HSI_STARTUP_TIMEOUT */  
 
 /**
- * @brief Internal Low Speed oscillator (LSI) value.
- */
-#if !defined(LSI_VALUE)
-#define LSI_VALUE ((uint32_t)40000)
-#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \
-                        The real value may vary depending on the variations  \
-                        in voltage and temperature.  */
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE) 
+ #define LSI_VALUE  ((uint32_t)40000)    
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
 /**
- * @brief External Low Speed oscillator (LSE) value.
- */
-#if !defined(LSE_VALUE)
-#define LSE_VALUE \
-    ((uint32_t)32768) /*!< Value of the External Low Speed oscillator in Hz */
-#endif                /* LSE_VALUE */
-
-/**
- * @brief Time out for LSE start up value in ms.
- */
-#if !defined(LSE_STARTUP_TIMEOUT)
-#define LSE_STARTUP_TIMEOUT \
-    ((uint32_t)5000) /*!< Time out for LSE start up, in ms */
-#endif               /* LSE_STARTUP_TIMEOUT */
+  * @brief External Low Speed oscillator (LSE) value.
+  */
+#if !defined  (LSE_VALUE)
+ #define LSE_VALUE  ((uint32_t)32768)    /*!< Value of the External Low Speed oscillator in Hz */
+#endif /* LSE_VALUE */     
 
 /**
- * @brief External clock source for I2S peripheral
- *        This value is used by the I2S HAL module to compute the I2S clock
- * source frequency, this source is inserted directly through I2S_CKIN pad.
- *        - External clock generated through external PLL component on EVAL 303
- * (based on MCO or crystal)
- *        - External clock not generated on EVAL 373
- */
-#if !defined(EXTERNAL_CLOCK_VALUE)
-#define EXTERNAL_CLOCK_VALUE \
-    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz*/
-#endif                  /* EXTERNAL_CLOCK_VALUE */
+  * @brief Time out for LSE start up value in ms.
+  */
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
 
-    /* Tip: To avoid modifying this file each time you need to use different
-       HSE,
-       ===  you can define the HSE value in your toolchain compiler
-       preprocessor. */
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source 
+  *        frequency, this source is inserted directly through I2S_CKIN pad.
+  *        - External clock generated through external PLL component on EVAL 303 (based on MCO or crystal)
+  *        - External clock not generated on EVAL 373
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
 
-    /* ########################### System Configuration ######################### */
-    /**
-     * @brief This is the HAL system configuration section
-     */
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
 
-#define VDD_VALUE ((uint32_t)3300) /*!< Value of VDD in mv */
-#define TICK_INT_PRIORITY \
-    ((uint32_t)0) /*!< tick interrupt priority (lowest by default)  */
-#define USE_RTOS 0
-#define PREFETCH_ENABLE 1
-#define INSTRUCTION_CACHE_ENABLE 0
-#define DATA_CACHE_ENABLE 0
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */     
 
-    /* ########################## Assert Selection ############################## */
-    /**
-     * @brief Uncomment the line below to expanse the "assert_param" macro in
-     * the HAL drivers code
-     */
-    /* #define USE_FULL_ASSERT    1U */
+#define  VDD_VALUE                   ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0)    /*!< tick interrupt priority (lowest by default)  */            
+#define  USE_RTOS                     0
+#define  PREFETCH_ENABLE              1
+#define  INSTRUCTION_CACHE_ENABLE     0
+#define  DATA_CACHE_ENABLE            0
 
-    /* ################## SPI peripheral configuration ########################## */
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1U */
 
-    /* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
-     * Activated: CRC code is present inside driver
-     * Deactivated: CRC code cleaned from driver
-     */
+/* ################## SPI peripheral configuration ########################## */
 
-#define USE_SPI_CRC 0U
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+* Activated: CRC code is present inside driver
+* Deactivated: CRC code cleaned from driver
+*/
 
-    /* Includes
-     * ------------------------------------------------------------------*/
-    /**
-     * @brief Include module's header file
-     */
+#define USE_SPI_CRC                     0U
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file 
+  */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-#include "stm32f3xx_hal_rcc.h"
+ #include "stm32f3xx_hal_rcc.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
 
 #ifdef HAL_EXTI_MODULE_ENABLED
-#include "stm32f3xx_hal_exti.h"
+ #include "stm32f3xx_hal_exti.h"
 #endif /* HAL_EXTI_MODULE_ENABLED */
 
 #ifdef HAL_GPIO_MODULE_ENABLED
-#include "stm32f3xx_hal_gpio.h"
+ #include "stm32f3xx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_DMA_MODULE_ENABLED
-#include "stm32f3xx_hal_dma.h"
+  #include "stm32f3xx_hal_dma.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
-
+   
 #ifdef HAL_CORTEX_MODULE_ENABLED
-#include "stm32f3xx_hal_cortex.h"
+ #include "stm32f3xx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-#include "stm32f3xx_hal_adc.h"
+ #include "stm32f3xx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_CAN_MODULE_ENABLED
-#include "stm32f3xx_hal_can.h"
+ #include "stm32f3xx_hal_can.h"
 #endif /* HAL_CAN_MODULE_ENABLED */
 
 #ifdef HAL_CEC_MODULE_ENABLED
-#include "stm32f3xx_hal_cec.h"
+ #include "stm32f3xx_hal_cec.h"
 #endif /* HAL_CEC_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-#include "stm32f3xx_hal_comp.h"
+ #include "stm32f3xx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-#include "stm32f3xx_hal_crc.h"
+ #include "stm32f3xx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_DAC_MODULE_ENABLED
-#include "stm32f3xx_hal_dac.h"
+ #include "stm32f3xx_hal_dac.h"
 #endif /* HAL_DAC_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-#include "stm32f3xx_hal_flash.h"
+ #include "stm32f3xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_SRAM_MODULE_ENABLED
-#include "stm32f3xx_hal_sram.h"
+  #include "stm32f3xx_hal_sram.h"
 #endif /* HAL_SRAM_MODULE_ENABLED */
 
 #ifdef HAL_NOR_MODULE_ENABLED
-#include "stm32f3xx_hal_nor.h"
+  #include "stm32f3xx_hal_nor.h"
 #endif /* HAL_NOR_MODULE_ENABLED */
 
 #ifdef HAL_NAND_MODULE_ENABLED
-#include "stm32f3xx_hal_nand.h"
+  #include "stm32f3xx_hal_nand.h"
 #endif /* HAL_NAND_MODULE_ENABLED */
 
 #ifdef HAL_PCCARD_MODULE_ENABLED
-#include "stm32f3xx_hal_pccard.h"
-#endif /* HAL_PCCARD_MODULE_ENABLED */
+  #include "stm32f3xx_hal_pccard.h"
+#endif /* HAL_PCCARD_MODULE_ENABLED */ 
 
 #ifdef HAL_HRTIM_MODULE_ENABLED
-#include "stm32f3xx_hal_hrtim.h"
+ #include "stm32f3xx_hal_hrtim.h"
 #endif /* HAL_HRTIM_MODULE_ENABLED */
 
 #ifdef HAL_I2C_MODULE_ENABLED
-#include "stm32f3xx_hal_i2c.h"
+ #include "stm32f3xx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_I2S_MODULE_ENABLED
-#include "stm32f3xx_hal_i2s.h"
+ #include "stm32f3xx_hal_i2s.h"
 #endif /* HAL_I2S_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
-#include "stm32f3xx_hal_irda.h"
+ #include "stm32f3xx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
-#include "stm32f3xx_hal_iwdg.h"
+ #include "stm32f3xx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_OPAMP_MODULE_ENABLED
-#include "stm32f3xx_hal_opamp.h"
+ #include "stm32f3xx_hal_opamp.h"
 #endif /* HAL_OPAMP_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-#include "stm32f3xx_hal_pcd.h"
+ #include "stm32f3xx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
-#include "stm32f3xx_hal_pwr.h"
+ #include "stm32f3xx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
-#include "stm32f3xx_hal_rtc.h"
+ #include "stm32f3xx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SDADC_MODULE_ENABLED
-#include "stm32f3xx_hal_sdadc.h"
+ #include "stm32f3xx_hal_sdadc.h"
 #endif /* HAL_SDADC_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
-#include "stm32f3xx_hal_smartcard.h"
+ #include "stm32f3xx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_SMBUS_MODULE_ENABLED
-#include "stm32f3xx_hal_smbus.h"
+ #include "stm32f3xx_hal_smbus.h"
 #endif /* HAL_SMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPI_MODULE_ENABLED
-#include "stm32f3xx_hal_spi.h"
+ #include "stm32f3xx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
-#include "stm32f3xx_hal_tim.h"
+ #include "stm32f3xx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_TSC_MODULE_ENABLED
-#include "stm32f3xx_hal_tsc.h"
+ #include "stm32f3xx_hal_tsc.h"
 #endif /* HAL_TSC_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
-#include "stm32f3xx_hal_uart.h"
+ #include "stm32f3xx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
-#include "stm32f3xx_hal_usart.h"
+ #include "stm32f3xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
-#include "stm32f3xx_hal_wwdg.h"
+ #include "stm32f3xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
-#ifdef USE_FULL_ASSERT
-    /**
-     * @brief  The assert_param macro is used for function's parameters check.
-     * @param  expr: If expr is false, it calls assert_failed function
-     *         which reports the name of the source file and the source
-     *         line number of the call that failed.
-     *         If expr is true, it returns no value.
-     * @retval None
-     */
-#define assert_param(expr) \
-    ((expr) ? (void)0U : assert_failed((char *)__FILE__, __LINE__))
-    /* Exported functions
-     * ------------------------------------------------------- */
-    void assert_failed(char *file, uint32_t line);
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((char *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(char* file, uint32_t line);
 #else
-#define assert_param(expr) ((void)0U)
-#endif /* USE_FULL_ASSERT */
-
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */    
+    
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Everytime we re-generate `stm32f3xx_hal_conf.h`, an extra `\` would get appended. This is quite annoying so I decided to ignore clang-format on all `stm32f3xx_hal_conf.h`. However, this means I also had to re-generate a fresh copy of `stm32f3xx_hal_conf.h` for each project to get the unformatted version.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
FSM, DCM, and PDM still compile.

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
