### PR TITLE
Handle Error_Handler() and assert_param()

### DIFF
--- a/src/DCM/Inc/main.h
+++ b/src/DCM/Inc/main.h
@@ -31,10 +31,9 @@ extern "C"
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f3xx_hal.h"
 
-    /* Private includes
-     * ----------------------------------------------------------*/
-    /* USER CODE BEGIN Includes */
-
+/* Private includes ----------------------------------------------------------*/
+/* USER CODE BEGIN Includes */
+#include "SharedHalHandler.h"
     /* USER CODE END Includes */
 
     /* Exported types

--- a/src/DCM/Src/main.c
+++ b/src/DCM/Src/main.c
@@ -542,9 +542,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 void Error_Handler(void)
 {
     /* USER CODE BEGIN Error_Handler_Debug */
-    /* User can add his own implementation to report the HAL error return state
-     */
-
+    SharedHalHandler_ErrorHandler(file, line);
     /* USER CODE END Error_Handler_Debug */
 }
 
@@ -559,9 +557,7 @@ void Error_Handler(void)
 void assert_failed(char *file, uint32_t line)
 {
     /* USER CODE BEGIN 6 */
-    /* User can add his own implementation to report the file name and line
-       number, tex: printf("Wrong parameters value: file %s on line %d\r\n",
-       file, line) */
+    SharedHalHandler_AssertFailed(file, line);
     /* USER CODE END 6 */
 }
 #endif /* USE_FULL_ASSERT */

--- a/src/FSM/Inc/main.h
+++ b/src/FSM/Inc/main.h
@@ -34,7 +34,7 @@ extern "C"
     /* Private includes
      * ----------------------------------------------------------*/
     /* USER CODE BEGIN Includes */
-
+#include "SharedHalHandler.h"
     /* USER CODE END Includes */
 
     /* Exported types

--- a/src/FSM/Src/main.c
+++ b/src/FSM/Src/main.c
@@ -473,9 +473,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 void Error_Handler(void)
 {
     /* USER CODE BEGIN Error_Handler_Debug */
-    /* User can add his own implementation to report the HAL error return state
-     */
-
+    SharedHalHandler_ErrorHandler(file, line);
     /* USER CODE END Error_Handler_Debug */
 }
 
@@ -490,9 +488,7 @@ void Error_Handler(void)
 void assert_failed(char *file, uint32_t line)
 {
     /* USER CODE BEGIN 6 */
-    /* User can add his own implementation to report the file name and line
-       number, tex: printf("Wrong parameters value: file %s on line %d\r\n",
-       file, line) */
+    SharedHalHandler_AssertFailed(file, line);
     /* USER CODE END 6 */
 }
 #endif /* USE_FULL_ASSERT */

--- a/src/PDM/Inc/main.h
+++ b/src/PDM/Inc/main.h
@@ -34,7 +34,7 @@ extern "C"
     /* Private includes
      * ----------------------------------------------------------*/
     /* USER CODE BEGIN Includes */
-
+#include "SharedHalHandler.h"
     /* USER CODE END Includes */
 
     /* Exported types

--- a/src/PDM/Src/main.c
+++ b/src/PDM/Src/main.c
@@ -580,9 +580,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 void Error_Handler(void)
 {
     /* USER CODE BEGIN Error_Handler_Debug */
-    /* User can add his own implementation to report the HAL error return state
-     */
-
+    SharedHalHandler_ErrorHandler(file, line);
     /* USER CODE END Error_Handler_Debug */
 }
 
@@ -597,9 +595,7 @@ void Error_Handler(void)
 void assert_failed(char *file, uint32_t line)
 {
     /* USER CODE BEGIN 6 */
-    /* User can add his own implementation to report the file name and line
-       number, tex: printf("Wrong parameters value: file %s on line %d\r\n",
-       file, line) */
+    SharedHalHandler_AssertFailed(file, line);
     /* USER CODE END 6 */
 }
 #endif /* USE_FULL_ASSERT */

