### PR TITLE
Add handler for hard fault exception

### DIFF
--- a/src/DCM/Src/main.c
+++ b/src/DCM/Src/main.c
@@ -29,6 +29,7 @@
 #include "SharedCmsisOs.h"
 #include "SharedCan.h"
 #include "SharedHeartbeat.h"
+#include "SharedHardFaultHandler.h"
 #include "Io_Can.h"
 /* USER CODE END Includes */
 
@@ -93,6 +94,7 @@ int main(void)
 {
     /* USER CODE BEGIN 1 */
     __HAL_DBGMCU_FREEZE_IWDG();
+    SharedHardFaultHandler_Init();
     /* USER CODE END 1 */
 
     /* MCU

--- a/src/DCM/Src/stm32f3xx_it.c
+++ b/src/DCM/Src/stm32f3xx_it.c
@@ -25,6 +25,7 @@
 #include "task.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "SharedHardFaultHandler.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -87,7 +88,7 @@ void NMI_Handler(void)
 void HardFault_Handler(void)
 {
     /* USER CODE BEGIN HardFault_IRQn 0 */
-
+    SharedHardFaultHandler_HandleHardFault();
     /* USER CODE END HardFault_IRQn 0 */
     while (1)
     {

--- a/src/FSM/Src/main.c
+++ b/src/FSM/Src/main.c
@@ -29,6 +29,7 @@
 #include "SharedCmsisOs.h"
 #include "SharedCan.h"
 #include "SharedHeartbeat.h"
+#include "SharedHardFaultHandler.h"
 #include "Io_Can.h"
 /* USER CODE END Includes */
 
@@ -90,6 +91,7 @@ int main(void)
 {
     /* USER CODE BEGIN 1 */
     __HAL_DBGMCU_FREEZE_IWDG();
+    SharedHardFaultHandler_Init();
     /* USER CODE END 1 */
 
     /* MCU

--- a/src/FSM/Src/stm32f3xx_it.c
+++ b/src/FSM/Src/stm32f3xx_it.c
@@ -25,6 +25,7 @@
 #include "task.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "SharedHardFaultHandler.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -87,7 +88,7 @@ void NMI_Handler(void)
 void HardFault_Handler(void)
 {
     /* USER CODE BEGIN HardFault_IRQn 0 */
-
+    SharedHardFaultHandler_HandleHardFault();
     /* USER CODE END HardFault_IRQn 0 */
     while (1)
     {

--- a/src/PDM/Src/main.c
+++ b/src/PDM/Src/main.c
@@ -29,6 +29,7 @@
 #include "SharedCmsisOs.h"
 #include "SharedCan.h"
 #include "SharedHeartbeat.h"
+#include "SharedHardFaultHandler.h"
 #include "Io_Can.h"
 /* USER CODE END Includes */
 
@@ -93,6 +94,7 @@ int main(void)
 {
     /* USER CODE BEGIN 1 */
     __HAL_DBGMCU_FREEZE_IWDG();
+    SharedHardFaultHandler_Init();
     /* USER CODE END 1 */
 
     /* MCU

--- a/src/PDM/Src/stm32f3xx_it.c
+++ b/src/PDM/Src/stm32f3xx_it.c
@@ -25,6 +25,7 @@
 #include "task.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "SharedHardFaultHandler.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -87,7 +88,7 @@ void NMI_Handler(void)
 void HardFault_Handler(void)
 {
     /* USER CODE BEGIN HardFault_IRQn 0 */
-
+    SharedHardFaultHandler_HandleHardFault();
     /* USER CODE END HardFault_IRQn 0 */
     while (1)
     {

--- a/src/shared/HardFaultHandler/SharedHardFaultHandler.c
+++ b/src/shared/HardFaultHandler/SharedHardFaultHandler.c
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * Includes
+ ******************************************************************************/
+#include <stm32f3xx_hal.h>
+#include "SharedHardFaultHandler.h"
+
+/******************************************************************************
+ * Function Definitions
+ ******************************************************************************/
+void SharedHardFaultHandler_Init(void)
+{
+    // Div-by-zero exception is disabled by default and must be enabled manually
+    SCB->CCR |= SCB_CCR_DIV_0_TRP_Msk;
+}
+
+// TODO (Issue: #400): Remove #pragma when we are using the variables to
+// transmit the data over CAN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+void SharedHardFaultHandler_LogInformation(uint32_t *fault_stack)
+{
+    // Registers pushed onto the stack frame before entering hard fault handler
+    volatile uint32_t stacked_r0;
+    volatile uint32_t stacked_r1;
+    volatile uint32_t stacked_r2;
+    volatile uint32_t stacked_r3;
+    volatile uint32_t stacked_r12;
+    volatile uint32_t stacked_lr;  // Link register
+    volatile uint32_t stacked_pc;  // Program counter
+    volatile uint32_t stacked_psr; // Program status register
+
+    // Fault exception registers with information about the exception
+    volatile uint32_t cfsr;
+    volatile uint32_t hfsr;
+    volatile uint32_t afsr;
+    volatile uint32_t bfar;  // Only valid if BFARVALID is set
+    volatile uint32_t mmfar; // Only valid if MMARVALID is set
+
+    // The register values are read from the stack based on the order in which
+    // registers are pushed onto the stack frame upon entering an exception
+    stacked_r0  = fault_stack[0];
+    stacked_r1  = fault_stack[1];
+    stacked_r2  = fault_stack[2];
+    stacked_r3  = fault_stack[3];
+    stacked_r12 = fault_stack[4];
+    stacked_lr  = fault_stack[5];
+    stacked_pc  = fault_stack[6];
+    stacked_psr = fault_stack[7];
+
+    cfsr  = SCB->CFSR;
+    hfsr  = SCB->HFSR;
+    afsr  = SCB->AFSR;
+    bfar  = SCB->BFAR;
+    mmfar = SCB->MMFAR;
+
+    for (;;)
+    {
+    };
+}
+#pragma GCC diagnostic pop

--- a/src/shared/HardFaultHandler/SharedHardFaultHandler.h
+++ b/src/shared/HardFaultHandler/SharedHardFaultHandler.h
@@ -1,0 +1,59 @@
+/**
+ * @file  SharedCan.h
+ * @brief Shared library with callback functions for hard-fault exceptions
+ * @note  This library is inspired by the example code here:
+ *        https://www.freertos.org/Debugging-Hard-Faults-On-Cortex-M-Microcontrollers.html
+ */
+#ifndef SHARED_HARD_FAULT_HANDLER_H
+#define SHARED_HARD_FAULT_HANDLER_H
+/******************************************************************************
+ * Includes
+ ******************************************************************************/
+#include <stdint.h>
+
+/******************************************************************************
+ * Preprocessor Macros
+ ******************************************************************************/
+// Right before the the processor enters HardFault_Handler(), the following
+// register values are pushed onto the stack: R0-R4, R12, LR, PC, PSR. These
+// register values make up of what is called a "stack frame". The stack frame
+// can be stored in either MSP (main stack pointer) or PSP (process stack
+// pointer). The following assembly function determines which stack pointer was
+// used was then hard fault occured, and passes it as an argument to
+// SharedHardFaultHandler_LogInformation().
+//
+// Note: The MSP/PSP architecture is specific to the Cortex-M microcontroller
+//       family.
+#define SharedHardFaultHandler_HandleHardFault()                   \
+    __asm volatile(" tst lr, #4                                \n" \
+                   " ite eq                                    \n" \
+                   " mrseq r0, msp                             \n" \
+                   " mrsne r0, psp                             \n" \
+                   " ldr r1, [r0, #24]                         \n" \
+                   " b SharedHardFaultHandler_LogInformation   \n");
+
+/******************************************************************************
+ * Function Prototypes
+ ******************************************************************************/
+/**
+ * @brief Add the naked attributes to HardFault_Handler function declaration.
+ * @note  The compiler will not generate prologue and epilogue sequences for
+ *        naked functions because they are embedded assembly functions.
+ */
+__attribute__((naked)) void HardFault_Handler(void);
+
+/**
+ * @brief Enable the desired exceptions.
+ * @note  Try to call this as early as possible to catch as many exceptions as
+ *        possible.
+ */
+void SharedHardFaultHandler_Init(void);
+
+/**
+ * @brief Log information that can help us identify what caused the hard fault.
+ * @param fault_stack Pointer to the stack that was used when the hard fault
+ *        occurred.
+ */
+void SharedHardFaultHandler_LogInformation(uint32_t *fault_stack);
+
+#endif /* SHARED_HARD_FAULT_HANDLER_H */


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
When a hard fault occurs, we should log relevant information that can help us root-cause the issue. The relevant information would include
1. The stack frame
2. Exception-related registers

I plan to send the values over CAN at some point, but for now we can just read the information into memory and trap in a while(1) loop.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
I tested that the divide-by-zero and illegal memory access was caught by the hard fault, and the appropriate status registers are set.

Divide by zero:
```
uint32_t i = 0;
uint32_t j = 0;
i = i / j;
```

Illegal memory access (Write to flash ROM)
```
void *ptr = MX_GPIO_Init;
memset(ptr, 1, 123);
```
### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
