### PR TITLE
Remove "set -v" from .travis.yml to simplify CI build outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ script:
     # then this will cause travis to exit. Commands encapsulated between 
     # conditionals, for example, do not report their return codes. Instead,
     # only the conditional, a command itself, gets polled, so if cmake or 
-    # python throws an error, the information is lost. Using `set -ev` ensures
+    # python throws an error, the information is lost. Using `set -e` ensures
     # that this does not happen
-    - set -ev
+    - set -e
 
     - |
       if [ "$RUN_BUILD" = "true" ]; then 


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Travis already echos the command being executed, so right now we are echoing the same command twice with `set -v`. Unless I am missing something else, i think `set -x` is sufficient for catching errors. `set -v` is polluting the CI output a bit and making things hard to read.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

With `set -v`, the output looks like:
```
$ if [ "$RUN_BUILD" = "true" ]; then 
  # Build each project
  for BOARD_NAME in FSM DCM PDM
  do
    cmake src/$BOARD_NAME/CMakeLists.txt
    make -C src/$BOARD_NAME
  done
fi
if [ "$RUN_BUILD" = "true" ]; then 
  # Build each project
  for BOARD_NAME in FSM DCM PDM
  do
    cmake src/$BOARD_NAME/CMakeLists.txt
    make -C src/$BOARD_NAME
  done
fi
```
And without `set -v`, the output is simply:
```
$ if [ "$RUN_BUILD" = "true" ]; then 
  # Build each project
  for BOARD_NAME in FSM DCM PDM
  do
    cmake src/$BOARD_NAME/CMakeLists.txt
    make -C src/$BOARD_NAME
  done
fi
```

Furthermore, `set -v` also introduces internal Travis commands such as 
```
travis_run_before_cache
travis_run_create_workspaces
travis_run_cache
travis_run_after_success
travis_run_after_failure
travis_run_after_script
travis_run_finish
travis_cleanup
travis_footer
```

Which just aren't that interesting or important to someone reviewing the log.
### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
