### PR TITLE
Remove alloc_index from Io code with malloc

### DIFF
--- a/boards/BMS/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
+++ b/boards/BMS/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/boards/BMS/Inc/Io/Io_SharedPwmInputConfig.h
+++ b/boards/BMS/Inc/Io/Io_SharedPwmInputConfig.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define MAX_NUM_OF_PWM_INPUTS 5

--- a/boards/DCM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
+++ b/boards/DCM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/boards/DCM/Inc/Io/Io_SharedPwmInputConfig.h
+++ b/boards/DCM/Inc/Io/Io_SharedPwmInputConfig.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define MAX_NUM_OF_PWM_INPUTS 5

--- a/boards/DIM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
+++ b/boards/DIM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/boards/DIM/Inc/Io/Io_SharedPwmInputConfig.h
+++ b/boards/DIM/Inc/Io/Io_SharedPwmInputConfig.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define MAX_NUM_OF_PWM_INPUTS 1

--- a/boards/FSM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
+++ b/boards/FSM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define MAX_NUM_OF_FREQ_ONLY_PWM_INPUTS 2

--- a/boards/FSM/Inc/Io/Io_SharedPwmInputConfig.h
+++ b/boards/FSM/Inc/Io/Io_SharedPwmInputConfig.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define MAX_NUM_OF_PWM_INPUTS 2

--- a/boards/PDM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
+++ b/boards/PDM/Inc/Io/Io_SharedFreqOnlyPwmInputConfig.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/boards/PDM/Inc/Io/Io_SharedPwmInputConfig.h
+++ b/boards/PDM/Inc/Io/Io_SharedPwmInputConfig.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define MAX_NUM_OF_PWM_INPUTS 5

--- a/boards/shared/Inc/Io/Io_SharedFreqOnlyPwmInput.h
+++ b/boards/shared/Inc/Io/Io_SharedFreqOnlyPwmInput.h
@@ -1,9 +1,4 @@
 #pragma once
-#include "Io_SharedFreqOnlyPwmInputConfig.h"
-
-#ifndef MAX_NUM_OF_FREQ_ONLY_PWM_INPUTS
-#define MAX_NUM_OF_FREQ_ONLY_PWM_INPUTS 1
-#endif
 
 struct FreqOnlyPwmInput;
 

--- a/boards/shared/Inc/Io/Io_SharedPwmInput.h
+++ b/boards/shared/Inc/Io/Io_SharedPwmInput.h
@@ -2,15 +2,6 @@
 
 #include <stm32f3xx_hal.h>
 
-// Application specific configuration options.
-#include "Io_SharedPwmInputConfig.h"
-
-// Check all the required application specific macros have been defined in
-// <Io_SharedPwmInputConfig.h>.
-#ifndef MAX_NUM_OF_PWM_INPUTS
-#error Missing definition: MAX_NUM_OF_PWM_INPUTS must be defined in Io_SharedPwmInputConfig.h.
-#endif
-
 struct PwmInput;
 
 /**

--- a/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
@@ -49,6 +49,7 @@ struct FreqOnlyPwmInput *Io_SharedFreqOnlyPwmInput_Create(
 
     struct FreqOnlyPwmInput *const pwm_input =
         (struct FreqOnlyPwmInput *)malloc(sizeof(struct FreqOnlyPwmInput));
+    assert(pwm_input != NULL);
 
     pwm_input->frequency_hz        = NAN;
     pwm_input->htim                = htim;

--- a/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
@@ -48,7 +48,7 @@ struct FreqOnlyPwmInput *Io_SharedFreqOnlyPwmInput_Create(
     assert(htim != NULL);
 
     struct FreqOnlyPwmInput *const pwm_input =
-        (struct FreqOnlyPwmInput *)malloc(sizeof(struct FreqOnlyPwmInput));
+        malloc(sizeof(struct FreqOnlyPwmInput));
     assert(pwm_input != NULL);
 
     pwm_input->frequency_hz        = NAN;

--- a/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stm32f3xx_hal.h>
 #include <stdbool.h>
-#include "Io_SharedFreqOnlyPwmInput.h"
+#include <stdlib.h>
 
 struct FreqOnlyPwmInput
 {
@@ -46,12 +46,9 @@ struct FreqOnlyPwmInput *Io_SharedFreqOnlyPwmInput_Create(
     HAL_TIM_ActiveChannel tim_active_channel)
 {
     assert(htim != NULL);
-    static struct FreqOnlyPwmInput pwm_inputs[MAX_NUM_OF_FREQ_ONLY_PWM_INPUTS];
-    static size_t                  alloc_index = 0;
 
-    assert(alloc_index < MAX_NUM_OF_FREQ_ONLY_PWM_INPUTS);
-
-    struct FreqOnlyPwmInput *const pwm_input = &pwm_inputs[alloc_index++];
+    struct FreqOnlyPwmInput *const pwm_input =
+        (struct FreqOnlyPwmInput *)malloc(sizeof(struct FreqOnlyPwmInput));
 
     pwm_input->frequency_hz        = NAN;
     pwm_input->htim                = htim;

--- a/boards/shared/Src/Io/Io_SharedPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedPwmInput.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdlib.h>
 #include "Io_SharedPwmInput.h"
 
 struct PwmInput
@@ -51,12 +52,8 @@ struct PwmInput *Io_SharedPwmInput_Create(
 {
     assert(htim != NULL);
 
-    static struct PwmInput pwm_inputs[MAX_NUM_OF_PWM_INPUTS];
-    static size_t          alloc_index = 0;
-
-    assert(alloc_index < MAX_NUM_OF_PWM_INPUTS);
-
-    struct PwmInput *const pwm_input = &pwm_inputs[alloc_index++];
+    struct PwmInput *const pwm_input =
+        (struct PwmInput *)malloc(sizeof(struct PwmInput));
 
     pwm_input->htim                     = htim;
     pwm_input->timer_frequency_hz       = timer_frequency_hz;

--- a/boards/shared/Src/Io/Io_SharedPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedPwmInput.c
@@ -54,6 +54,7 @@ struct PwmInput *Io_SharedPwmInput_Create(
 
     struct PwmInput *const pwm_input =
         (struct PwmInput *)malloc(sizeof(struct PwmInput));
+    assert(pwm_input != NULL);
 
     pwm_input->htim                     = htim;
     pwm_input->timer_frequency_hz       = timer_frequency_hz;

--- a/boards/shared/Src/Io/Io_SharedPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedPwmInput.c
@@ -52,8 +52,7 @@ struct PwmInput *Io_SharedPwmInput_Create(
 {
     assert(htim != NULL);
 
-    struct PwmInput *const pwm_input =
-        (struct PwmInput *)malloc(sizeof(struct PwmInput));
+    struct PwmInput *const pwm_input = malloc(sizeof(struct PwmInput));
     assert(pwm_input != NULL);
 
     pwm_input->htim                     = htim;


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
After discussing with @thekenu we have decided to use malloc in `Io_x_Create` functions instead of statically allocating memory with `alloc_index` (not including `Io_SharedSoftwareWatchdog`)

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
 - Changed from static memory allocation to malloc in `Io_SharedPwmInput_Create.c` and `Io_FreqOnlySharedPwmInput.c`
- Removed `Io_SharedPwmInputConfig.h` and `Io_SharedFreqOnlyPwmInputConfig.h` for all boards.

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
