### PR TITLE
Remove obsolete installation innstructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Open any one of the folders under `boards/` (e.g. `boards/DCM`) in **CLion**.
 
 ### Environment Dependencies
 Follow these steps so you can compile the code in **CLion**:
-1. **Install Dependencies**: There are several dependencies required in order to mimic what CI is doing. *(Note: All links below are for windows. All equivalent linux utilities may be easily installed via the package manager for your linux distribution (`apt-get` in Ubuntu, etc.) or using the scripts found under `scripts/environment_setup/`)*
+1. **Install Dependencies**: There are several dependencies required in order to mimic what CI is doing.
   * GNU Make: http://gnuwin32.sourceforge.net/packages/make.htm
   * CMake: https://cmake.org/install/
   * Python 3+ (*Python < 3 will NOT work*): https://www.python.org/downloads/
   * ARM GNU Embedded Toolchain: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads (Check `install_gcc_arm_none_eabi.sh` for which version to download)
-  *  J-Link Software and Documentation Pack: https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack
+  * J-Link Software and Documentation Pack: https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack
 2. **Modify your `PATH` Environment Variable**: Make sure to add the binary executables to `PATH`. To add these, find `Environment Variables` in your start menu and then add the appropriate paths to `PATH`:
 ```
 C:\Program Files (x86)\GNU Tools Arm Embedded\<VERSION>\bin


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
We should not use `apt-get` to install gcc on Linux because it is not the most up to date. The current version from `apt-get` won't actually compile the project due to the ISO99 error with the `Error_Handler()` hack.
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
