### PR TITLE
Normalize code size in SeriesCI

### DIFF
--- a/scripts/travis_ci/series_ci.sh
+++ b/scripts/travis_ci/series_ci.sh
@@ -30,8 +30,8 @@ bss="${size_output[2]}"
 flash="$(echo "scale=2; 100 * ($text + $data) / $FLASH_MAX_SIZE" | bc)%"
 ram="$(echo "scale=2; 100 * ($bss + $data) / $RAM_MAX_SIZE" | bc)%"
 
-echo FLASH: $(($text + $data))/$FLASH_MAX_SIZE ($flash)
-echo RAM: $(($bss + $data))/$RAM_MAX_SIZE ($ram)
+echo "FLASH: $(($text + $data)) / $FLASH_MAX_SIZE ($flash)"
+echo "RAM: $(($bss + $data)) / $RAM_MAX_SIZE ($ram)"
 
 curl \
   --header "Authorization: Token 27d62d1f-71c6-4075-95b5-f7aec56d0204" \

--- a/scripts/travis_ci/series_ci.sh
+++ b/scripts/travis_ci/series_ci.sh
@@ -28,10 +28,10 @@ bss="${size_output[2]}"
 #
 # Read more: https://interrupt.memfault.com/best-firmware-size-tools
 flash="$(echo "scale=2; 100 * ($text + $data) / $FLASH_MAX_SIZE" | bc)%"
-ram="$(echo "scale=2; 100 * ($data + $bss) / $RAM_MAX_SIZE" | bc)%"
+ram="$(echo "scale=2; 100 * ($bss + $data) / $RAM_MAX_SIZE" | bc)%"
 
-echo FLASH: $flash
-echo RAM: $ram
+echo FLASH: $(($text + $data))/$FLASH_MAX_SIZE ($flash)
+echo RAM: $(($bss + $data))/$RAM_MAX_SIZE ($ram)
 
 curl \
   --header "Authorization: Token 27d62d1f-71c6-4075-95b5-f7aec56d0204" \

--- a/scripts/travis_ci/series_ci.sh
+++ b/scripts/travis_ci/series_ci.sh
@@ -30,8 +30,8 @@ bss="${size_output[2]}"
 flash="$(echo "scale=2; 100 * ($text + $data) / $FLASH_MAX_SIZE" | bc)%"
 ram="$(echo "scale=2; 100 * ($data + $bss) / $RAM_MAX_SIZE" | bc)%"
 
-echo $flash
-echo $ram
+echo FLASH: $flash
+echo RAM: $ram
 
 curl \
   --header "Authorization: Token 27d62d1f-71c6-4075-95b5-f7aec56d0204" \

--- a/scripts/travis_ci/series_ci.sh
+++ b/scripts/travis_ci/series_ci.sh
@@ -1,10 +1,14 @@
-if [ "$#" -ne 3 ]; then
-    echo "Please provide the Series name, the .ELF file, and SHA as arguments!"
+#!/bin/bash
+
+if [ "$#" -ne 5 ]; then
+    echo "Please provide the Series name, .ELF file, SHA, max RAM size, and max FLASH size as arguments!"
     exit 1
 else
     SERIES_NAME=$1
     ELF=$2
     SHA=$3
+    RAM_MAX_SIZE=$4
+    FLASH_MAX_SIZE=$5
 fi
 
 # Example output of arm-none-eabi-size:
@@ -19,8 +23,18 @@ text="${size_output[0]}"
 data="${size_output[1]}"
 bss="${size_output[2]}"
 
+# Flash memory consists of .text and .data because the initialization values
+# for the initialized static values are stored in flash.
+#
+# Read more: https://interrupt.memfault.com/best-firmware-size-tools
+flash="$(echo "scale=2; 100 * ($text + $data) / $FLASH_MAX_SIZE" | bc)%"
+ram="$(echo "scale=2; 100 * ($data + $bss) / $RAM_MAX_SIZE" | bc)%"
+
+echo $flash
+echo $ram
+
 curl \
   --header "Authorization: Token 27d62d1f-71c6-4075-95b5-f7aec56d0204" \
   --header "Content-Type: application/json" \
-  --data "{\"values\":[{\"value\":\"$text\",\"line\":\"text\"},{\"value\":\"$data\",\"line\":\"data\"},{\"value\":\"$bss\",\"line\":\"bss\"}],\"sha\":\"$SHA\"}" \
+  --data "{\"values\":[{\"value\":\"$ram\",\"line\":\"RAM\"},{\"value\":\"$flash\",\"line\":\"FLASH\"}],\"sha\":\"$SHA\"}" \
   https://seriesci.com/api/UBCFormulaElectric/Consolidated-Firmware/$SERIES_NAME/many

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -22,7 +22,7 @@ if [ "$RUN_ARM_BUILD" = "true" ]; then
     do
         travis_run make --directory=$BUILD_DIR $BOARD.elf
         # Upload the text/data/bss size to SeriesCI. For pull-request builds,
-        # we use ${TRAVIS_PULL_REQUEST_SHA} to get the branch commit SHA. 
+        # we use ${TRAVIS_PULL_REQUEST_SHA} to get the branch commit SHA.
         if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
             # Travis CI Branch build
             SHA=${TRAVIS_COMMIT}

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -22,14 +22,19 @@ if [ "$RUN_ARM_BUILD" = "true" ]; then
     do
         travis_run make --directory=$BUILD_DIR $BOARD.elf
         # Upload the text/data/bss size to SeriesCI. For pull-request builds,
-        # we use ${TRAVIS_PULL_REQUEST_SHA} to get the branch commit SHA.
+        # we use ${TRAVIS_PULL_REQUEST_SHA} to get the branch commit SHA. 
+        SHA=""
         if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
             # Travis CI Branch build
-            travis_run ./scripts/travis_ci/series_ci.sh $BOARD $BUILD_DIR/$BOARD/$BOARD.elf ${TRAVIS_COMMIT}
+            SHA=${TRAVIS_COMMIT}
         else
             # Travis CI Pull Request build
-            travis_run ./scripts/travis_ci/series_ci.sh $BOARD $BUILD_DIR/$BOARD/$BOARD.elf ${TRAVIS_PULL_REQUEST_SHA}
+            SHA=${TRAVIS_PULL_REQUEST_SHA}
         fi
+        # For now, the maximum RAM and FLASH size are the same for every board.
+        MAX_RAM_SIZE=40960 
+        MAX_FLASH_SIZE=262144
+        travis_run ./scripts/travis_ci/series_ci.sh $BOARD $BUILD_DIR/$BOARD/$BOARD.elf $SHA $MAX_RAM_SIZE $MAX_FLASH_SIZE
     done
 fi
 

--- a/scripts/travis_ci/travis_script.sh
+++ b/scripts/travis_ci/travis_script.sh
@@ -23,7 +23,6 @@ if [ "$RUN_ARM_BUILD" = "true" ]; then
         travis_run make --directory=$BUILD_DIR $BOARD.elf
         # Upload the text/data/bss size to SeriesCI. For pull-request builds,
         # we use ${TRAVIS_PULL_REQUEST_SHA} to get the branch commit SHA. 
-        SHA=""
         if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
             # Travis CI Branch build
             SHA=${TRAVIS_COMMIT}


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Raw bss, data, text didn't show up nicely on the SeriesCI plots because their order of magnitude can be quite different. Simplified the information by tracking everything as a normalized percetange. Also started tracking RAM and FLASH instead of bss, data, and text.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
