### PR TITLE
Use bitfields for code generated from cantools

### DIFF
--- a/src/shared/CanMsgs/Inc/CanMsgs.h
+++ b/src/shared/CanMsgs/Inc/CanMsgs.h
@@ -77,14 +77,14 @@ struct CanMsgs_fsm_errors_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t papps_out_of_range;
+    uint8_t papps_out_of_range : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sapps_out_of_range;
+    uint8_t sapps_out_of_range : 1;
 };
 
 /**
@@ -100,7 +100,7 @@ struct CanMsgs_fsm_can_tx_fifo_overflow_t {
      * Scale: 1
      * Offset: 0
      */
-    uint32_t overflow_count;
+    uint32_t overflow_count : 32;
 };
 
 /**
@@ -176,56 +176,56 @@ struct CanMsgs_pdm_errors_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t missing_heartbeat;
+    uint8_t missing_heartbeat : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t boost_pgood_fault;
+    uint8_t boost_pgood_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t cell_balance_overvoltage_fault;
+    uint8_t cell_balance_overvoltage_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t charger_fault;
+    uint8_t charger_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t efuse_fault;
+    uint8_t efuse_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t _12_v_fault_under_voltage;
+    uint8_t _12_v_fault_under_voltage : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t _12_v_fault_over_voltage;
+    uint8_t _12_v_fault_over_voltage : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t vbat_fault;
+    uint8_t vbat_fault : 1;
 };
 
 /**
@@ -241,7 +241,7 @@ struct CanMsgs_pdm_can_tx_fifo_overflow_t {
      * Scale: 1
      * Offset: 0
      */
-    uint32_t overflow_count;
+    uint32_t overflow_count : 32;
 };
 
 /**
@@ -317,7 +317,7 @@ struct CanMsgs_bms_can_tx_fifo_overflow_t {
      * Scale: 1
      * Offset: 0
      */
-    uint32_t overflow_count;
+    uint32_t overflow_count : 32;
 };
 
 /**
@@ -331,7 +331,7 @@ struct CanMsgs_dcm_can_tx_fifo_overflow_t {
      * Scale: 1
      * Offset: 0
      */
-    uint32_t overflow_count;
+    uint32_t overflow_count : 32;
 };
 
 /**

--- a/src/shared/CanMsgs/generate_c_code_from_sym.py
+++ b/src/shared/CanMsgs/generate_c_code_from_sym.py
@@ -57,7 +57,7 @@ def generate_code_from_sym_file(database_name):
             filename_c, 
             "", 
             floating_point_numbers=True,
-            bit_fields=False
+            bit_fields=True
     )
 
     header = purge_timestamps_from_generated_code(header)


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Without the `bit_fields` option enabled, `cantools` will represent any CAN signal less than 8 bits as an `uint8_t`

For example, if `missing_heartbeat` takes up 1 bit out of the 64 bits in the CAN message `PDM_ERRORS`, we would get the follow struct
```
struct CanMsgs_pdm_errors_t {
  uint8_t missing_heartbeat;
}
```
instead of 
```
struct CanMsgs_pdm_errors_t {
  uint8_t missing_heartbeat : 1;
}
```
I believe we should move towards using bit fields because let's say if we want to store a copy of the one-hot encoded `PDM_ERRORS` in memory, we can use the autogenerated `struct CanMsgs_pdm_errors_t` with minimal memory footprint.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
