### PR TITLE
 Fix error where Travis CI doesn't report error when ctest fails

### DIFF
--- a/boards/DCM/Test/Src/state_machine_tests.cpp
+++ b/boards/DCM/Test/Src/state_machine_tests.cpp
@@ -36,14 +36,6 @@ class DcmStateMachineTest : public testing::Test
         RESET_FAKE(send_non_periodic_msg_DCM_WATCHDOG_TIMEOUT);
     }
 
-    virtual void SetInitialState(const struct State *initial_state)
-    {
-        assert(initial_state != NULL);
-        App_SharedStateMachine_Destroy(state_machine);
-        state_machine = App_SharedStateMachine_Create(world, initial_state);
-        EXPECT_TRUE(state_machine);
-    }
-
     virtual void TearDown()
     {
         assert(state_machine != NULL);
@@ -62,19 +54,8 @@ class DcmStateMachineTest : public testing::Test
 
 TEST_F(
     DcmStateMachineTest,
-    check_startup_message_is_broadcasted_on_init_state_entry)
-{
-    SetInitialState(App_GetInitState());
-
-    ASSERT_EQ(1, send_non_periodic_msg_DCM_STARTUP_fake.call_count);
-}
-
-TEST_F(
-    DcmStateMachineTest,
     check_init_immediately_transitions_to_run_on_first_tick)
 {
-    SetInitialState(App_GetInitState());
-
     // We need to tick twice, once to run the `Init` state, and once more
     // to have the state machine transition to the `Run` state.
     App_SharedStateMachine_Tick(state_machine);

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -28,7 +28,7 @@ if [ "$RUN_X86_TESTS" = "true" ]; then
     BUILD_DIR=boards/x86_build
     travis_run cmake -S boards -B $BUILD_DIR -DPLATFORM=x86
     travis_run make --directory=$BUILD_DIR
-    travis_run cd $BUILD_DIR && ctest
+    travis_run "cd $BUILD_DIR && ctest"
 
     if [ $? -ne 0 ]; then
         echo "Ctest failed. Please check the test log for more information."

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -30,8 +30,7 @@ if [ "$RUN_X86_TESTS" = "true" ]; then
     travis_run make --directory=$BUILD_DIR
     travis_run cd $BUILD_DIR && ctest
 
-    return_code=$?
-    if [ $return -ne 0 ]; then
+    if [ $? -ne 0 ]; then
         echo "Ctest failed. Please check the test log for more information."
         exit 1
     else

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -28,7 +28,15 @@ if [ "$RUN_X86_TESTS" = "true" ]; then
     BUILD_DIR=boards/x86_build
     travis_run cmake -S boards -B $BUILD_DIR -DPLATFORM=x86
     travis_run make --directory=$BUILD_DIR
-    travis_run cd $BUILD_DIR && ctest && cd -
+    travis_run cd $BUILD_DIR && ctest
+
+    return_code=$?
+    if [ $return -ne 0 ]; then
+        echo "Ctest failed. Please check the test log for more information."
+        exit 1
+    else
+        travis_run cd -
+    fi
 fi
 
 if [ "$RUN_FORMATTING_CHECKS" = "true" ]; then

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -29,8 +29,9 @@ if [ "$RUN_X86_TESTS" = "true" ]; then
     travis_run cmake -S boards -B $BUILD_DIR -DPLATFORM=x86
     travis_run make --directory=$BUILD_DIR
     travis_run "cd $BUILD_DIR && ctest"
+    CTEST_RETURN_CODE=$?
 
-    if [ $? -ne 0 ]; then
+    if [ $CTEST_RETURN_CODE -ne 0 ]; then
         echo "Ctest failed. Please check the test log for more information."
         exit 1
     else


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
CI was not failing when `ctest` returns non-zero exit code :cry:

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