--- a/src/shared/HalHandler/SharedHalHandler.c
+++ b/src/shared/HalHandler/SharedHalHandler.c
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Includes
+ ******************************************************************************/
+#include "SharedLogging.h"
+#include "SharedHalHandler.h"
+#include "stm32f3xx_hal.h"
+
+/******************************************************************************
+ * Module Preprocessor Constants
+ ******************************************************************************/
+/**
+ * @brief Delay between detecting an error and performing a system reset. This
+ *        value is more-or-less arbitrarily decided.
+ */
+#define DELAY_BETWEEN_ERROR_AND_SYSTEM_RESET_MS 500U
+
+/******************************************************************************
+ * Private Function Prototypes
+ ******************************************************************************/
+/**
+ * @brief Simple wrapped to delay some time before performing a system reset.
+ * @param delay_ms Amount of time to wait before rebooting
+ */
+static void WaitAndReset(uint32_t delay_ms);
+
+/******************************************************************************
+ * Private Function Definitions
+ ******************************************************************************/
+static void WaitAndReset(uint32_t delay_ms)
+{
+    // Delay a little before shutdown so the debug message can be sent out
+    HAL_Delay(delay_ms);
+
+    // Trigger a software reboot
+    HAL_NVIC_SystemReset();
+}
+
+/******************************************************************************
+ * Function Definitions
+ ******************************************************************************/
+void SharedHalHandler_ErrorHandler(char *file, uint32_t line)
+{
+    // Print debug information
+    SharedLogging_Printf(
+        "Error_Handler() called at %s:%d. Resetting.\r\n", file, line);
+
+    WaitAndReset(DELAY_BETWEEN_ERROR_AND_SYSTEM_RESET_MS);
+}
+
+void SharedHalHandler_AssertFailed(char *file, uint32_t line)
+{
+    // Print debug information
+    SharedLogging_Printf(
+        "Wrong parameter value used at %s:%d. Resetting.\r\n", file, line);
+
+    WaitAndReset(DELAY_BETWEEN_ERROR_AND_SYSTEM_RESET_MS);
+}

--- a/src/shared/HalHandler/SharedHalHandler.h
+++ b/src/shared/HalHandler/SharedHalHandler.h
@@ -1,0 +1,60 @@
+/**
+ * @file  SharedHalHandler.h
+ * @brief Shared library with callback function for HAL library
+ * @note  Include this header file in main.h, above the auto-generated function
+ *        prototype `void ErrorHandler(void)`. Then, fill in the function
+ *        definition in main.c as if the function prototype is
+ *        `void ErrorHandler(char *file, uint32_t line)`
+ */
+#ifndef SHARED_HAL_HANDLER_H
+#define SHARED_HAL_HANDLER_H
+
+/******************************************************************************
+ * Includes
+ ******************************************************************************/
+#include <stdint.h>
+
+/******************************************************************************
+ * Preprocessor Macros
+ ******************************************************************************/
+// clang-format off
+// __FILE__ contains the absolute path whereas __FILENAME__ contains the base
+// filename. __FILENAME__ is preferred over __FILE__ to provide a cleaner
+// debugging output in RTT viewer.
+#define __FILENAME__                                                         \
+    (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 \
+                                      : __FILE__)
+
+// This is a "fix" taken from the ST forum (shorturl.at/iqDKV) to 
+//
+// 1. Replace "Error_Handler(void)" with "Error_Handler(char * file, uint32_t line)"
+// 2. Replace calls to "Error_Handler()" with "Error_Handler(__FILENAME__, __LINE__)"
+//
+// This allows us to pass in file and line number to the callback functions,
+// and transmit them over the debugging interface (Segger RTT).
+#define GET_MACRO(_0, _1, NAME, ...) NAME
+#define Error_Handler(...) \
+    GET_MACRO(_0, ##__VA_ARGS__, Error_Handler1, Error_Handler0)()
+#define Error_Handler0() _Error_Handler(__FILENAME__, __LINE__)
+#define Error_Handler1(unused) _Error_Handler(char *file, uint32_t line)
+void _Error_Handler(char *, uint32_t);
+// clang-format on
+//
+/******************************************************************************
+ * Function Prototypes
+ ******************************************************************************/
+/**
+ * @brief Callback function for HAL library's Error_Handler()
+ * @param file: pointer to the source file name.
+ * @param line: assert_param error line source number.
+ */
+void SharedHalHandler_ErrorHandler(char *file, uint32_t line);
+
+/**
+ * @brief Callback function for HAL library's assert_failed()
+ * @param file: pointer to the source file name.
+ * @param line: assert_param error line source number.
+ */
+void SharedHalHandler_AssertFailed(char *file, uint32_t line);
+
+#endif // SHARED_HAL_HANDLER_H


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
While testing the FSM, I discovered that the `MX_CAN_Init()` was returning error status. However, since we don't handle the errors in any way, it was quite tedious to track down exactly where the problem occurred. `Error_Handler()` is just an empty function right now but we should make it trap in a `while(1)` loop. `Error_Handler()` is called when a peripheral fails to initialize, and I would say at this point of development cycle we should just trap the microcontroller.

A similar story goes for `assert_param()`, right now it doesn't do anything and I think we should take action when `assert_param()` fails.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->
Resolves #382 

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
