### PR TITLE
Changed the inactive pwm input frequency from NaN to 0.0 Hz

### DIFF
--- a/boards/shared/Inc/Io/Io_SharedFreqOnlyPwmInput.h
+++ b/boards/shared/Inc/Io/Io_SharedFreqOnlyPwmInput.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stm32f3xx_hal.h>
+
 struct FreqOnlyPwmInput;
 
 /**
@@ -47,14 +49,13 @@ HAL_TIM_ActiveChannel Io_SharedFreqOnlyPwmInput_GetTimerActiveChannel(
 
 /**
  * Update the frequency for the given PWM input
- *
  * @param pwm_input: The PWM input to update for
  */
 void Io_SharedFreqOnlyPwmInput_Tick(struct FreqOnlyPwmInput *pwm_input);
 
 /**
- * Check if the given PWM signal is active. If it is inactive (i.e. It has been
- * unplugged or unpowered), set the frequency to NaN.
+ * Check if the given PWM signal is active. If the sensor detects a DC signal
+ * set the frequency to 0Hz.
  * @note This function should be called in the timer overflow interrupt
  *       for the PWM signal
  * @param pwm_input: The PWM input to check for

--- a/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
@@ -1,8 +1,8 @@
 #include <math.h>
 #include <assert.h>
-#include <stm32f3xx_hal.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include "Io_SharedFreqOnlyPwmInput.h"
 
 struct FreqOnlyPwmInput
 {
@@ -33,7 +33,7 @@ static void Io_SetFrequency(
     struct FreqOnlyPwmInput *const pwm_input,
     const float                    frequency_hz)
 {
-    assert(frequency_hz >= 0.0f || isnanf(frequency_hz));
+    assert(frequency_hz >= 0.0f);
 
     pwm_input->frequency_hz = frequency_hz;
 }
@@ -51,7 +51,7 @@ struct FreqOnlyPwmInput *Io_SharedFreqOnlyPwmInput_Create(
         malloc(sizeof(struct FreqOnlyPwmInput));
     assert(pwm_input != NULL);
 
-    pwm_input->frequency_hz        = NAN;
+    pwm_input->frequency_hz        = 0.0f;
     pwm_input->htim                = htim;
     pwm_input->tim_frequency_hz    = tim_frequency_hz;
     pwm_input->tim_channel         = tim_channel;
@@ -133,7 +133,7 @@ void Io_SharedFreqOnlyPwmInput_Tick(struct FreqOnlyPwmInput *const pwm_input)
             // measured is too low), or either when a tick arrives before the
             // counter can upcount (i.e. The PWM frequency being measured is
             // too high)
-            Io_SetFrequency(pwm_input, NAN);
+            Io_SetFrequency(pwm_input, 0.0f);
         }
     }
 }
@@ -142,9 +142,9 @@ void Io_SharedFreqOnlyPwmInput_CheckIfPwmIsActive(
     struct FreqOnlyPwmInput *const pwm_input)
 {
     // If the timer overflows twice without a rising edge, the PWM signal is
-    // likely inactive and its frequency can't be computed
+    // likely inactive (DC signal) and its frequency can't be computed
     if (++pwm_input->tim_overflow_count == 2U)
     {
-        Io_SetFrequency(pwm_input, NAN);
+        Io_SetFrequency(pwm_input, 0.0f);
     }
 }

--- a/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
@@ -1,4 +1,3 @@
-#include <math.h>
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
+++ b/boards/shared/Src/Io/Io_SharedFreqOnlyPwmInput.c
@@ -142,7 +142,7 @@ void Io_SharedFreqOnlyPwmInput_CheckIfPwmIsActive(
     struct FreqOnlyPwmInput *const pwm_input)
 {
     // If the timer overflows twice without a rising edge, the PWM signal is
-    // likely inactive (DC signal) and its frequency can't be computed
+    // likely inactive (i.e. DC signal) and its frequency can't be computed
     if (++pwm_input->tim_overflow_count == 2U)
     {
         Io_SetFrequency(pwm_input, 0.0f);


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Ken and I decided to change the frequency to 0.0Hz when we detect an inactive input. This is because the sensor is most likely inactive when it detects a DC signal, instead of it being unplugged or unpowered. 

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
- Replace code which set the frequency for an inactive pwm input channel to NaN with 0.0Hz


### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
