### PR TITLE
Add CLion OpenOCD download configuration back in

### DIFF
--- a/src/DCM/.idea/runConfigurations/DCM_OpenOCD.xml
+++ b/src/DCM/.idea/runConfigurations/DCM_OpenOCD.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DCM_OpenOCD" type="com.jetbrains.cidr.embedded.openocd.conf.type" factoryName="com.jetbrains.cidr.embedded.openocd.conf.factory" PASS_PARENT_ENVS_2="true" PROJECT_NAME="DCM" TARGET_NAME="DCM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="DCM" RUN_TARGET_NAME="DCM.elf">
+    <openocd gdb-port="3333" telnet-port="4444" board-config="../../../..$PROJECT_DIR$/../shared/OpenOCD/stm32f3x.cfg" reset-type="INIT" download-type="ALWAYS" />
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/DCM/.idea/runConfigurations/DCM_SeggerGDB.xml
+++ b/src/DCM/.idea/runConfigurations/DCM_SeggerGDB.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DCM_SeggerGDB" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-select USB -device STM32F302C8 -endian little -if SWD -speed 4000 -ir -LocalhostOnly -vd -strict -rtos GDBServer/RTOSPlugin_FreeRTOS" PASS_PARENT_ENVS_2="true" PROJECT_NAME="DCM" TARGET_NAME="DCM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="DCM" RUN_TARGET_NAME="DCM.elf">
+    <custom-gdb-server version="1" gdb-connect="localhost:2331" executable="/usr/bin/JLinkGDBServer" reset-cmd="monitor reset" warmup-ms="500" download-type="UPDATED_ONLY" />
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/DCM/.idea/runConfigurations/DCM_elf.xml
+++ b/src/DCM/.idea/runConfigurations/DCM_elf.xml
@@ -1,8 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="DCM.elf" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" nameIsGenerated="true" PROGRAM_PARAMS="-select USB -device STM32F302C8 -endian little -if SWD -speed 4000 -ir -LocalhostOnly -vd -strict -rtos GDBServer/RTOSPlugin_FreeRTOS" PASS_PARENT_ENVS_2="true" PROJECT_NAME="DCM" TARGET_NAME="DCM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="DCM" RUN_TARGET_NAME="DCM.elf">
-    <custom-gdb-server version="1" gdb-connect="localhost:2331" executable="/usr/bin/JLinkGDBServer" reset-cmd="monitor reset" warmup-ms="500" download-type="UPDATED_ONLY" />
-    <method v="2">
-      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
-    </method>
-  </configuration>
-</component>

--- a/src/FSM/.idea/runConfigurations/FSM_OpenOCD_elf.xml
+++ b/src/FSM/.idea/runConfigurations/FSM_OpenOCD_elf.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="FSM_OpenOCD.elf" type="com.jetbrains.cidr.embedded.openocd.conf.type" factoryName="com.jetbrains.cidr.embedded.openocd.conf.factory" PASS_PARENT_ENVS_2="true" PROJECT_NAME="FSM" TARGET_NAME="FSM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="FSM" RUN_TARGET_NAME="FSM.elf">
+    <openocd gdb-port="3333" telnet-port="4444" board-config="../../../..$PROJECT_DIR$/../shared/OpenOCD/stm32f3x.cfg" reset-type="INIT" download-type="ALWAYS" />
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/FSM/.idea/runConfigurations/FSM_SeggerGDB_elf.xml
+++ b/src/FSM/.idea/runConfigurations/FSM_SeggerGDB_elf.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="FSM_SeggerGDB.elf" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-select USB -device STM32F302C8 -endian little -if SWD -speed 4000 -ir -LocalhostOnly -vd -strict -rtos GDBServer/RTOSPlugin_FreeRTOS" PASS_PARENT_ENVS_2="true" PROJECT_NAME="FSM" TARGET_NAME="FSM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="FSM" RUN_TARGET_NAME="FSM.elf">
+    <custom-gdb-server version="1" gdb-connect="localhost:2331" executable="/usr/bin/JLinkGDBServer" reset-cmd="monitor reset" warmup-ms="500" download-type="UPDATED_ONLY" />
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/FSM/.idea/runConfigurations/FSM_elf.xml
+++ b/src/FSM/.idea/runConfigurations/FSM_elf.xml
@@ -1,8 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="FSM.elf" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" nameIsGenerated="true" PROGRAM_PARAMS="-select USB -device STM32F302C8 -endian little -if SWD -speed 4000 -ir -LocalhostOnly -vd -strict -rtos GDBServer/RTOSPlugin_FreeRTOS" PASS_PARENT_ENVS_2="true" PROJECT_NAME="FSM" TARGET_NAME="FSM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="FSM" RUN_TARGET_NAME="FSM.elf">
-    <custom-gdb-server version="1" gdb-connect="localhost:2331" executable="/usr/bin/JLinkGDBServer" reset-cmd="monitor reset" warmup-ms="500" download-type="UPDATED_ONLY" />
-    <method v="2">
-      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
-    </method>
-  </configuration>
-</component>

