### PR TITLE
Check if CAN code generation library is initialized

### DIFF
--- a/boards/BMS/Src/main.c
+++ b/boards/BMS/Src/main.c
@@ -31,6 +31,7 @@
 #include "SharedWatchdog.h"
 #include "Io_Can.h"
 #include "auto_generated/App_CanTx.h"
+#include "auto_generated/App_CanRx.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -100,6 +101,8 @@ int main(void)
     /* USER CODE BEGIN 1 */
     __HAL_DBGMCU_FREEZE_IWDG();
     SharedHardFaultHandler_Init();
+    App_CanTx_Init();
+    App_CanRx_Init();
     /* USER CODE END 1 */
 
     /* MCU

--- a/boards/DCM/Src/main.c
+++ b/boards/DCM/Src/main.c
@@ -106,6 +106,8 @@ int main(void)
     /* USER CODE BEGIN 1 */
     __HAL_DBGMCU_FREEZE_IWDG();
     SharedHardFaultHandler_Init();
+    App_CanTx_Init();
+    App_CanRx_Init();
     /* USER CODE END 1 */
 
     /* MCU
@@ -133,8 +135,7 @@ int main(void)
     MX_DAC_Init();
     MX_IWDG_Init();
     /* USER CODE BEGIN 2 */
-    App_CanTx_Init();
-    App_CanRx_Init();
+
     /* USER CODE END 2 */
 
     /* USER CODE BEGIN RTOS_MUTEX */

--- a/boards/FSM/Src/main.c
+++ b/boards/FSM/Src/main.c
@@ -103,6 +103,8 @@ int main(void)
     /* USER CODE BEGIN 1 */
     __HAL_DBGMCU_FREEZE_IWDG();
     SharedHardFaultHandler_Init();
+    App_CanTx_Init();
+    App_CanRx_Init();
     /* USER CODE END 1 */
 
     /* MCU
@@ -129,8 +131,7 @@ int main(void)
     MX_ADC1_Init();
     MX_IWDG_Init();
     /* USER CODE BEGIN 2 */
-    App_CanTx_Init();
-    App_CanRx_Init();
+
     /* USER CODE END 2 */
 
     /* USER CODE BEGIN RTOS_MUTEX */

--- a/boards/PDM/Src/main.c
+++ b/boards/PDM/Src/main.c
@@ -106,6 +106,8 @@ int main(void)
     /* USER CODE BEGIN 1 */
     __HAL_DBGMCU_FREEZE_IWDG();
     SharedHardFaultHandler_Init();
+    App_CanTx_Init();
+    App_CanRx_Init();
     /* USER CODE END 1 */
 
     /* MCU
@@ -133,8 +135,7 @@ int main(void)
     MX_ADC1_Init();
     MX_IWDG_Init();
     /* USER CODE BEGIN 2 */
-    App_CanTx_Init();
-    App_CanRx_Init();
+
     /* USER CODE END 2 */
 
     /* USER CODE BEGIN RTOS_MUTEX */

--- a/boards/shared/CAN/codegen_shared.py
+++ b/boards/shared/CAN/codegen_shared.py
@@ -174,3 +174,16 @@ class CanSignal:
         self.uppercase_name = signal_name_snakecase.upper()
         self.msg_name_snakecase = msg_name_snakecase
         self.msg_name_uppercase = msg_name_snakecase.upper()
+
+class Variable:
+    def __init__(self, type, name, init_val, comment):
+        self.__name = name
+        self.__definition = '''\
+/** @brief {comment} */
+{type} {name} = {init_val};'''.format(
+            comment=comment, type=type, name=name, init_val=init_val)
+
+    def get_definition(self):
+        return self.__definition
+    def get_name(self):
+        return self.__name


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The CAN code generation library doesn't check if its functions are getting called before the `Init` function is called. Fixed that. Found this to be a problem because I realized I forgot to add the `Init` functions to BMS.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
