### PR TITLE
Update CMake version in Travis CI and clean up .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
-#l Note: Setting `sudo` to `required` will add 20-50s to CI image boot time
-os:
-  linux
-
-sudo: false
+# Note: Setting `sudo` to `required` will add 20-50s to CI image boot time
+os: linux
 dist: trusty
+sudo: false
 language: python
-
-python:
-  - "3.6"
+python: "3.6"
 
 before_install:
   - git submodule update --init --recursive
@@ -15,23 +11,10 @@ before_install:
 
 install:
   - pipenv install
-  - |
-    if [ "$RUN_BUILD" = "true" ] || [ "$RUN_TESTS" = "true" ]; then 
-      # Download the ARM GCC Embedded Toolchain.
-      # Unfortunately, since this is a literal URL, it does not pull the latest
-      # API available, and the URL must be changed manually.
-      #
-      # To change the URL:
-      # 1. Go to https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
-      # 2. Right-click and save the link to download the Linux 64-bit version
-      URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2?revision=c34d758a-be0c-476e-a2de-af8c6e16a8a2?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2019-q3-update
-      # Download the ARM GCC Embedded Toolchain
-      wget $URL -O /tmp/gcc-arm-none-eabi.tar.bz2
-      # Unzip the ARM GCC Embedded Toolchain
-      tar -xvjf /tmp/gcc-arm-none-eabi.tar.bz2
-      # Enable CMake to find the ARM GCC Embedded Toolchain
-      export PATH=$PATH:$PWD/gcc-arm-none-eabi-8-2019-q3-update/bin/
-    fi
+  # Modify $PATH directly in .travis.yml because a child process (i.e.
+  # travis_install_binaries.sh) can't modify the environmental variables of its
+  # parent process (i.e. .travis.yml)
+  - INSTALL_DIR=/usr/local && PATH=$INSTALL_DIR/bin:$PATH && ./scripts/travis_ci/travis_install_binaries.sh $INSTALL_DIR
 
 addons:
   apt_packages:
@@ -40,76 +23,16 @@ addons:
     - lib32z1
 
 before_script:
+  - ./scripts/travis_ci/print_bin_versions.sh
 
 script:
-    # If any command exits with a non-zero value (i.e. it throws an error)
-    # then this will cause travis to exit. Commands encapsulated between 
-    # conditionals, for example, do not report their return codes. Instead,
-    # only the conditional, a command itself, gets polled, so if cmake or 
-    # python throws an error, the information is lost. Using `set -e` ensures
-    # that this does not happen
-    - set -e
-
-    - |
-      if [ "$RUN_BUILD" = "true" ]; then 
-        # Build each project
-        for BOARD_NAME in FSM DCM PDM
-        do
-          cmake boards/$BOARD_NAME/CMakeLists.txt
-          make -C boards/$BOARD_NAME
-        done
-      fi
-    - |
-      if [ "$RUN_TESTS" = "true" ]; then 
-        :
-      fi
-    - |
-      if [ "$RUN_FORMATTING_CHECKS" = "true" ]; then
-            # Run clang-format recursively
-            echo "Y" | python clang-format/fix_formatting.py;
-            # Check if there is any difference
-            CHANGED_FILES=(`git diff --name-only`)
-            if [ "$CHANGED_FILES" ]; then
-                echo ""
-                echo "#########################"
-                echo "FAILED - Git diff was non-zero!"
-                echo "Run clang_format/fix_formatting.py to format your code properly:"
-                echo ""
-                echo $CHANGED_FILES
-                echo "#########################"
-                echo ""
-                return 1;
-            else
-                echo "PASSED - Code is correctly formatted!"
-            fi
-      fi
-    - |
-      if [ "$GENERATE_CODE_FROM_SYM" = "true" ]; then 
-            # Try to convert the .sym to C code
-            pipenv run python boards/shared/CanMsgs/generate_c_code_from_sym.py;
-            # Check if there is any difference
-            CHANGED_FILES=(`git diff --name-only`)
-            if [ "$CHANGED_FILES" ]; then
-                echo ""
-                echo "#########################"
-                echo "FAILED - Git diff was non-zero!"
-                echo "Make sure to update your version of cantools using pipenv,"
-                echo "and re-run generate_c_code_from_sym.py to generate C code from the .sym file:"
-                echo ""
-                echo $CHANGED_FILES
-                echo "#########################"
-                echo ""
-                return 1;
-            else
-                echo "PASSED - C code generated from .sym looks good!"
-            fi
-      fi
+  - ./scripts/travis_ci/travis_script.sh
 
 matrix:
