### PR TITLE
Initialize App and Io code after CubeMX Init functions

### DIFF
--- a/boards/BMS/Src/main.c
+++ b/boards/BMS/Src/main.c
@@ -134,31 +134,7 @@ static void CanTxQueueOverflowCallBack(size_t overflow_count)
 int main(void)
 {
     /* USER CODE BEGIN 1 */
-    __HAL_DBGMCU_FREEZE_IWDG();
-    Io_SharedHardFaultHandler_Init();
 
-    Io_Imd_Init();
-    imd = App_Imd_Create(
-        Io_Imd_GetFrequency, 2.0f, Io_Imd_GetDutyCycle,
-        Io_Imd_GetTimeSincePowerOn);
-
-    can_tx = App_CanTx_Create(
-        Io_CanTx_EnqueueNonPeriodicMsg_BMS_STARTUP,
-        Io_CanTx_EnqueueNonPeriodicMsg_BMS_WATCHDOG_TIMEOUT);
-
-    can_rx = App_CanRx_Create();
-
-    heartbeat_monitor = App_SharedHeartbeatMonitor_Create(
-        Io_HeartbeatMonitor_GetCurrentMs, 300U,
-        FSM_HEARTBEAT_ONE_HOT | DCM_HEARTBEAT_ONE_HOT | PDM_HEARTBEAT_ONE_HOT,
-        Io_HeartbeatMonitor_TimeoutCallback);
-
-    world = App_BmsWorld_Create(can_tx, can_rx, imd, heartbeat_monitor);
-
-    App_StackWaterMark_Init(can_tx);
-    Io_SoftwareWatchdog_Init(can_tx);
-
-    state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
     /* USER CODE END 1 */
 
     /* MCU
@@ -187,6 +163,32 @@ int main(void)
     MX_TIM2_Init();
     MX_ADC2_Init();
     /* USER CODE BEGIN 2 */
+    __HAL_DBGMCU_FREEZE_IWDG();
+    Io_SharedHardFaultHandler_Init();
+
+    Io_Imd_Init();
+    imd = App_Imd_Create(
+        Io_Imd_GetFrequency, 2.0f, Io_Imd_GetDutyCycle,
+        Io_Imd_GetTimeSincePowerOn);
+
+    can_tx = App_CanTx_Create(
+        Io_CanTx_EnqueueNonPeriodicMsg_BMS_STARTUP,
+        Io_CanTx_EnqueueNonPeriodicMsg_BMS_WATCHDOG_TIMEOUT);
+
+    can_rx = App_CanRx_Create();
+
+    heartbeat_monitor = App_SharedHeartbeatMonitor_Create(
+        Io_HeartbeatMonitor_GetCurrentMs, 300U,
+        FSM_HEARTBEAT_ONE_HOT | DCM_HEARTBEAT_ONE_HOT | PDM_HEARTBEAT_ONE_HOT,
+        Io_HeartbeatMonitor_TimeoutCallback);
+
+    world = App_BmsWorld_Create(can_tx, can_rx, imd, heartbeat_monitor);
+
+    App_StackWaterMark_Init(can_tx);
+    Io_SoftwareWatchdog_Init(can_tx);
+
+    state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
+
     struct CanMsgs_bms_startup_t payload = { .dummy = 0 };
     App_CanTx_SendNonPeriodicMsg_BMS_STARTUP(can_tx, &payload);
     /* USER CODE END 2 */

--- a/boards/DCM/Src/main.c
+++ b/boards/DCM/Src/main.c
@@ -126,25 +126,6 @@ static void CanTxQueueOverflowCallBack(size_t overflow_count)
 int main(void)
 {
     /* USER CODE BEGIN 1 */
-    __HAL_DBGMCU_FREEZE_IWDG();
-    Io_SharedHardFaultHandler_Init();
-
-    can_tx = App_CanTx_Create(
-        Io_CanTx_EnqueueNonPeriodicMsg_DCM_STARTUP,
-        Io_CanTx_EnqueueNonPeriodicMsg_DCM_WATCHDOG_TIMEOUT);
-
-    can_rx = App_CanRx_Create();
-
-    heartbeat_monitor = App_SharedHeartbeatMonitor_Create(
-        Io_HeartbeatMonitor_GetCurrentMs, 300U, BMS_HEARTBEAT_ONE_HOT,
-        Io_HeartbeatMonitor_TimeoutCallback);
-
-    world = App_DcmWorld_Create(can_tx, can_rx, heartbeat_monitor);
-
-    App_StackWaterMark_Init(can_tx);
-    Io_SoftwareWatchdog_Init(can_tx);
-
-    state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
 
     /* USER CODE END 1 */
 
@@ -172,6 +153,26 @@ int main(void)
     MX_CAN_Init();
     MX_IWDG_Init();
     /* USER CODE BEGIN 2 */
+    __HAL_DBGMCU_FREEZE_IWDG();
+    Io_SharedHardFaultHandler_Init();
+
+    can_tx = App_CanTx_Create(
+        Io_CanTx_EnqueueNonPeriodicMsg_DCM_STARTUP,
+        Io_CanTx_EnqueueNonPeriodicMsg_DCM_WATCHDOG_TIMEOUT);
+
+    can_rx = App_CanRx_Create();
+
+    heartbeat_monitor = App_SharedHeartbeatMonitor_Create(
+        Io_HeartbeatMonitor_GetCurrentMs, 300U, BMS_HEARTBEAT_ONE_HOT,
+        Io_HeartbeatMonitor_TimeoutCallback);
+
+    world = App_DcmWorld_Create(can_tx, can_rx, heartbeat_monitor);
+
+    App_StackWaterMark_Init(can_tx);
+    Io_SoftwareWatchdog_Init(can_tx);
+
+    state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
+
     struct CanMsgs_dcm_startup_t payload = { .dummy = 0 };
     App_CanTx_SendNonPeriodicMsg_DCM_STARTUP(can_tx, &payload);
     /* USER CODE END 2 */

--- a/boards/DIM/Src/main.c
+++ b/boards/DIM/Src/main.c
@@ -125,6 +125,33 @@ static void CanTxQueueOverflowCallBack(size_t overflow_count)
 int main(void)
 {
     /* USER CODE BEGIN 1 */
+
+    /* USER CODE END 1 */
+
+    /* MCU
+     * Configuration--------------------------------------------------------*/
+
+    /* Reset of all peripherals, Initializes the Flash interface and the
+     * Systick. */
+    HAL_Init();
+
+    /* USER CODE BEGIN Init */
+
+    /* USER CODE END Init */
+
+    /* Configure the system clock */
+    SystemClock_Config();
+
+    /* USER CODE BEGIN SysInit */
+
+    /* USER CODE END SysInit */
+
+    /* Initialize all configured peripherals */
+    MX_GPIO_Init();
+    MX_CAN_Init();
+    MX_ADC2_Init();
+    MX_SPI2_Init();
+    /* USER CODE BEGIN 2 */
     __HAL_DBGMCU_FREEZE_IWDG();
     Io_SharedHardFaultHandler_Init();
 
@@ -155,32 +182,7 @@ int main(void)
         can_tx, can_rx, seven_seg_displays, heartbeat_monitor);
 
     state_machine = App_SharedStateMachine_Create(world, App_GetDriveState());
-    /* USER CODE END 1 */
 
-    /* MCU
-     * Configuration--------------------------------------------------------*/
-
-    /* Reset of all peripherals, Initializes the Flash interface and the
-     * Systick. */
-    HAL_Init();
-
-    /* USER CODE BEGIN Init */
-
-    /* USER CODE END Init */
-
-    /* Configure the system clock */
-    SystemClock_Config();
-
-    /* USER CODE BEGIN SysInit */
-
-    /* USER CODE END SysInit */
-
-    /* Initialize all configured peripherals */
-    MX_GPIO_Init();
-    MX_CAN_Init();
-    MX_ADC2_Init();
-    MX_SPI2_Init();
-    /* USER CODE BEGIN 2 */
     struct CanMsgs_dim_startup_t payload = { .dummy = 0 };
     App_CanTx_SendNonPeriodicMsg_DIM_STARTUP(can_tx, &payload);
     /* USER CODE END 2 */

--- a/boards/FSM/Src/main.c
+++ b/boards/FSM/Src/main.c
@@ -133,33 +133,7 @@ static void CanTxQueueOverflowCallBack(size_t overflow_count)
 int main(void)
 {
     /* USER CODE BEGIN 1 */
-    __HAL_DBGMCU_FREEZE_IWDG();
-    Io_SharedHardFaultHandler_Init();
 
-    Io_FlowMeters_Init(&htim4);
-    primary_flow_meter = App_FlowMeter_Create(Io_FlowMeters_GetPrimaryFlowRate);
-    secondary_flow_meter =
-        App_FlowMeter_Create(Io_FlowMeters_GetSecondaryFlowRate);
-
-    can_tx = App_CanTx_Create(
-        Io_CanTx_EnqueueNonPeriodicMsg_FSM_STARTUP,
-        Io_CanTx_EnqueueNonPeriodicMsg_FSM_WATCHDOG_TIMEOUT,
-        Io_CanTx_EnqueueNonPeriodicMsg_FSM_AIR_SHUTDOWN);
-
-    can_rx = App_CanRx_Create();
-
-    heartbeat_monitor = App_SharedHeartbeatMonitor_Create(
-        Io_HeartbeatMonitor_GetCurrentMs, 300U, BMS_HEARTBEAT_ONE_HOT,
-        Io_HeartbeatMonitor_TimeoutCallback);
-
-    world = App_FsmWorld_Create(
-        can_tx, can_rx, heartbeat_monitor, primary_flow_meter,
-        secondary_flow_meter);
-
-    state_machine = App_SharedStateMachine_Create(world, App_GetAirOpenState());
-
-    App_StackWaterMark_Init(can_tx);
-    Io_SoftwareWatchdog_Init(can_tx);
     /* USER CODE END 1 */
 
     /* MCU
@@ -187,10 +161,33 @@ int main(void)
     MX_ADC2_Init();
     MX_TIM4_Init();
     /* USER CODE BEGIN 2 */
+    __HAL_DBGMCU_FREEZE_IWDG();
+    Io_SharedHardFaultHandler_Init();
+
     Io_FlowMeters_Init(&htim4);
     primary_flow_meter = App_FlowMeter_Create(Io_FlowMeters_GetPrimaryFlowRate);
     secondary_flow_meter =
         App_FlowMeter_Create(Io_FlowMeters_GetSecondaryFlowRate);
+
+    can_tx = App_CanTx_Create(
+        Io_CanTx_EnqueueNonPeriodicMsg_FSM_STARTUP,
+        Io_CanTx_EnqueueNonPeriodicMsg_FSM_WATCHDOG_TIMEOUT,
+        Io_CanTx_EnqueueNonPeriodicMsg_FSM_AIR_SHUTDOWN);
+
+    can_rx = App_CanRx_Create();
+
+    heartbeat_monitor = App_SharedHeartbeatMonitor_Create(
+        Io_HeartbeatMonitor_GetCurrentMs, 300U, BMS_HEARTBEAT_ONE_HOT,
+        Io_HeartbeatMonitor_TimeoutCallback);
+
+    world = App_FsmWorld_Create(
+        can_tx, can_rx, heartbeat_monitor, primary_flow_meter,
+        secondary_flow_meter);
+
+    state_machine = App_SharedStateMachine_Create(world, App_GetAirOpenState());
+
+    App_StackWaterMark_Init(can_tx);
+    Io_SoftwareWatchdog_Init(can_tx);
 
     struct CanMsgs_fsm_startup_t payload = { .dummy = 0 };
     App_CanTx_SendNonPeriodicMsg_FSM_STARTUP(can_tx, &payload);

--- a/boards/PDM/Src/main.c
+++ b/boards/PDM/Src/main.c
@@ -133,6 +133,34 @@ static void CanTxQueueOverflowCallBack(size_t overflow_count)
 int main(void)
 {
     /* USER CODE BEGIN 1 */
+
+    /* USER CODE END 1 */
+
+    /* MCU
+     * Configuration--------------------------------------------------------*/
+
+    /* Reset of all peripherals, Initializes the Flash interface and the
+     * Systick. */
+    HAL_Init();
+
+    /* USER CODE BEGIN Init */
+
+    /* USER CODE END Init */
+
+    /* Configure the system clock */
+    SystemClock_Config();
+
+    /* USER CODE BEGIN SysInit */
+
+    /* USER CODE END SysInit */
+
+    /* Initialize all configured peripherals */
+    MX_GPIO_Init();
+    MX_CAN_Init();
+    MX_SPI2_Init();
+    MX_ADC1_Init();
+    MX_IWDG_Init();
+    /* USER CODE BEGIN 2 */
     __HAL_DBGMCU_FREEZE_IWDG();
     Io_SharedHardFaultHandler_Init();
 
@@ -174,33 +202,7 @@ int main(void)
     Io_SoftwareWatchdog_Init(can_tx);
     Io_VoltageMonitor_Init(can_tx);
     App_StackWaterMark_Init(can_tx);
-    /* USER CODE END 1 */
 
-    /* MCU
-     * Configuration--------------------------------------------------------*/
-
-    /* Reset of all peripherals, Initializes the Flash interface and the
-     * Systick. */
-    HAL_Init();
-
-    /* USER CODE BEGIN Init */
-
-    /* USER CODE END Init */
-
-    /* Configure the system clock */
-    SystemClock_Config();
-
-    /* USER CODE BEGIN SysInit */
-
-    /* USER CODE END SysInit */
-
-    /* Initialize all configured peripherals */
-    MX_GPIO_Init();
-    MX_CAN_Init();
-    MX_SPI2_Init();
-    MX_ADC1_Init();
-    MX_IWDG_Init();
-    /* USER CODE BEGIN 2 */
     struct CanMsgs_pdm_startup_t payload = { .dummy = 0 };
     App_CanTx_SendNonPeriodicMsg_PDM_STARTUP(can_tx, &payload);
     /* USER CODE END 2 */


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The CubeMX Init functions (e.g. `MX_GPIO_INIT`) has been causing side effects to our`Io_Init` code. A few examples:

- `Io_SevenSegDisplays_Init` is supposed to configure maximum brightness by writing to the DIMMING pin, but then `MX_GPIO_Init` immediately overwrites to value
- `Io_FlowMeters_Init` requires a valid `hspi` but it doesn't get initialized until `MX_SPI2_Init`

Putting all the initialization code in USER CODE BLOCK 1 was an arbitrary choice to begin with, so we're moving everything to USER CODE BLOCK 2

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