--- a/src/PDM/.idea/runConfigurations/PDM_OpenOCD_elf.xml
+++ b/src/PDM/.idea/runConfigurations/PDM_OpenOCD_elf.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="PDM_OpenOCD.elf" type="com.jetbrains.cidr.embedded.openocd.conf.type" factoryName="com.jetbrains.cidr.embedded.openocd.conf.factory" PASS_PARENT_ENVS_2="true" PROJECT_NAME="PDM" TARGET_NAME="PDM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="PDM" RUN_TARGET_NAME="PDM.elf">
+    <openocd gdb-port="3333" telnet-port="4444" board-config="../../../..$PROJECT_DIR$/../shared/OpenOCD/stm32f3x.cfg" reset-type="INIT" download-type="ALWAYS" />
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/PDM/.idea/runConfigurations/PDM_SeggerGDB_elf.xml
+++ b/src/PDM/.idea/runConfigurations/PDM_SeggerGDB_elf.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="PDM_SeggerGDB.elf" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-select USB -device STM32F302C8 -endian little -if SWD -speed 4000 -ir -LocalhostOnly -vd -rtos GDBServer/RTOSPlugin_FreeRTOS" PASS_PARENT_ENVS_2="true" PROJECT_NAME="PDM" TARGET_NAME="PDM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="PDM" RUN_TARGET_NAME="PDM.elf">
+    <custom-gdb-server version="1" gdb-connect="localhost:2331" executable="/usr/bin/JLinkGDBServer" reset-cmd="monitor reset" warmup-ms="500" download-type="UPDATED_ONLY" />
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/PDM/.idea/runConfigurations/PDM_elf.xml
+++ b/src/PDM/.idea/runConfigurations/PDM_elf.xml
@@ -1,8 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="PDM.elf" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" nameIsGenerated="true" PROGRAM_PARAMS="-select USB -device STM32F302C8 -endian little -if SWD -speed 4000 -ir -LocalhostOnly -vd -rtos GDBServer/RTOSPlugin_FreeRTOS" PASS_PARENT_ENVS_2="true" PROJECT_NAME="PDM" TARGET_NAME="PDM.elf" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="PDM" RUN_TARGET_NAME="PDM.elf">
-    <custom-gdb-server version="1" gdb-connect="localhost:2331" executable="/usr/bin/JLinkGDBServer" reset-cmd="monitor reset" warmup-ms="500" download-type="UPDATED_ONLY" />
-    <method v="2">
-      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
-    </method>
-  </configuration>
-</component>


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
in #385 when i added new Segger GDB server configuration in CLion, I also deleted the old OpenOCD configuration because they had overlapping functionality. However, I found out one very annoying quirk with the Segger GDB server configuration, that is, you can't just simply flash a program. Instead, you must flash *AND* debug everytime. This actually becomes quite annoying when you are just trying to program the board but not step through the code. As a result, I am recovering the old OpenOCD configuration in CLion to make programming the boards a little easier.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
