### PR TITLE
Add shared library for printf-style logging

### DIFF
--- a/src/shared/Logging/SharedLogging.c
+++ b/src/shared/Logging/SharedLogging.c
@@ -2,10 +2,14 @@
  * Includes
  ******************************************************************************/
 #include "SharedLogging.h"
+#include "SEGGER_RTT_Conf.h"
 
 /******************************************************************************
  * Module Preprocessor Constants
  ******************************************************************************/
+// RTT channel 0 is always present and reserved for Terminal usage. Name is
+// fixed to "Terminal".
+#define SEGGER_RTT_TERMINAL_CHANNEL (0)
 
 /******************************************************************************
  * Module Preprocessor Macros
@@ -35,6 +39,6 @@ void SharedLogging_Printf(const char *sFormat, ...)
     va_list ParamList;
 
     va_start(ParamList, sFormat);
-    (void)SEGGER_RTT_vprintf(0, sFormat, &ParamList);
+    (void)SEGGER_RTT_vprintf(SEGGER_RTT_TERMINAL_CHANNEL, sFormat, &ParamList);
     va_end(ParamList);
 }

--- a/src/shared/Logging/SharedLogging.h
+++ b/src/shared/Logging/SharedLogging.h
@@ -32,7 +32,7 @@
  * Function Prototypes
  ******************************************************************************/
 /**
- * @brief  Printf-style function to print data over Segger RTT
+ * @brief  Printf-style function to print data to the terminal using Segger RTT
  * @param  sFormat Pointer to format string, followed by the arguments for
  *         conversion
  */


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Create a wrapped for using the SEGGER RTT printf because the original function requires the buffer index as an argument but for our use-case we will always use 0 for this value. The value 0 represent "terminal".

```
*       SEGGER_RTT_vprintf
*
*  Function description
*    Stores a formatted string in SEGGER RTT control block.
*    This data is read by the host.
*
*  Parameters
*    BufferIndex  Index of "Up"-buffer to be used. (e.g. 0 for "Terminal")
*    sFormat      Pointer to format string
*    pParamList   Pointer to the list of arguments for the format string
*
*  Return values
*    >= 0:  Number of bytes which have been stored in the "Up"-buffer.
* 
```  

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
