### PR TITLE
Remove the unwanted system_stm32f3xx.c from the compilation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,10 @@ auto_generated/
 .mxproject
 MXTmpFiles
 
+# This unwanted file gets created when you use the STM32CubeMX GUI to generate
+# code. This doesn't happen if you use the STM32CubeMX command-line interface.
+**/Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c
+
 # PCAN-Explorer
 *.dsk
 *.dsk~

--- a/CMakeLists_template.txt
+++ b/CMakeLists_template.txt
@@ -53,7 +53,13 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/../shared __shared__)
 include_directories(${SHARED_INCLUDE_DIRS})
 
 # 3. STM32CubeMX driver code
+# 3-1. Global the source files recursively
 file(GLOB_RECURSE STM32CUBEMX_DRIVER_SRCS "startup/*.*" "Middlewares/*.*" "Drivers/*.*" "Src/syscalls.c")
+# 3-2. STM32CubeMX GUI generates a second copy of system_stm32f3xx.c, which
+# causes the linking process to fail due to multiple definition. Manually remove
+# this second copy of system_stm32f3xx.c from the compilation process. Note that
+# the correct system_stm32f3xx.c lives under Src/.
+list(FILTER STM32CUBEMX_DRIVER_SRCS EXCLUDE REGEX ".*Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c")
 
 # 4. Auto-generated code
 # 4-1. Generate CAN code using DBC

--- a/boards/BMS/CMakeLists.txt
+++ b/boards/BMS/CMakeLists.txt
@@ -53,7 +53,13 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/../shared __shared__)
 include_directories(${SHARED_INCLUDE_DIRS})
 
 # 3. STM32CubeMX driver code
+# 3-1. Global the source files recursively
 file(GLOB_RECURSE STM32CUBEMX_DRIVER_SRCS "startup/*.*" "Middlewares/*.*" "Drivers/*.*" "Src/syscalls.c")
+# 3-2. STM32CubeMX GUI generates a second copy of system_stm32f3xx.c, which
+# causes the linking process to fail due to multiple definition. Manually remove
+# this second copy of system_stm32f3xx.c from the compilation process. Note that
+# the correct system_stm32f3xx.c lives under Src/.
+list(FILTER STM32CUBEMX_DRIVER_SRCS EXCLUDE REGEX ".*Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c")
 
 # 4. Auto-generated code
 # 4-1. Generate CAN code using DBC

--- a/boards/DCM/CMakeLists.txt
+++ b/boards/DCM/CMakeLists.txt
@@ -53,7 +53,13 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/../shared __shared__)
 include_directories(${SHARED_INCLUDE_DIRS})
 
 # 3. STM32CubeMX driver code
+# 3-1. Global the source files recursively
 file(GLOB_RECURSE STM32CUBEMX_DRIVER_SRCS "startup/*.*" "Middlewares/*.*" "Drivers/*.*" "Src/syscalls.c")
+# 3-2. STM32CubeMX GUI generates a second copy of system_stm32f3xx.c, which
+# causes the linking process to fail due to multiple definition. Manually remove
+# this second copy of system_stm32f3xx.c from the compilation process. Note that
+# the correct system_stm32f3xx.c lives under Src/.
+list(FILTER STM32CUBEMX_DRIVER_SRCS EXCLUDE REGEX ".*Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c")
 
 # 4. Auto-generated code
 # 4-1. Generate CAN code using DBC

--- a/boards/FSM/CMakeLists.txt
+++ b/boards/FSM/CMakeLists.txt
@@ -53,7 +53,13 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/../shared __shared__)
 include_directories(${SHARED_INCLUDE_DIRS})
 
 # 3. STM32CubeMX driver code
+# 3-1. Global the source files recursively
 file(GLOB_RECURSE STM32CUBEMX_DRIVER_SRCS "startup/*.*" "Middlewares/*.*" "Drivers/*.*" "Src/syscalls.c")
+# 3-2. STM32CubeMX GUI generates a second copy of system_stm32f3xx.c, which
+# causes the linking process to fail due to multiple definition. Manually remove
+# this second copy of system_stm32f3xx.c from the compilation process. Note that
+# the correct system_stm32f3xx.c lives under Src/.
+list(FILTER STM32CUBEMX_DRIVER_SRCS EXCLUDE REGEX ".*Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c")
 
 # 4. Auto-generated code
 # 4-1. Generate CAN code using DBC

--- a/boards/PDM/CMakeLists.txt
+++ b/boards/PDM/CMakeLists.txt
@@ -53,7 +53,13 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/../shared __shared__)
 include_directories(${SHARED_INCLUDE_DIRS})
 
 # 3. STM32CubeMX driver code
+# 3-1. Global the source files recursively
 file(GLOB_RECURSE STM32CUBEMX_DRIVER_SRCS "startup/*.*" "Middlewares/*.*" "Drivers/*.*" "Src/syscalls.c")
+# 3-2. STM32CubeMX GUI generates a second copy of system_stm32f3xx.c, which
+# causes the linking process to fail due to multiple definition. Manually remove
+# this second copy of system_stm32f3xx.c from the compilation process. Note that
+# the correct system_stm32f3xx.c lives under Src/.
+list(FILTER STM32CUBEMX_DRIVER_SRCS EXCLUDE REGEX ".*Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c")
 
 # 4. Auto-generated code
 # 4-1. Generate CAN code using DBC


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
```
# 3-2. STM32CubeMX GUI generates a second copy of system_stm32f3xx.c, which
# causes the linking process to fail due to multiple definition. Manually remove
# this second copy of system_stm32f3xx.c from the compilation process. Note that
# the correct copy lives under Src/.
```

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
I can compile the project successfully even if the bad file is generated.

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->
#482 

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
