### PR TITLE
Set automatic breakpoints for hard faults and assert failures

### DIFF
--- a/boards/BMS/Inc/stm32f3xx_hal_conf.h
+++ b/boards/BMS/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2020 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/DCM/Inc/stm32f3xx_hal_conf.h
+++ b/boards/DCM/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2020 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/FSM/Inc/stm32f3xx_hal_conf.h
+++ b/boards/FSM/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2020 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/PDM/Inc/stm32f3xx_hal_conf.h
+++ b/boards/PDM/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2020 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/shared/Assert/SharedAssert.c
+++ b/boards/shared/Assert/SharedAssert.c
@@ -55,6 +55,8 @@ void SharedAssert_AssertFailed(char *file_path, uint32_t line, char *expr)
         "%s:%d %s: Assertion `%s' failed\r\n", __BASENAME__(file_path), line,
         __func__, _expr);
 
+    BREAK_IF_DEBUGGER_CONNECTED();
+
     for (;;)
     {
         // Trap here forever. It might be desirable in the future to use

--- a/boards/shared/HardFaultHandler/SharedHardFaultHandler.c
+++ b/boards/shared/HardFaultHandler/SharedHardFaultHandler.c
@@ -3,6 +3,7 @@
  ******************************************************************************/
 #include <stm32f3xx_hal.h>
 #include "SharedHardFaultHandler.h"
+#include "SharedMacros.h"
 
 /******************************************************************************
  * Function Definitions
@@ -52,6 +53,8 @@ void SharedHardFaultHandler_LogInformation(uint32_t *fault_stack)
     afsr  = SCB->AFSR;
     bfar  = SCB->BFAR;
     mmfar = SCB->MMFAR;
+
+    BREAK_IF_DEBUGGER_CONNECTED();
 
     for (;;)
     {

--- a/boards/shared/Macros/SharedMacros.h
+++ b/boards/shared/Macros/SharedMacros.h
@@ -14,8 +14,16 @@
 // clang-format off
 #define NUM_ELEMENTS_IN_ARRAY(array_pointer) \
     sizeof(array_pointer) / sizeof(array_pointer[0])
+
 /* @brief Extract the basename from a file path */
 #define __BASENAME__(path) \
     (__builtin_strrchr(path, '/') ? __builtin_strrchr(path, '/') + 1 : path)
+
+/* @brief Set a software breakpoint if debugger is connected */
+#define BREAK_IF_DEBUGGER_CONNECTED() \
+if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) \
+{ \
+    __asm__ __volatile__ ("bkpt #0"); \
+} \
 
 #endif /* SHARED_MACROS_H */


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The most aggressive form of error handling we have is to trap in a while(1) loop. However, this causes the watchdog to timeout and thus the board resets. I added some code to *automatically* halt program execution with the debugger connected.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
Verified that breakpoints are automatically set when:

- HAL init functions fail and invoke `Error_Handler()`
- `assert_param(0);` // assert provided by HAL
- `shared_assert(0);` // our version of assert

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
