### PR TITLE
Add shared logging library

### DIFF
--- a/src/shared/Errors/SharedErrorCodes.h
+++ b/src/shared/Errors/SharedErrorCodes.h
@@ -1,0 +1,13 @@
+/**
+ * @file  SharedErrorCodes.h
+ * @brief Shared error codes
+ */
+#ifndef SHARED_ERROR_CODES_H
+#define SHARED_ERROR_CODES_H
+
+typedef enum
+{
+    NO_ERROR = 0,
+} ErrorCode_e;
+
+#endif // SHARED_ERROR_CODES_H

--- a/src/shared/Logging/SharedLogging.c
+++ b/src/shared/Logging/SharedLogging.c
@@ -1,0 +1,16 @@
+/******************************************************************************
+ * Includes
+ ******************************************************************************/
+#include "SharedLogging.h"
+
+/******************************************************************************
+ * Function Definitions
+ ******************************************************************************/
+void SharedLogging_Printf(const char *sFormat, ...)
+{
+    va_list ParamList;
+
+    va_start(ParamList, sFormat);
+    (void)SEGGER_RTT_vprintf(0, sFormat, &ParamList);
+    va_end(ParamList);
+}

--- a/src/shared/Logging/SharedLogging.h
+++ b/src/shared/Logging/SharedLogging.h
@@ -1,0 +1,40 @@
+/**
+ * @file  SharedLogging.h
+ * @brief Library for logging information
+ */
+
+#ifndef SHARED_LOGGING_H
+#define SHARED_LOGGING_H
+/******************************************************************************
+ * Includes
+ ******************************************************************************/
+#include "SEGGER_RTT.h"
+
+/******************************************************************************
+ * Preprocessor Macros
+ ******************************************************************************/
+// clang-format off
+
+// __FILE__ contains the absolute path whereas __FILENAME__ contains the base
+// filename. __FILENAME__ is preferred over __FILE__ to provide a cleaner
+// debugging output in RTT viewer.
+#define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__)
+
+#define LOG_INFO(fmt, ...) \
+    SharedLogging_Printf("[INFO] %s::%s(%u) : " fmt "\n", __FILENAME__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define LOG_ERROR(error_code, fmt, ...) \
+    SharedLogging_Printf("[ERROR %u] %s::%s(%u) : " fmt "\n", (ErrorCode_e)error_code, __FILENAME__, __FUNCTION__, __LINE__, __VA_ARGS__)
+
+// clang-format on
+
+/******************************************************************************
+ * Function Prototypes
+ ******************************************************************************/
+/**
+ * @brief  Printf-style function to print data over Segger RTT
+ * @param  sFormat Pointer to format string, followed by the arguments for
+ *         conversion
+ */
+void SharedLogging_Printf(const char *sFormat, ...);
+
+#endif // SHARED_LOGGING_H


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Create a logging library that can be used in all projects. Here are some design decisions that went behind it:
- The `SharedErrorCode.h` isn't quite fleshed out yet. But I am hoping to have an unified list of error codes that is applicable to every board. I don't want every board to have its own list of error codes if possible.
- This logging library isn't meant to replace CAN alerts
- This library is useful for displaying verbose information as **strings** 
- I wanted to expose more than just LOG_ERROR and LOG_INFO. But I figured that extra debuggging levels such as LOG_WARNING, LOG_CRITICAL, LOG_DEBUG would just become too confusing for our codebase.
- This won't requires a J-Link to be connected to the target which means the logging won't be available while driving
- Building on the last point, the RTT library is non-blocking so if there's no J-Link connected to the target everything will still run fine 

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
By applying this [patch.txt](https://github.com/UBCFormulaElectric/Consolidated-Firmware/files/3415621/patch.txt) to DCM, I was able to confirm that `LOG_INFO` and `LOG_ERROR` are working as intended by using the Segger RTT viewer:
![image](https://user-images.githubusercontent.com/16970019/61604570-eb548480-abf6-11e9-83e7-2e4a31a94d04.png)

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