-    include:
-        - name: "Build and Run Tests"
-          env: RUN_BUILD="true" RUN_TESTS="true"
-        - name: "Check Formatting"
-          env: RUN_FORMATTING_CHECKS="true"
-        - name: "Check C Code Generation From .sym"
-          env: GENERATE_CODE_FROM_SYM="true"
+  include:
+    - name: "Build and Run Tests"
+      env: RUN_BUILD="true" RUN_TESTS="true"
+    - name: "Check Formatting"
+      env: RUN_FORMATTING_CHECKS="true"
+    - name: "Check C Code Generation From .sym"
+      env: GENERATE_CODE_FROM_SYM="true"

--- a/CMakeLists_template.txt
+++ b/CMakeLists_template.txt
@@ -1,7 +1,7 @@
 #${templateWarning}
 SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_VERSION 1)
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.14)
 
 # specify cross compilers and tools
 SET(CMAKE_C_COMPILER_WORKS 1)

--- a/boards/DCM/CMakeLists.txt
+++ b/boards/DCM/CMakeLists.txt
@@ -1,7 +1,7 @@
 #THIS FILE IS AUTO GENERATED FROM THE TEMPLATE! DO NOT CHANGE!
 SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_VERSION 1)
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.14)
 
 # specify cross compilers and tools
 SET(CMAKE_C_COMPILER_WORKS 1)

--- a/boards/FSM/CMakeLists.txt
+++ b/boards/FSM/CMakeLists.txt
@@ -1,7 +1,7 @@
 #THIS FILE IS AUTO GENERATED FROM THE TEMPLATE! DO NOT CHANGE!
 SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_VERSION 1)
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.14)
 
 # specify cross compilers and tools
 SET(CMAKE_C_COMPILER_WORKS 1)

--- a/boards/PDM/CMakeLists.txt
+++ b/boards/PDM/CMakeLists.txt
@@ -1,7 +1,7 @@
 #THIS FILE IS AUTO GENERATED FROM THE TEMPLATE! DO NOT CHANGE!
 SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_VERSION 1)
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.14)
 
 # specify cross compilers and tools
 SET(CMAKE_C_COMPILER_WORKS 1)

--- a/clang-format/fix_formatting.py
+++ b/clang-format/fix_formatting.py
@@ -66,10 +66,11 @@ def runClangFormat():
     if _isWindows():
         CLANG_FORMAT_BINARY += ".exe"
 
-    # Prepare ${REPO_ROOT}/src directory
-    SOURCE_DIR = os.path.join("..", "src")
+    # Prepare path to recursive traverse
+    SOURCE_DIR = os.path.join("..", "boards")
 
-    # Now iterate through all the files inside the ${REPO_ROOT}/src directory
+    # Recursively traverse through file tree and apply clang-format
+    print("Apply clang-format to files under {}:".format(os.path.join(os.getcwd(), SOURCE_DIR)))
     for root, dirnames, filenames in os.walk(SOURCE_DIR):
         # Remove directories that we don't want to format from search list
         dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
@@ -97,14 +98,8 @@ if __name__ == '__main__':
     # Change into the directory this python file is in so we can use relative paths
     os.chdir(PYTHON_EXECUTABLE_DIRECTORY)
 
-    continueScript = input("THIS WILL FORMAT YOUR CODE! CONTINUE (Y | N)? ")
-    if continueScript != 'Y' and continueScript != 'y':
-        sys.exit(2)
+    if runClangFormat() != 0:
+        print("ERROR: Clang-Format encountered issues!")
+        sys.exit(1)
     else:
-        # Print newline because `echo "Y"` in Travis CI doesn't include LF
-        print("\r")
-        if runClangFormat() != 0:
-            print("ERROR: Clang-Format encountered issues!")
-            sys.exit(1)
-        else:
-            print("SUCCESS: Clang-Format ran on all files!")
+        print("SUCCESS: Clang-Format ran on all files!")

--- a/scripts/environment_setup/install_cmake.sh
+++ b/scripts/environment_setup/install_cmake.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# This script downloads and installs CMake
+# ----------------------------------------------------------------------------
+# Import shared bash scripts
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPT_DIR/../shared_funcs.sh
+
+check_installation_path_argument $#
+
+echo_border
+echo "Start downloading and installing CMake..."
+echo_border
+
+# Modify these variables to update the CMake version
+VERSION_MAJOR=3
+VERSION_MINOR=15
+VERSION_MICRO=2
+SHA256=f8cbec2abc433938bd9378b129d1d288bb33b8b5a277afe19644683af6e32a59
+
+VERSION=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_MICRO
+INSTALL_DIR=$1
+BIN_DIR=$INSTALL_DIR/bin
+
+if test -f $BIN_DIR/cmake && ($BIN_DIR/cmake --version | grep -q "$VERSION"); then
+    echo "CMake $VERSION already installed in $BIN_DIR"
+else
+    FILE=cmake-$VERSION-Linux-x86_64.tar.gz
+    URL=https://cmake.org/files/v$VERSION_MAJOR.$VERSION_MINOR/$FILE
+    TMPFILE=$(mktemp --tmpdir cmake-$VERSION-Linux-x86_64.XXXXXXXX.tar.gz)
+    # Download CMake
+    echo "Downloading CMake ($URL)..."
+    wget "$URL" -O "$TMPFILE"
+    # Check if downloaded file is correupt
+    if ! (shasum -a256 "$TMPFILE" | grep -q "$SHA256"); then
+        echo "Checksum mismatch ($TMPFILE)"
+        exit 1
+    fi
+    # Create the installation directory
+    mkdir -p "$INSTALL_DIR"
+    # Unzip CMake to the installation directory
+    tar xzf "$TMPFILE" -C "$INSTALL_DIR" --strip 1
+    # Remove temporary installation file
+    rm $TMPFILE
+fi
+
+echo_border
+echo "Downloading and installing CMake completed successfully!"
+echo_border

