### PR TITLE
Disable RGB LED sequence on DIM

### DIFF
--- a/boards/BMS/Src/Io/Io_RgbLedSequence.c
+++ b/boards/BMS/Src/Io/Io_RgbLedSequence.c
@@ -3,21 +3,24 @@
 
 void Io_RgbLedSequence_TurnOnRedLed(void)
 {
-    HAL_GPIO_WritePin(STATUS_R_GPIO_Port, STATUS_R_Pin, GPIO_PIN_RESET);
-    HAL_GPIO_WritePin(STATUS_G_GPIO_Port, STATUS_G_Pin, GPIO_PIN_SET);
-    HAL_GPIO_WritePin(STATUS_B_GPIO_Port, STATUS_B_Pin, GPIO_PIN_SET);
+    // TODO: DIM-2019 uses the same net for RGB LED and DIM LED, which means
+    // only one of them can be used a time. We will prioritize DIM LED for now
+    // and this function shall be left blank until the next DIM revision uses
+    // different bet for RGB LED and DIM LED.
 }
 
 void Io_RgbLedSequence_TurnOnGreenLed(void)
 {
-    HAL_GPIO_WritePin(STATUS_R_GPIO_Port, STATUS_R_Pin, GPIO_PIN_SET);
-    HAL_GPIO_WritePin(STATUS_G_GPIO_Port, STATUS_G_Pin, GPIO_PIN_RESET);
-    HAL_GPIO_WritePin(STATUS_B_GPIO_Port, STATUS_B_Pin, GPIO_PIN_SET);
+    // TODO: DIM-2019 uses the same net for RGB LED and DIM LED, which means
+    // only one of them can be used a time. We will prioritize DIM LED for now
+    // and this function shall be left blank until the next DIM revision uses
+    // different bet for RGB LED and DIM LED.
 }
 
 void Io_RgbLedSequence_TurnOnBlueLed(void)
 {
-    HAL_GPIO_WritePin(STATUS_R_GPIO_Port, STATUS_R_Pin, GPIO_PIN_SET);
-    HAL_GPIO_WritePin(STATUS_G_GPIO_Port, STATUS_G_Pin, GPIO_PIN_SET);
-    HAL_GPIO_WritePin(STATUS_B_GPIO_Port, STATUS_B_Pin, GPIO_PIN_RESET);
+    // TODO: DIM-2019 uses the same net for RGB LED and DIM LED, which means
+    // only one of them can be used a time. We will prioritize DIM LED for now
+    // and this function shall be left blank until the next DIM revision uses
+    // different bet for RGB LED and DIM LED.
 }


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The current DIM hardware wired up the RGB LED and DIM LED together, which means we can only control one of them at a time and the other must be disabled. Decided to disable RGB LED in favor of DIM LED.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
