### PR TITLE
Fix J-Link mini connector image sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,5 @@ It is conventional for the frequency of periodic tasks in embedded systems to be
 ## FAQ
 ### What is the correct orientation for plugging in the J-Link mini connector?
 The red marking on the ribbon cable indicates pin 1. Align the red marking with the pin 1 marker next to the J-Link mini connector.
-<img src="https://github.com/UBCFormulaElectric/Consolidated-Firmware/blob/master/images/jlink_connector.png" width="50" height="50"/>
+
+<img src="https://github.com/UBCFormulaElectric/Consolidated-Firmware/blob/master/images/jlink_connector.png" width="50%" height="50%"/>


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Forgot to add `%` to the image sizing. The image rendering came out all looking goofy.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