--- a/scripts/environment_setup/install_gcc_arm_none_eabi.sh
+++ b/scripts/environment_setup/install_gcc_arm_none_eabi.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# This script downloads and installs gcc-arm-none-eabi
+# ----------------------------------------------------------------------------
+# Import shared bash scripts
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPT_DIR/../shared_funcs.sh
+
+check_installation_path_argument $#
+
+echo_border
+echo "Start downloading and installing gcc-arm-none-eabi..."
+echo_border
+
+INSTALL_DIR=$1
+BIN_DIR=$INSTALL_DIR/bin
+
+if test -f $BIN_DIR/arm-none-eabi-gcc ; then
+    echo "arm-none-eabi-gcc already installed in $BIN_DIR"
+else
+    # Unfortunately, the download link is a literal URL which means it does not
+    # pull the latest version automatically.
+    #
+    # To change the download link:
+    # 1. Go to https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
+    # 2. Right-click and save the link to download the Linux 64-bit version
+    URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2?revision=c34d758a-be0c-476e-a2de-af8c6e16a8a2?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2019-q3-update
+    TMPFILE=$(mktemp --tmpdir gcc-arm-none-eabi.XXXXXXXX.tar.bz2)
+    # Download gcc-arm-none-eabi
+    echo "Downloading gcc-arm-none-eabi($URL)..."
+    wget "$URL" -O "$TMPFILE"
+    # Create the install directory
+    mkdir -p "$INSTALL_DIR"
+    # Unzip gcc-arm-none-eabi to the install directory
+    tar -xjf "$TMPFILE" -C "$INSTALL_DIR" --strip 1
+    # Remove the temporary installation file
+    rm $TMPFILE
+fi
+
+echo_border
+echo "Downloading and installing gcc-arm-none-eabi completed successfully!"
+echo_border

--- a/scripts/shared_funcs.sh
+++ b/scripts/shared_funcs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# This script contains shared functions for environment setup scripts.
+# ------------------------------------------------------------------------------
+# Exit immediately if a command exits with a non-zero status because each step
+set -e
+
+# Echo an 80 character length border
+echo_border() {
+    echo "==============================================================================="
+}
+
+# Scripts that install binaries shall take the installation path as an argument
+check_installation_path_argument() {
+    num_arguments=$1
+    if [ "$num_arguments" -ne 1 ]; then
+        echo "Please provide the installation path as argument!"
+        exit 2
+    fi
+}

--- a/scripts/travis_ci/print_bin_versions.sh
+++ b/scripts/travis_ci/print_bin_versions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# This script prints out binary versions relevant to Travis CI
+# -----------------------------------------------------------------------------
+# Import shared bash scripts
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPT_DIR/travis_shared.sh
+
+if [ "$RUN_BUILD" = "true" ] || [ "$RUN_TESTS" = "true" ]; then
+  # CMake
+  travis_run cmake --version
+  # gcc-arm-none-eabi
+  travis_run arm-none-eabi-gcc --version
+  travis_run arm-none-eabi-objcopy --version
+  travis_run arm-none-eabi-objdump --version
+  travis_run arm-none-eabi-size --version
+  travis_run arm-none-eabi-gcc-ar --version
+  travis_run arm-none-eabi-gdb --version
+fi

