### PR TITLE
Add voting algorithm for SoCs

### DIFF
--- a/boards/BMS/Inc/App/App_Soc.h
+++ b/boards/BMS/Inc/App/App_Soc.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "App_SharedExitCode.h"
+
+/**
+ * Given three state-of-charge (SoCs), check whether the difference between any
+ * two SoCs is less than or equal to the specified threshold. If any two SoCs
+ * pass the check, return the average value of those two SoCs.
+ * @param max_difference The maximum tolerable difference between any two given
+ *                       state-of-charge values
+ * @param soc_1 The first SoC
+ * @param soc_2 The second SoC
+ * @param soc_3 The third SoC
+ * @param result The average value of two SoCs whose difference is less than or
+ *               equal to max_value, else NaN. In the event of a tiebreak (i.e.
+ *               All three SoCs pass the check), th first two SoCs are used to
+ *               calculate the average value.
+ * @return EXIT_CODE_INVALID_ARGS if the max difference or any of the SoCs is
+ *                                less than 0 or greater than 100
+ */
+ExitCode App_Soc_Vote(
+    float  max_difference,
+    float  soc_1,
+    float  soc_2,
+    float  soc_3,
+    float *result);

--- a/boards/BMS/Inc/App/App_Soc.h
+++ b/boards/BMS/Inc/App/App_Soc.h
@@ -3,23 +3,43 @@
 #include "App_SharedExitCode.h"
 
 /**
- * Given three state-of-charge (SoCs), check whether the difference between any
- * two SoCs is less than or equal to the specified threshold. If any two SoCs
- * pass the check, return the average value of those two SoCs.
- * @param max_difference The maximum tolerable difference between any two given
- *                       state-of-charge values
- * @param soc_1 The first SoC
- * @param soc_2 The second SoC
- * @param soc_3 The third SoC
- * @param result The average value of two SoCs whose difference is less than or
- *               equal to max_value, else NaN. In the event of a tiebreak (i.e.
- *               All three SoCs pass the check), th first two SoCs are used to
- *               calculate the average value.
- * @return EXIT_CODE_INVALID_ARGS if the max difference or any of the SoCs is
- *                                less than 0 or greater than 100
+ * Given three state-of-charge (SoCs), check whether the absolute difference
+ * between any two SoCs is less than or equal to the specified maximum absolute
+ * difference. If any two SoCs pass the check, return the average value of those
+ * two SoCs.
+ * @param max_abs_difference The maximum allowable absolute difference between
+ *                           any two given SoCs, must be between 0 and 100
+ *                           inclusive
+ * @param soc_1 The first SoC, must be between 0 and 100 inclusive
+ * @param soc_2 The second SoC, must be between 0 and 100 inclusive
+ * @param soc_3 The third SoC, must be between 0 and 100 inclusive
+ * @param result This will be set to the average value of the two SoCs whose
+ *               difference is less than or equal to max_difference. Multiple
+ *               SoC pairs may have their difference less than or equal to
+ *               max_difference. In this scenario, we prioritize as follows:
+ *
+ *               Highest Priority: soc_1 / soc_2
+ *                                 soc_2 / soc_3
+ *               Lowest Priority:  soc_1 / soc_3
+ *
+ *               If no two suitable SoCs can be found, this will be set to NaN.
+ * @note An example of a tiebreaker:
+ *
+ *         max_difference = 5
+ *         soc_1 = 0
+ *         soc_2 = 50
+ *         soc_3 = 100
+ *
+ *       In this scenario, the difference between soc_1 and soc_2 is the same as
+ *       the difference between soc_2 and soc_3, but we prioritize soc_1 / soc_2
+ *       ovr soc_2 / soc_3. Thus, the average value to calculate,
+ *
+ *       (soc_1 + soc_2) / 2 = 25
+ * @return EXIT_CODE_INVALID_ARGS if max_difference, soc_1, soc_2, or soc_3 is
+ *                                not between 0 and 100 inclusive
  */
 ExitCode App_Soc_Vote(
-    float  max_difference,
+    float  max_abs_difference,
     float  soc_1,
     float  soc_2,
     float  soc_3,

--- a/boards/BMS/Inc/App/App_Soc.h
+++ b/boards/BMS/Inc/App/App_Soc.h
@@ -32,9 +32,7 @@
  *
  *       In this scenario, the difference between soc_1 and soc_2 is the same as
  *       the difference between soc_2 and soc_3, but we prioritize soc_1 / soc_2
- *       ovr soc_2 / soc_3. Thus, the average value to calculate,
- *
- *       (soc_1 + soc_2) / 2 = 25
+ *       over soc_2 / soc_3. Thus, result is set to  (soc_1 + soc_2) / 2 = 25.
  * @return EXIT_CODE_INVALID_ARGS if max_difference, soc_1, soc_2, or soc_3 is
  *                                not between 0 and 100 inclusive
  */

--- a/boards/BMS/Src/App/App_Soc.c
+++ b/boards/BMS/Src/App/App_Soc.c
@@ -2,42 +2,37 @@
 #include "App_Soc.h"
 
 ExitCode App_Soc_Vote(
-    float  max_difference,
+    float  max_abs_difference,
     float  soc_1,
     float  soc_2,
     float  soc_3,
     float *result)
 {
-    if (max_difference < 0.0f || max_difference > 100.0f)
+    if (max_abs_difference < 0.0f || max_abs_difference > 100.0f ||
+        soc_1 < 0.0f || soc_1 > 100.0f || soc_2 < 0.0f || soc_2 > 100.0f ||
+        soc_3 < 0.0f || soc_3 > 100.0f)
+    {
         return EXIT_CODE_INVALID_ARGS;
-
-    if (soc_1 < 0.0f || soc_1 > 100.0f)
-        return EXIT_CODE_INVALID_ARGS;
-
-    if (soc_2 < 0.0f || soc_2 > 100.0f)
-        return EXIT_CODE_INVALID_ARGS;
-
-    if (soc_3 < 0.0f || soc_3 > 100.0f)
-        return EXIT_CODE_INVALID_ARGS;
+    }
 
     float diff = 0.0f;
 
     diff = fabsf(soc_1 - soc_2);
-    if (diff <= max_difference)
+    if (diff <= max_abs_difference)
     {
         *result = (soc_1 + soc_2) / 2.0f;
         return EXIT_CODE_OK;
     }
 
     diff = fabsf(soc_2 - soc_3);
-    if (diff <= max_difference)
+    if (diff <= max_abs_difference)
     {
         *result = (soc_2 + soc_3) / 2.0f;
         return EXIT_CODE_OK;
     }
 
     diff = fabsf(soc_1 - soc_3);
-    if (diff <= max_difference)
+    if (diff <= max_abs_difference)
     {
         *result = (soc_1 + soc_3) / 2.0f;
         return EXIT_CODE_OK;

--- a/boards/BMS/Src/App/App_Soc.c
+++ b/boards/BMS/Src/App/App_Soc.c
@@ -1,0 +1,48 @@
+#include <math.h>
+#include "App_Soc.h"
+
+ExitCode App_Soc_Vote(
+    float  max_difference,
+    float  soc_1,
+    float  soc_2,
+    float  soc_3,
+    float *result)
+{
+    if (max_difference < 0.0f || max_difference > 100.0f)
+        return EXIT_CODE_INVALID_ARGS;
+
+    if (soc_1 < 0.0f || soc_1 > 100.0f)
+        return EXIT_CODE_INVALID_ARGS;
+
+    if (soc_2 < 0.0f || soc_2 > 100.0f)
+        return EXIT_CODE_INVALID_ARGS;
+
+    if (soc_3 < 0.0f || soc_3 > 100.0f)
+        return EXIT_CODE_INVALID_ARGS;
+
+    float diff = 0.0f;
+
+    diff = fabsf(soc_1 - soc_2);
+    if (diff <= max_difference)
+    {
+        *result = (soc_1 + soc_2) / 2.0f;
+        return EXIT_CODE_OK;
+    }
+
+    diff = fabsf(soc_2 - soc_3);
+    if (diff <= max_difference)
+    {
+        *result = (soc_2 + soc_3) / 2.0f;
+        return EXIT_CODE_OK;
+    }
+
+    diff = fabsf(soc_1 - soc_3);
+    if (diff <= max_difference)
+    {
+        *result = (soc_1 + soc_3) / 2.0f;
+        return EXIT_CODE_OK;
+    }
+
+    *result = NAN;
+    return EXIT_CODE_OK;
+}

--- a/boards/BMS/Test/Src/Test_SocVoting.cpp
+++ b/boards/BMS/Test/Src/Test_SocVoting.cpp
@@ -1,0 +1,123 @@
+#include <math.h>
+#include "Test_Bms.h"
+
+extern "C"
+{
+#include "App_Soc.h"
+}
+
+class SocVotingTest : public testing::Test
+{
+  protected:
+    float       result;
+    const float TEST_VALUE          = 0.5f;
+    const float TEST_MAX_DIFFERENCE = 1.0f;
+    const float UNDERFLOW_SOC =
+        std::nextafter(0.0f, std::numeric_limits<float>::lowest());
+    const float OVERFLOW_SOC =
+        std::nextafter(100.0f, std::numeric_limits<float>::max());
+};
+
+TEST_F(SocVotingTest, max_difference_underflow)
+{
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(UNDERFLOW_SOC, 0.0f, 0.0f, 0.0f, &result));
+}
+
+TEST_F(SocVotingTest, one_number_underflow)
+{
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, UNDERFLOW_SOC, 0.0f, 0.0f, &result));
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, 0.0f, UNDERFLOW_SOC, 0.0f, &result));
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, 0.0f, 0.0f, UNDERFLOW_SOC, &result));
+}
+
+TEST_F(SocVotingTest, one_number_overflow)
+{
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, OVERFLOW_SOC, 0.0f, 0.0f, &result));
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, 0.0f, OVERFLOW_SOC, 0.0f, &result));
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, 0.0f, 0.0f, OVERFLOW_SOC, &result));
+}
+
+TEST_F(SocVotingTest, two_numbers_underflow)
+{
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, UNDERFLOW_SOC, UNDERFLOW_SOC, 0.0f, &result));
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, 0.0f, UNDERFLOW_SOC, UNDERFLOW_SOC, &result));
+}
+
+TEST_F(SocVotingTest, two_numbers_overflow)
+{
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, OVERFLOW_SOC, OVERFLOW_SOC, 0.0f, &result));
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, 0.0f, OVERFLOW_SOC, OVERFLOW_SOC, &result));
+}
+
+TEST_F(SocVotingTest, three_numbers_underflow)
+{
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(
+            0.0f, UNDERFLOW_SOC, UNDERFLOW_SOC, UNDERFLOW_SOC, &result));
+}
+
+TEST_F(SocVotingTest, three_numbers_overflow)
+{
+    ASSERT_EQ(
+        EXIT_CODE_INVALID_ARGS,
+        App_Soc_Vote(0.0f, OVERFLOW_SOC, OVERFLOW_SOC, OVERFLOW_SOC, &result));
+}
+
+TEST_F(SocVotingTest, three_identical_numbers)
+{
+    ASSERT_EQ(
+        EXIT_CODE_OK,
+        App_Soc_Vote(0.0f, TEST_VALUE, TEST_VALUE, TEST_VALUE, &result));
+    ASSERT_EQ(TEST_VALUE, result);
+}
+
+TEST_F(SocVotingTest, difference_is_smaller_than_max_difference)
+{
+    ASSERT_EQ(
+        EXIT_CODE_OK,
+        App_Soc_Vote(
+            std::nextafter(TEST_VALUE, std::numeric_limits<float>::max()), 0.0f,
+            TEST_VALUE, 2 * TEST_VALUE, &result));
+    ASSERT_EQ(TEST_VALUE / 2.0f, result);
+}
+
+TEST_F(SocVotingTest, difference_is_equal_to_max_difference)
+{
+    ASSERT_EQ(
+        EXIT_CODE_OK,
+        App_Soc_Vote(TEST_VALUE, 0.0f, TEST_VALUE, 2 * TEST_VALUE, &result));
+    ASSERT_EQ(TEST_VALUE / 2.0f, result);
+}
+
+TEST_F(SocVotingTest, difference_is_larger_than_max_difference)
+{
+    ASSERT_EQ(
+        EXIT_CODE_OK,
+        App_Soc_Vote(
+            std::nextafter(TEST_VALUE, std::numeric_limits<float>::lowest()),
+            0.0f, TEST_VALUE, 2 * TEST_VALUE, &result));
+    ASSERT_TRUE(isnanf(result));
+}


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The SoC is stored in EEPROM which can get corrupted. As a workaround, the same SoC value is stored in 3 separate EEPROM locations. If one EEPROM value is corrupted (e.g. due to power failure), the other two may still be valid.

```
t = 0
SoC 1 = 1.0% 
SoC 2 = 1.0% 
SoC 3 = 1.0% 

t = 1 // Power failure prevents 1.5% to be written on SoC 2 and 3
SoC 1 = 1.5% 
SoC 2 = 1.0% 
SoC 3 = 1.0% 
```
There are many other ways that data can get corrupted. To be as safe as possible, we look for the two values out of the three that are the closest.
 
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
Wrote unit tests

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
