### PR TITLE
Fix path for .map files

### DIFF
--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -187,8 +187,6 @@ function(create_arm_binary
             -fstack-usage
             -Wconversion
         )
-
-
     target_link_options(${BOARD_NAME}.elf
         PUBLIC
             ${FPU_FLAGS}

--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -187,10 +187,12 @@ function(create_arm_binary
             -fstack-usage
             -Wconversion
         )
+
+
     target_link_options(${BOARD_NAME}.elf
         PUBLIC
             ${FPU_FLAGS}
-            -Wl,-Map=${PROJECT_BINARY_DIR}/${BOARD_NAME}.map
+            -Wl,-Map=${CMAKE_CURRENT_BINARY_DIR}/${BOARD_NAME}.map
             -Wl,-gc-sections,--print-memory-usage
             -Wl,-T ${ARM_LINKER_SCRIPT}
             --specs=nano.specs


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
The build folder currently looks like
```
cmake-build-embedded
    - FSM
        - FSM.elf
        - FSM hex
    - FSM.map
```
This PR changes it to   
```
cmake-build-embedded
    - FSM
        - FSM.elf
        - FSM hex
        - FSM.map
```

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