--- a/scripts/travis_ci/travis_install_binaries.sh
+++ b/scripts/travis_ci/travis_install_binaries.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# This script prints out binary versions relevant to Travis CI
+# ------------------------------------------------------------------------------
+# Import shared bash scripts
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPT_DIR/travis_shared.sh
+source $SCRIPT_DIR/../shared_funcs.sh
+
+check_installation_path_argument $#
+
+if [ "$RUN_BUILD" = "true" ] || [ "$RUN_TESTS" = "true" ]; then
+  # Prepend bin path to $PATH in order to override the built-in CMake
+  INSTALL_DIR=$1
+  PATH=$INSTALL_DIR/bin:$PATH
+  # Install binaries
+  travis_run sudo scripts/environment_setup/install_cmake.sh $INSTALL_DIR
+  travis_run sudo scripts/environment_setup/install_gcc_arm_none_eabi.sh $INSTALL_DIR
+fi

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# This script is intended to run in the 'script' phase of a Travis CI build
+# ------------------------------------------------------------------------------
+# Import shared bash scripts
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPT_DIR/travis_shared.sh
+source $SCRIPT_DIR/../shared_funcs.sh
+
+if [ "$RUN_BUILD" = "true" ]; then
+    # Build each project
+    for BOARD_NAME in FSM DCM PDM
+    do
+        travis_run "cmake boards/$BOARD_NAME/CMakeLists.txt && make -C boards/$BOARD_NAME"
+    done
+fi
+
+if [ "$RUN_TESTS" = "true" ]; then
+    :
+fi
+
+if [ "$RUN_FORMATTING_CHECKS" = "true" ]; then
+    # Run clang-format recursively
+    travis_run python clang-format/fix_formatting.py
+    # Check if there is any difference
+    CHANGED_FILES=(`git diff --name-only`)
+    if [ "$CHANGED_FILES" ]; then
+        echo ""
+        echo_border
+        echo "FAILED - Git diff was non-zero!"
+        echo "Run clang_format/fix_formatting.py to format your code properly:"
+        echo ""
+        echo $CHANGED_FILES
+        echo_border
+        echo ""
+        exit 1;
+    else
+        echo_border
+        echo "PASSED - Code is correctly formatted!"
+        echo_border
+    fi
+fi
+
+if [ "$GENERATE_CODE_FROM_SYM" = "true" ]; then
+    # Try to convert the .sym to C code
+    travis_run pipenv run python boards/shared/CanMsgs/generate_c_code_from_sym.py
+    # Check if there is any difference
+    CHANGED_FILES=(`git diff --name-only`)
+    if [ "$CHANGED_FILES" ]; then
+        echo ""
+        echo_border
+        echo "FAILED - Git diff was non-zero!"
+        echo "Make sure to update your version of cantools using pipenv,"
+        echo "and re-run generate_c_code_from_sym.py to generate C code from the .sym file:"
+        echo ""
+        echo $CHANGED_FILES
+        echo_border
+        echo ""
+        exit 1;
+    else
+        echo_border
+        echo "PASSED - C code generated from .sym looks good!"
+        echo_border
+    fi
+fi
+
+echo_border
+echo "Travis CI Script has finished successfully!"
+echo_border
+exit 0

--- a/scripts/travis_ci/travis_shared.sh
+++ b/scripts/travis_ci/travis_shared.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# This script contains shared functions for Travis related scripts.
+# ------------------------------------------------------------------------------
+# Any command in .travis.yml that exits with a non-zero value will cause Travis
+# to exit. However, commands encapsulated within the top-level command may not
+# report their return codes. For example, if we run './my_script.sh' in
+# .travis.yml, and in that script.sh there is a CMake command. If this CMake
+# command throws an error, this information is lost unless my_script.sh
+# explicitly propogate the error code to its parent. Using `set -e` ensures
+# that any command with non-zero command will immediately return and abort
+# Travis.
+set -e
+
+# This allows us to 'fold' commands in Travis console
+TRAVIS_FOLD_COUNTER=0
+function travis_run() {
+  local command=$@
+
+  echo -e "\e[0Ktravis_fold:start:$(basename $0).command.$TRAVIS_FOLD_COUNTER \e[34m$ $command\e[0m"
+  # Actually run command, and kill the build if there's a non-zero return code.
+  eval ${command} || exit 1
+  echo -e -n "\e[0Ktravis_fold:end:$(basename $0).command.$TRAVIS_FOLD_COUNTER\e[0m"
+
+  let "TRAVIS_FOLD_COUNTER += 1"
+}


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The CMake built into Travis was giving us trouble (ex. Errors weren't being caught properly), so I updated it to 3.15 and updated the CMake version requirement in CMakeLists.txt. I used this opportunity to do some clean up on the .yml file. The general theme is to not put the bash commands in .yml, and instead refactor commands into their respective bash scripts. The .yml will simply invoke these refactored bash scripts.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
- Update CMake for Travis
- refactored CI code to scripts
- Add some nice folding to Travis console output
- Remove 'Y' check from `fix_formatting.py` to improve ease-of-use

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
- The objcopt step of our CMake build process now executes successfully! This means the .hex and other related artifacts are built correctly.
- Verified that each Travis job console outputs is same 
### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->
Resolves #410 
### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code standards detailed in http://svformulaep1.teams.apsc.ubc.ca:8090/display/TR/Workflow (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
