### PR TITLE
Add Io code to read internal die temperatures

### DIFF
--- a/boards/BMS/Inc/App/configs/App_CellConfigs.h
+++ b/boards/BMS/Inc/App/configs/App_CellConfigs.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "assert.h"
+
+enum CellMonitorICs
+{
+    CELL_MONITOR_IC_0,
+    CELL_MONITOR_IC_1,
+    NUM_OF_CELL_MONITOR_ICS
+};
+
+#define NUM_OF_CELLS_READ_PER_IC 16U

--- a/boards/BMS/Inc/Io/Io_CellVoltages.h
+++ b/boards/BMS/Inc/Io/Io_CellVoltages.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+#include "App_SharedExitCode.h"
+
+/**
+ * Read cell voltages (100µV) from the cell monitoring chips.
+ * @return EXIT_CODE_OK if cell voltages were acquired successfully from all
+ * cell monitoring chips. Else, EXIT_CODE_ERROR.
+ */
+ExitCode Io_CellVoltages_ReadCellVoltages(void);
+
+/**
+ * Get the pointer to the 2D array containing converted cell voltages (100µV)
+ * read from the cell monitoring chips.
+ * @note Call Io_CellVoltages_ReadCellVoltages to get the most recent cell
+ * voltages from the cell monitoring chips before calling this function.
+ * @note The first subscript value of the 2D array is the number of cell
+ * monitoring devices on the daisy chain. The second subscript value is the
+ * number of cell voltages that are monitored per cell monitoring chip.
+ * @note Divide the cell voltages by 1e4 to convert to V.
+ *
+ * @return A pointer to the 2D array containing converted converted cell
+ * voltages (100µV).
+ */
+uint16_t *Io_CellVoltages_GetCellVoltages(void);

--- a/boards/BMS/Inc/Io/Io_CellVoltages.h
+++ b/boards/BMS/Inc/Io/Io_CellVoltages.h
@@ -5,15 +5,15 @@
 #include "App_SharedExitCode.h"
 
 /**
- * Read cell voltages (100µV) from the cell monitoring chips.
- * @return EXIT_CODE_OK if cell voltages were acquired successfully from all
- * cell monitoring chips. Else, EXIT_CODE_ERROR.
+ * Read cell voltages from the cell monitoring chips.
+ * @return EXIT_CODE_OK if cell voltages (100µV) were acquired successfully from
+ * all cell monitoring chips. Else, EXIT_CODE_ERROR.
  */
 ExitCode Io_CellVoltages_ReadCellVoltages(void);
 
 /**
- * Get the pointer to the 2D array containing converted cell voltages (100µV)
- * read from the cell monitoring chips.
+ * Get the pointer to the 2D array containing cell voltages read from the cell
+ * monitoring chips.
  * @note Call Io_CellVoltages_ReadCellVoltages to get the most recent cell
  * voltages from the cell monitoring chips before calling this function.
  * @note The first subscript value of the 2D array is the number of cell

--- a/boards/BMS/Inc/Io/Io_CellVoltages.h
+++ b/boards/BMS/Inc/Io/Io_CellVoltages.h
@@ -19,8 +19,7 @@ ExitCode Io_CellVoltages_ReadCellVoltages(void);
  * @note The first subscript value of the 2D array is the number of cell
  * monitoring devices on the daisy chain. The second subscript value is the
  * number of cell voltages that are monitored per cell monitoring chip.
- * @note Divide the cell voltages by 1e4 to convert to V.
- *
+ * @note Divide the cell voltages by 10000 to convert to V.
  * @return A pointer to the 2D array containing converted converted cell
  * voltages (100µV).
  */

--- a/boards/BMS/Inc/Io/Io_CellVoltages.h
+++ b/boards/BMS/Inc/Io/Io_CellVoltages.h
@@ -16,10 +16,9 @@ ExitCode Io_CellVoltages_ReadCellVoltages(void);
  * monitoring chips.
  * @note Call Io_CellVoltages_ReadCellVoltages to get the most recent cell
  * voltages from the cell monitoring chips before calling this function.
- * @note The first subscript value of the 2D array is the number of cell
- * monitoring devices on the daisy chain. The second subscript value is the
- * number of cell voltages that are monitored per cell monitoring chip.
- * @note Divide the cell voltages by 10000 to convert to V.
+ * @note The row of the 2D array is equal to the number of cell monitoring
+ * devices on the daisy chain. The column of the 2D array is equal to the number
+ * of cell voltages that are monitored per cell monitoring chip.
  * @return A pointer to the 2D array containing converted converted cell
  * voltages (100µV).
  */

--- a/boards/BMS/Inc/Io/Io_LTC6813.h
+++ b/boards/BMS/Inc/Io/Io_LTC6813.h
@@ -21,7 +21,7 @@ void Io_LTC6813_Init(
  * @param size The number of data elements used to calculate the PEC15 code
  * @note The size can be a positive integer less than or equal to the size
  * of the data buffer.
- * @return The calculated PEC15 code
+ * @return The calculated PEC15 code for the given data buffer.
  */
 uint16_t Io_LTC6813_CalculatePec15(uint8_t *data_buffer, uint32_t size);
 
@@ -48,15 +48,15 @@ ExitCode Io_LTC6813_StartCellVoltageConversions(void);
 ExitCode Io_LTC6813_StartInternalDeviceConversions(void);
 
 /**
- * Wait for the completion of all ADC conversions on the LTC6813 in the daisy
- * chain.
- * @return EXIT_CODE_OK if all ADC conversions on the LTC6813 chips on the daisy
- * chain have completed successfully. Else, EXIT_CODE_TIMEOUT.
+ * Wait for the completion of all ADC conversions for the LTC6813 chips on the
+ * daisy chain.
+ * @return EXIT_CODE_OK if all ADC conversions have completed successfully.
+ * Else, EXIT_CODE_TIMEOUT.
  */
 ExitCode Io_LTC6813_PollConversions(void);
 
 /**
- * Configure register A for all chips on the LTC6813 daisy chain.
+ * Configure register A for all LTC6813 chips on the LTC6813 daisy chain.
  * @return EXIT_CODE_OK if all chips on the daisy chain are configured
  * successfully. Else, EXIT_CODE_ERROR.
  */

--- a/boards/BMS/Inc/Io/Io_LTC6813.h
+++ b/boards/BMS/Inc/Io/Io_LTC6813.h
@@ -3,6 +3,17 @@
 #include <stm32f3xx_hal.h>
 #include "App_SharedExitCode.h"
 
+enum CellVoltageRegisterGroups
+{
+    CELL_VOLTAGE_REGISTER_GROUP_A,
+    CELL_VOLTAGE_REGISTER_GROUP_B,
+    CELL_VOLTAGE_REGISTER_GROUP_C,
+    CELL_VOLTAGE_REGISTER_GROUP_D,
+    CELL_VOLTAGE_REGISTER_GROUP_E,
+    CELL_VOLTAGE_REGISTER_GROUP_F,
+    NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS
+};
+
 /**
  * Initialize all chips on the LTC6813 daisy chain.
  * @param spi_handle The given SPI handle for the LTC6813 daisy chain.
@@ -15,33 +26,55 @@ void Io_LTC6813_Init(
     uint16_t           nss_pin);
 
 /**
- * Configure all chips on the LTC6813 daisy chain.
+ * Calculate the 15-bit packet error code (PEC15) for the given data buffer.
+ * @param data_buffer A pointer to the buffer containing data used to calculate
+ * the PEC15 code.
+ * @param size The number of data elements used to calculate the PEC15 code
+ * @note The size can be a positive integer less than or equal to the size
+ * of the data buffer.
+ * @return The calculated PEC15 code
+ */
+uint16_t Io_LTC6813_CalculatePec15(uint8_t *data_buffer, uint32_t size);
+
+/**
+ * Transition all LTC6813 chips on the daisy chain from the IDLE state to the
+ * READY state.
+ * @return EXIT_CODE_OK if the SCK and NSS pin can be toggled successfully.
+ * Else, EXIT_CODE_ERROR.
+ */
+ExitCode Io_LTC6813_EnterReadyState(void);
+
+/**
+ * Start cell voltage conversions for all LTC6813 chips on the daisy chain.
+ * @return EXIT_CODE_OK if the command to start cell voltage conversions is sent
+ * successfully. Else, EXIT_CODE_ERROR.
+ */
+ExitCode Io_LTC6813_StartCellVoltageConversions(void);
+
+/**
+ * Start internal device conversions for all LTC6813 chips on the daisy chain.
+ * @return EXIT_CODE_OK if the command to start internal device conversions is
+ * sent successfully. Else, EXIT_CODE_ERROR.
+ */
+ExitCode Io_LTC6813_StartInternalDeviceConversions(void);
+
+/**
+ * Wait for the completion of all ADC conversions on the LTC6813 in the daisy
+ * chain.
+ * @return EXIT_CODE_OK if all ADC conversions on the LTC6813 chips on the daisy
+ * chain have completed successfully. Else, EXIT_CODE_TIMEOUT.
+ */
+ExitCode Io_LTC6813_PollConversions(void);
+
+/**
+ * Configure register A for all chips on the LTC6813 daisy chain.
  * @return EXIT_CODE_OK if all chips on the daisy chain are configured
- * successfully. Else, return EXIT_CODE_TIMEOUT if the data cannot be
- * transmitted to the chips on the LTC6813 daisy chain.
+ * successfully. Else, EXIT_CODE_ERROR.
  */
-ExitCode Io_LTC6813_Configure(void);
+ExitCode Io_LTC6813_ConfigureRegisterA(void);
 
 /**
- * Read all cell register groups for each chip on the LTC6813 daisy chain.
- * @return If data cannot be transmitted to or received from the chips on the
- * LTC6813 daisy chain, return EXIT_CODE_TIMEOUT. Else if PEC15 mismatches
- * are detected, return EXIT_CODE_ERROR. Else, return EXIT_CODE_OK.
+ * Get the SPI interface configured for the LTC6813 daisy chain.
+ * @return The SPI interface configured for the LTC6813 daisy chain.
  */
-ExitCode Io_LTC6813_ReadAllCellRegisterGroups(void);
-
-/**
- * Get the pointer to the 2D array containing converted cell voltages for
- * each chip on the daisy chain.
- *
- * @note The 2D array has its first subscript value as NUM_OF_LTC6813 (the total
- * number of LTC6813 chips connected on the daisy chain), and its second
- * subscript value as NUM_OF_CELLS_PER_LTC6813 (the number of cell voltages that
- * can be monitored per LTC6813 chip).
- * Each cell voltage read back from the LTC6813 daisy chain is a 16-bit unsigned
- * integer where the LSB represents 100µV.
- *
- * @return A pointer to the 2D array containing converted chip cell
- * voltages.
- */
-uint16_t *Io_LTC6813_GetCellVoltages(void);
+struct SharedSpi *Io_LTC6813_GetSpiInterface(void);

--- a/boards/BMS/Inc/Io/Io_LTC6813.h
+++ b/boards/BMS/Inc/Io/Io_LTC6813.h
@@ -3,17 +3,6 @@
 #include <stm32f3xx_hal.h>
 #include "App_SharedExitCode.h"
 
-enum CellVoltageRegisterGroups
-{
-    CELL_VOLTAGE_REGISTER_GROUP_A,
-    CELL_VOLTAGE_REGISTER_GROUP_B,
-    CELL_VOLTAGE_REGISTER_GROUP_C,
-    CELL_VOLTAGE_REGISTER_GROUP_D,
-    CELL_VOLTAGE_REGISTER_GROUP_E,
-    CELL_VOLTAGE_REGISTER_GROUP_F,
-    NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS
-};
-
 /**
  * Initialize all chips on the LTC6813 daisy chain.
  * @param spi_handle The given SPI handle for the LTC6813 daisy chain.

--- a/boards/BMS/Inc/Io/Io_Temperatures.h
+++ b/boards/BMS/Inc/Io/Io_Temperatures.h
@@ -3,7 +3,7 @@
 #include "App_SharedExitCode.h"
 
 /**
- * Read internal die temperatures for all cell monitoring chips.
+ * Read internal die temperatures (°C) for all cell monitoring chips.
  * @return EXIT_CODE_OK if internal die temperatures were acquired successfully
  * from all cell monitoring chips. Else, EXIT_CODE_ERROR.
  */

--- a/boards/BMS/Inc/Io/Io_Temperatures.h
+++ b/boards/BMS/Inc/Io/Io_Temperatures.h
@@ -7,16 +7,16 @@
  * @return EXIT_CODE_OK if internal die temperatures were acquired successfully
  * from all cell monitoring chips. Else, EXIT_CODE_ERROR.
  */
-ExitCode Io_Temperatures_ReadDieTemperatures(void);
+ExitCode Io_Temperatures_ReadDieTemperaturesDegC(void);
 
 /**
  * Get the pointer to the array containing internal die temperatures read
  * from the cell monitoring chips.
- * @note The subscript value of the array is the number of cell monitoring
+ * @note The length of the array is equal to the number of cell monitoring
  * devices on the daisy chain.
  * @note Call Io_Temperatures_ReadDieTemperatures to acquire the most recent
  * die temperatures from the cell monitoring chips before calling this function.
- * @return A pointer to the array containing the internal die temperatures for
- * each cell monitoring chip.
+ * @return A pointer to the array containing the internal die temperatures (°C)
+ * for each cell monitoring chip.
  */
-float *Io_Temperatures_GetDieTemperatures(void);
+float *Io_Temperatures_GetDieTemperaturesDegC(void);

--- a/boards/BMS/Inc/Io/Io_Temperatures.h
+++ b/boards/BMS/Inc/Io/Io_Temperatures.h
@@ -16,13 +16,7 @@ ExitCode Io_Temperatures_ReadDieTemperatures(void);
  * devices on the daisy chain.
  * @note Call Io_Temperatures_ReadDieTemperatures to acquire the most recent
  * die temperatures from the cell monitoring chips before calling this function.
- * @note The internal die temperature is read back from the cell monitoring
- * chips as a voltage. Use the following equation to convert voltages to
- * temperatures (°C):
- *
- * ITMP(Measured_V) = Measured_V * (1°C / 13.1578e-3V) - 276°C
- *
  * @return A pointer to the array containing the internal die temperatures for
  * each cell monitoring chip.
  */
-uint16_t *Io_Temperatures_GetDieTemperatures(void);
+float *Io_Temperatures_GetDieTemperatures(void);

--- a/boards/BMS/Inc/Io/Io_Temperatures.h
+++ b/boards/BMS/Inc/Io/Io_Temperatures.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "App_SharedExitCode.h"
+
+/**
+ * Read internal die temperatures for all cell monitoring chips.
+ * @return EXIT_CODE_OK if internal die temperatures were acquired successfully
+ * from all cell monitoring chips. Else, EXIT_CODE_ERROR.
+ */
+ExitCode Io_Temperatures_ReadDieTemperatures(void);
+
+/**
+ * Get the pointer to the array containing internal die temperatures read
+ * from the cell monitoring chips.
+ * @note The subscript value of the array is the number of cell monitoring
+ * devices on the daisy chain.
+ * @note Call Io_Temperatures_ReadDieTemperatures to acquire the most recent
+ * die temperatures from the cell monitoring chips before calling this function.
+ * @note The internal die temperature is read back from the cell monitoring
+ * chips as a voltage. Use the following equation to convert voltages to
+ * temperatures (°C):
+ *
+ * ITMP(Measured_V) = Measured_V * (1°C / 13.1578e-3V) - 276°C
+ *
+ * @return A pointer to the array containing the internal die temperatures for
+ * each cell monitoring chip.
+ */
+uint16_t *Io_Temperatures_GetDieTemperatures(void);

--- a/boards/BMS/Inc/Io/configs/Io_LTC6813Configs.h
+++ b/boards/BMS/Inc/Io/configs/Io_LTC6813Configs.h
@@ -1,5 +1,11 @@
 #pragma once
 
-#define NUM_OF_LTC6813 2U
-#define NUM_OF_CELLS_PER_LTC6813 18U
-#define LTC6813_SPI_TIMEOUT_MS 1U
+#define NUM_OF_CMD_BYTES 4U
+#define NUM_OF_RX_BYTES 8U
+#define NUM_OF_PEC15_BYTES_PER_CMD 2U
+
+#define SPI_INTERFACE_TIMEOUT_MS_LTC6813 2U
+
+// ADC timeout threshold of 10 was chosen arbitrarily.
+// TODO: Determine the ADC conversion timeout threshold #674
+#define ADC_TIMEOUT_CYCLES_THRESHOLD 10U

--- a/boards/BMS/Src/Io/Io_CellVoltages.c
+++ b/boards/BMS/Src/Io/Io_CellVoltages.c
@@ -135,7 +135,7 @@ ExitCode Io_CellVoltages_ReadCellVoltages(void)
             return EXIT_CODE_ERROR;
         }
 
-        for (enum CellMonitorICs current_ic = 0U;
+        for (enum CellMonitorICs current_ic = CELL_MONITOR_IC_0;
              current_ic < NUM_OF_CELL_MONITOR_ICS; current_ic++)
         {
             if (Io_LTC6813_ParseCellsAndPerformPec15Check(

--- a/boards/BMS/Src/Io/Io_CellVoltages.c
+++ b/boards/BMS/Src/Io/Io_CellVoltages.c
@@ -1,0 +1,145 @@
+#include "Io_CellVoltages.h"
+#include "Io_LTC6813.h"
+#include "Io_SharedSpi.h"
+#include "configs/App_CellConfigs.h"
+#include "configs/Io_LTC6813Configs.h"
+
+#define NUM_OF_CELLS_PER_LTC6813_REGISTER_GROUP 3U
+
+static const uint16_t cell_voltage_register_group_commands
+    [NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS] = {
+        0x0400, // RDCVA
+        0x0600, // RDCVB
+        0x0800, // RDCVC
+        0x0A00, // RDCVD
+        0x0900, // RDCVE
+        0x0B00  // RDCVF
+    };
+
+static uint16_t cell_voltages[NUM_OF_CELL_MONITOR_ICS]
+                             [NUM_OF_CELLS_READ_PER_IC];
+
+/**
+ * Parse cell voltages received from the cell monitoring IC and perform PEC15
+ * checks.
+ * @param current_ic The current cell monitoring IC to parse cell voltages for.
+ * @param current_register_group The current register group on the given IC to
+ * parse cell voltages for.
+ * @param rx_cell_voltages The buffer containing the cell voltages read from the
+ * cell monitoring IC.
+ * @return EXIT_CODE_OK if the PEC15 check was successful. Else,
+ * EXIT_CODE_ERROR.
+ */
+static ExitCode Io_LTC6813_ParseCellsAndPerformPec15Check(
+    size_t  current_ic,
+    size_t  current_register_group,
+    uint8_t rx_cell_voltages[]);
+
+static ExitCode Io_LTC6813_ParseCellsAndPerformPec15Check(
+    size_t  current_ic,
+    size_t  current_register_group,
+    uint8_t rx_cell_voltages[])
+{
+    size_t cell_voltage_index = current_ic * NUM_OF_RX_BYTES;
+
+    for (size_t current_cell = 0U;
+         current_cell < NUM_OF_CELLS_PER_LTC6813_REGISTER_GROUP; current_cell++)
+    {
+        uint32_t cell_voltage =
+            (uint32_t)(rx_cell_voltages[cell_voltage_index]) |
+            (uint32_t)((rx_cell_voltages[cell_voltage_index + 1] << 8));
+
+        cell_voltages[current_ic]
+                     [current_cell +
+                      current_register_group *
+                          NUM_OF_CELLS_PER_LTC6813_REGISTER_GROUP] =
+                         (uint16_t)cell_voltage;
+
+        if (current_register_group == CELL_VOLTAGE_REGISTER_GROUP_F)
+        {
+            // Since 16 cells are monitored for each accumulator segment, ignore
+            // the last four bytes read back from the LTC6813 chip when reading
+            // from CELL_VOLTAGE_REGISTER_F. The cell voltage index is
+            // incremented by 6 to retrieve the PEC15 bytes for the register
+            // group.
+            cell_voltage_index += 6U;
+            break;
+        }
+        else
+        {
+            // Each cell voltage is represented as a pair of bytes. Therefore,
+            // the cell voltage index is incremented by 2 to retrieve the next
+            // cell voltage.
+            cell_voltage_index += 2U;
+        }
+    }
+
+    uint32_t received_pec15 =
+        (uint32_t)(rx_cell_voltages[cell_voltage_index] << 8) |
+        (uint32_t)(rx_cell_voltages[cell_voltage_index + 1]);
+
+    // Calculate the PEC15 using the first 6 bytes of data received from the
+    // chip.
+    uint32_t calculated_pec15 = Io_LTC6813_CalculatePec15(
+        &rx_cell_voltages[current_ic * NUM_OF_RX_BYTES], 6U);
+
+    if (received_pec15 != calculated_pec15)
+    {
+        return EXIT_CODE_ERROR;
+    }
+
+    return EXIT_CODE_OK;
+}
+
+ExitCode Io_CellVoltages_ReadCellVoltages(void)
+{
+    uint16_t cell_register_group_cmd;
+    uint8_t  tx_cmd[NUM_OF_CMD_BYTES];
+    uint8_t rx_cell_voltages[NUM_OF_RX_BYTES * NUM_OF_CELL_MONITOR_ICS] = { 0 };
+
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_EnterReadyState())
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_StartCellVoltageConversions())
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_PollConversions())
+
+    for (enum CellVoltageRegisterGroups current_register_group = 0U;
+         current_register_group < NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS;
+         current_register_group++)
+    {
+        cell_register_group_cmd =
+            cell_voltage_register_group_commands[current_register_group];
+
+        tx_cmd[0] = (uint8_t)cell_register_group_cmd;
+        tx_cmd[1] = (uint8_t)(cell_register_group_cmd >> 8);
+
+        uint16_t tx_cmd_pec15 =
+            Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
+        tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
+        tx_cmd[3] = (uint8_t)(tx_cmd_pec15);
+
+        if (Io_SharedSpi_TransmitAndReceive(
+                Io_LTC6813_GetSpiInterface(), tx_cmd, NUM_OF_CMD_BYTES,
+                rx_cell_voltages,
+                NUM_OF_RX_BYTES * NUM_OF_CELL_MONITOR_ICS) != HAL_OK)
+        {
+            return EXIT_CODE_ERROR;
+        }
+
+        for (enum CellMonitorICs current_ic = 0U;
+             current_ic < NUM_OF_CELL_MONITOR_ICS; current_ic++)
+        {
+            if (Io_LTC6813_ParseCellsAndPerformPec15Check(
+                    current_ic, current_register_group, rx_cell_voltages) !=
+                EXIT_CODE_OK)
+            {
+                return EXIT_CODE_ERROR;
+            }
+        }
+    }
+
+    return EXIT_CODE_OK;
+}
+
+uint16_t *Io_CellVoltages_GetCellVoltages(void)
+{
+    return &cell_voltages[0][0];
+}

--- a/boards/BMS/Src/Io/Io_CellVoltages.c
+++ b/boards/BMS/Src/Io/Io_CellVoltages.c
@@ -68,10 +68,11 @@ static ExitCode Io_LTC6813_ParseCellsAndPerformPec15Check(
 
         if (current_register_group == CELL_VOLTAGE_REGISTER_GROUP_F)
         {
-            // Since 16 cells are monitored for each accumulator segment, ignore
-            // the last two cell voltages read back from
-            // CELL_VOLTAGE_REGISTER_F. The cell voltage index is incremented by
-            // 6 to retrieve the PEC15 bytes for the register group.
+            // Since 16 cells are monitored for each accumulator segment and
+            // there are 3 cell voltages per register group, ignore the last 2
+            // cell voltages read back from CELL_VOLTAGE_REGISTER_F. The cell
+            // voltage index is incremented by 6 to retrieve the PEC15 bytes for
+            // the register group.
             cell_voltage_index += 6U;
             break;
         }

--- a/boards/BMS/Src/Io/Io_CellVoltages.c
+++ b/boards/BMS/Src/Io/Io_CellVoltages.c
@@ -6,6 +6,17 @@
 
 #define NUM_OF_CELLS_PER_LTC6813_REGISTER_GROUP 3U
 
+enum CellVoltageRegisterGroup
+{
+    CELL_VOLTAGE_REGISTER_GROUP_A,
+    CELL_VOLTAGE_REGISTER_GROUP_B,
+    CELL_VOLTAGE_REGISTER_GROUP_C,
+    CELL_VOLTAGE_REGISTER_GROUP_D,
+    CELL_VOLTAGE_REGISTER_GROUP_E,
+    CELL_VOLTAGE_REGISTER_GROUP_F,
+    NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS
+};
+
 static const uint16_t cell_voltage_register_group_commands
     [NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS] = {
         0x0400, // RDCVA
@@ -31,14 +42,14 @@ static uint16_t cell_voltages[NUM_OF_CELL_MONITOR_ICS]
  * EXIT_CODE_ERROR.
  */
 static ExitCode Io_LTC6813_ParseCellsAndPerformPec15Check(
-    size_t  current_ic,
-    size_t  current_register_group,
-    uint8_t rx_cell_voltages[]);
+    size_t                        current_ic,
+    enum CellVoltageRegisterGroup current_register_group,
+    uint8_t                       rx_cell_voltages[]);
 
 static ExitCode Io_LTC6813_ParseCellsAndPerformPec15Check(
-    size_t  current_ic,
-    size_t  current_register_group,
-    uint8_t rx_cell_voltages[])
+    size_t                        current_ic,
+    enum CellVoltageRegisterGroup current_register_group,
+    uint8_t                       rx_cell_voltages[])
 {
     size_t cell_voltage_index = current_ic * NUM_OF_RX_BYTES;
 
@@ -101,7 +112,7 @@ ExitCode Io_CellVoltages_ReadCellVoltages(void)
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_StartCellVoltageConversions())
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_PollConversions())
 
-    for (enum CellVoltageRegisterGroups current_register_group = 0U;
+    for (enum CellVoltageRegisterGroup current_register_group = 0U;
          current_register_group < NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS;
          current_register_group++)
     {

--- a/boards/BMS/Src/Io/Io_CellVoltages.c
+++ b/boards/BMS/Src/Io/Io_CellVoltages.c
@@ -69,16 +69,15 @@ static ExitCode Io_LTC6813_ParseCellsAndPerformPec15Check(
         if (current_register_group == CELL_VOLTAGE_REGISTER_GROUP_F)
         {
             // Since 16 cells are monitored for each accumulator segment, ignore
-            // the last four bytes read back from the LTC6813 chip when reading
-            // from CELL_VOLTAGE_REGISTER_F. The cell voltage index is
-            // incremented by 6 to retrieve the PEC15 bytes for the register
-            // group.
+            // the last two cell voltages read back from
+            // CELL_VOLTAGE_REGISTER_F. The cell voltage index is incremented by
+            // 6 to retrieve the PEC15 bytes for the register group.
             cell_voltage_index += 6U;
             break;
         }
         else
         {
-            // Each cell voltage is represented as a pair of bytes. Therefore,
+            // Each cell voltage is represented by 2 bytes. Therefore,
             // the cell voltage index is incremented by 2 to retrieve the next
             // cell voltage.
             cell_voltage_index += 2U;
@@ -112,7 +111,8 @@ ExitCode Io_CellVoltages_ReadCellVoltages(void)
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_StartCellVoltageConversions())
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_PollConversions())
 
-    for (enum CellVoltageRegisterGroup current_register_group = 0U;
+    for (enum CellVoltageRegisterGroup current_register_group =
+             CELL_VOLTAGE_REGISTER_GROUP_A;
          current_register_group < NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS;
          current_register_group++)
     {

--- a/boards/BMS/Src/Io/Io_LTC6813.c
+++ b/boards/BMS/Src/Io/Io_LTC6813.c
@@ -1,83 +1,10 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 #include "Io_LTC6813.h"
 #include "Io_SharedSpi.h"
+#include "configs/App_CellConfigs.h"
 #include "configs/Io_LTC6813Configs.h"
-
-enum CellVoltageRegisterGroups
-{
-    CELL_VOLTAGE_REGISTER_GROUP_A,
-    CELL_VOLTAGE_REGISTER_GROUP_B,
-    CELL_VOLTAGE_REGISTER_GROUP_C,
-    CELL_VOLTAGE_REGISTER_GROUP_D,
-    CELL_VOLTAGE_REGISTER_GROUP_E,
-    CELL_VOLTAGE_REGISTER_GROUP_F,
-    NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS
-};
-
-struct LookupTables
-{
-    // Commands used to read cell voltage register groups in
-    // Io_LTC6813_ReadAllCellRegisterGroups. The command is split into two bytes
-    // and transmitted to the IC.
-    uint16_t cell_voltage_register_group_commands
-        [NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS];
-
-    // The CRC table used to calculate 15 bit packet error codes (PEC15).
-    uint16_t crc[UINT8_MAX + 1];
-};
-
-// clang-format off
-static const struct LookupTables lookup_tables = {
-    .cell_voltage_register_group_commands =
-            {
-                0x0400, // RDCVA
-                0x0600, // RDCVB
-                0x0800, // RDCVC
-                0x0A00, // RDCVD
-                0x0900, // RDCVE
-                0x0B00  // RDCVF
-            },
-
-    .crc =
-            {   0x0, 0xC599, 0xCEAB, 0xB32,  0xD8CF, 0x1D56, 0x1664, 0xD3FD, 0xF407,
-                0x319E, 0x3AAC, 0xFF35, 0x2CC8, 0xE951, 0xE263, 0x27FA, 0xAD97, 0x680E,
-                0x633C, 0xA6A5, 0x7558, 0xB0C1, 0xBBF3, 0x7E6A, 0x5990, 0x9C09, 0x973B,
-                0x52A2, 0x815F, 0x44C6, 0x4FF4, 0x8A6D, 0x5B2E, 0x9EB7, 0x9585, 0x501C,
-                0x83E1, 0x4678, 0x4D4A, 0x88D3, 0xAF29, 0x6AB0, 0x6182, 0xA41B, 0x77E6,
-                0xB27F, 0xB94D, 0x7CD4, 0xF6B9, 0x3320, 0x3812, 0xFD8B, 0x2E76, 0xEBEF,
-                0xE0DD, 0x2544, 0x2BE,  0xC727, 0xCC15, 0x98C,  0xDA71, 0x1FE8, 0x14DA,
-                0xD143, 0xF3C5, 0x365C, 0x3D6E, 0xF8F7, 0x2B0A, 0xEE93, 0xE5A1, 0x2038,
-                0x7C2,  0xC25B, 0xC969, 0xCF0,  0xDF0D, 0x1A94, 0x11A6, 0xD43F, 0x5E52,
-                0x9BCB, 0x90F9, 0x5560, 0x869D, 0x4304, 0x4836, 0x8DAF, 0xAA55, 0x6FCC,
-                0x64FE, 0xA167, 0x729A, 0xB703, 0xBC31, 0x79A8, 0xA8EB, 0x6D72, 0x6640,
-                0xA3D9, 0x7024, 0xB5BD, 0xBE8F, 0x7B16, 0x5CEC, 0x9975, 0x9247, 0x57DE,
-                0x8423, 0x41BA, 0x4A88, 0x8F11, 0x57C,  0xC0E5, 0xCBD7, 0xE4E,  0xDDB3,
-                0x182A, 0x1318, 0xD681, 0xF17B, 0x34E2, 0x3FD0, 0xFA49, 0x29B4, 0xEC2D,
-                0xE71F, 0x2286, 0xA213, 0x678A, 0x6CB8, 0xA921, 0x7ADC, 0xBF45, 0xB477,
-                0x71EE, 0x5614, 0x938D, 0x98BF, 0x5D26, 0x8EDB, 0x4B42, 0x4070, 0x85E9,
-                0xF84,  0xCA1D, 0xC12F, 0x4B6,  0xD74B, 0x12D2, 0x19E0, 0xDC79, 0xFB83,
-                0x3E1A, 0x3528, 0xF0B1, 0x234C, 0xE6D5, 0xEDE7, 0x287E, 0xF93D, 0x3CA4,
-                0x3796, 0xF20F, 0x21F2, 0xE46B, 0xEF59, 0x2AC0, 0xD3A,  0xC8A3, 0xC391,
-                0x608,  0xD5F5, 0x106C, 0x1B5E, 0xDEC7, 0x54AA, 0x9133, 0x9A01, 0x5F98,
-                0x8C65, 0x49FC, 0x42CE, 0x8757, 0xA0AD, 0x6534, 0x6E06, 0xAB9F, 0x7862,
-                0xBDFB, 0xB6C9, 0x7350, 0x51D6, 0x944F, 0x9F7D, 0x5AE4, 0x8919, 0x4C80,
-                0x47B2, 0x822B, 0xA5D1, 0x6048, 0x6B7A, 0xAEE3, 0x7D1E, 0xB887, 0xB3B5,
-                0x762C, 0xFC41, 0x39D8, 0x32EA, 0xF773, 0x248E, 0xE117, 0xEA25, 0x2FBC,
-                0x846,  0xCDDF, 0xC6ED, 0x374,  0xD089, 0x1510, 0x1E22, 0xDBBB, 0xAF8,
-                0xCF61, 0xC453, 0x1CA,  0xD237, 0x17AE, 0x1C9C, 0xD905, 0xFEFF, 0x3B66,
-                0x3054, 0xF5CD, 0x2630, 0xE3A9, 0xE89B, 0x2D02, 0xA76F, 0x62F6, 0x69C4,
-                0xAC5D, 0x7fA0, 0xBA39, 0xB10B, 0x7492, 0x5368, 0x96F1, 0x9DC3, 0x585A,
-                0x8BA7, 0x4E3E, 0x450C, 0x8095}
-};
-// clang-format on
-
-#define NUM_OF_CELLS_PER_LTC6813_REGISTER_GROUP 3U
-#define NUM_OF_CMD_BYTES 4U
-#define NUM_OF_PEC15_BYTES_PER_CMD 2U
-#define NUM_OF_CELL_VOLTAGE_RX_BYTES 8U
 
 #define ADCOPT 0U
 #define REFON 1U
@@ -85,72 +12,57 @@ static const struct LookupTables lookup_tables = {
 #define VUV 0x4E1
 #define VOV 0x8CA
 
-#define MD 2U
+#define MD 1U
 #define DCP 0U
 #define CH 0U
+#define CHST 0U
 
-// ADC timeout threshold of 10 was chosen arbitrarily.
-// TODO: Determine the ADC conversion timeout threshold #674
-#define ADC_TIMEOUT_THRESHOLD 10U
+static struct SharedSpi *spi_interface;
 
-struct LTC6813
-{
-    // A pointer to the SPI interface
-    struct SharedSpi *spi;
-
-    // A counter used to count the number of times a PEC error occurs.
-    uint8_t pec15_error_counter;
-
-    // An array containing cell voltages for each LTC6813 IC.
-    uint16_t cell_voltages[NUM_OF_LTC6813][NUM_OF_CELLS_PER_LTC6813];
+static const uint16_t crc[UINT8_MAX + 1] = {
+    0x0,    0xC599, 0xCEAB, 0xB32,  0xD8CF, 0x1D56, 0x1664, 0xD3FD, 0xF407,
+    0x319E, 0x3AAC, 0xFF35, 0x2CC8, 0xE951, 0xE263, 0x27FA, 0xAD97, 0x680E,
+    0x633C, 0xA6A5, 0x7558, 0xB0C1, 0xBBF3, 0x7E6A, 0x5990, 0x9C09, 0x973B,
+    0x52A2, 0x815F, 0x44C6, 0x4FF4, 0x8A6D, 0x5B2E, 0x9EB7, 0x9585, 0x501C,
+    0x83E1, 0x4678, 0x4D4A, 0x88D3, 0xAF29, 0x6AB0, 0x6182, 0xA41B, 0x77E6,
+    0xB27F, 0xB94D, 0x7CD4, 0xF6B9, 0x3320, 0x3812, 0xFD8B, 0x2E76, 0xEBEF,
+    0xE0DD, 0x2544, 0x2BE,  0xC727, 0xCC15, 0x98C,  0xDA71, 0x1FE8, 0x14DA,
+    0xD143, 0xF3C5, 0x365C, 0x3D6E, 0xF8F7, 0x2B0A, 0xEE93, 0xE5A1, 0x2038,
+    0x7C2,  0xC25B, 0xC969, 0xCF0,  0xDF0D, 0x1A94, 0x11A6, 0xD43F, 0x5E52,
+    0x9BCB, 0x90F9, 0x5560, 0x869D, 0x4304, 0x4836, 0x8DAF, 0xAA55, 0x6FCC,
+    0x64FE, 0xA167, 0x729A, 0xB703, 0xBC31, 0x79A8, 0xA8EB, 0x6D72, 0x6640,
+    0xA3D9, 0x7024, 0xB5BD, 0xBE8F, 0x7B16, 0x5CEC, 0x9975, 0x9247, 0x57DE,
+    0x8423, 0x41BA, 0x4A88, 0x8F11, 0x57C,  0xC0E5, 0xCBD7, 0xE4E,  0xDDB3,
+    0x182A, 0x1318, 0xD681, 0xF17B, 0x34E2, 0x3FD0, 0xFA49, 0x29B4, 0xEC2D,
+    0xE71F, 0x2286, 0xA213, 0x678A, 0x6CB8, 0xA921, 0x7ADC, 0xBF45, 0xB477,
+    0x71EE, 0x5614, 0x938D, 0x98BF, 0x5D26, 0x8EDB, 0x4B42, 0x4070, 0x85E9,
+    0xF84,  0xCA1D, 0xC12F, 0x4B6,  0xD74B, 0x12D2, 0x19E0, 0xDC79, 0xFB83,
+    0x3E1A, 0x3528, 0xF0B1, 0x234C, 0xE6D5, 0xEDE7, 0x287E, 0xF93D, 0x3CA4,
+    0x3796, 0xF20F, 0x21F2, 0xE46B, 0xEF59, 0x2AC0, 0xD3A,  0xC8A3, 0xC391,
+    0x608,  0xD5F5, 0x106C, 0x1B5E, 0xDEC7, 0x54AA, 0x9133, 0x9A01, 0x5F98,
+    0x8C65, 0x49FC, 0x42CE, 0x8757, 0xA0AD, 0x6534, 0x6E06, 0xAB9F, 0x7862,
+    0xBDFB, 0xB6C9, 0x7350, 0x51D6, 0x944F, 0x9F7D, 0x5AE4, 0x8919, 0x4C80,
+    0x47B2, 0x822B, 0xA5D1, 0x6048, 0x6B7A, 0xAEE3, 0x7D1E, 0xB887, 0xB3B5,
+    0x762C, 0xFC41, 0x39D8, 0x32EA, 0xF773, 0x248E, 0xE117, 0xEA25, 0x2FBC,
+    0x846,  0xCDDF, 0xC6ED, 0x374,  0xD089, 0x1510, 0x1E22, 0xDBBB, 0xAF8,
+    0xCF61, 0xC453, 0x1CA,  0xD237, 0x17AE, 0x1C9C, 0xD905, 0xFEFF, 0x3B66,
+    0x3054, 0xF5CD, 0x2630, 0xE3A9, 0xE89B, 0x2D02, 0xA76F, 0x62F6, 0x69C4,
+    0xAC5D, 0x7fA0, 0xBA39, 0xB10B, 0x7492, 0x5368, 0x96F1, 0x9DC3, 0x585A,
+    0x8BA7, 0x4E3E, 0x450C, 0x8095
 };
 
-static struct LTC6813 ltc_6813;
+void Io_LTC6813_Init(
+    SPI_HandleTypeDef *spi_handle,
+    GPIO_TypeDef *     nss_port,
+    uint16_t           nss_pin)
+{
+    assert(spi_handle != NULL);
 
-/**
- * Calculate the 15-bit packet error code (PEC15) for the given data buffer.
- * @param data_buffer A pointer to the buffer containing data used to calculate
- * the PEC15 code.
- * @param size The number of data elements used to calculate the PEC15 code
- * (Note: The size can be a positive integer less than or equal to the size
- * of the data buffer).
- * @return The calculated PEC15 code
- */
-static uint16_t Io_CalculatePec15(uint8_t *data_buffer, uint32_t size);
+    spi_interface = Io_SharedSpi_Create(
+        spi_handle, nss_port, nss_pin, SPI_INTERFACE_TIMEOUT_MS_LTC6813);
+}
 
-/**
- * Transition all LTC6813 chips on the daisy chain from the IDLE state to the
- * READY state.
- * @return EXIT_CODE_OK if the SCK and NSS pin can be toggled without timing out
- * or errors. Else, EXIT_CODE_UNIMPLEMENTED.
- */
-static ExitCode Io_LTC6813_EnterReadyState(void);
-
-/**
- * Start ADC conversions for all LTC6813 chips on the daisy chain.
- * @return EXIT_CODE_OK if the command used to toggle the ADC can be sent to the
- * LTC6813 daisy chain without errors or timing out. Else,
- * EXIT_CODE_UNIMPLEMENTED.
- */
-static ExitCode Io_LTC6813_StartADCConversion(void);
-
-/**
- * Check if all LTC6813 chips in the daisy chain have all completed ADC
- * conversions.
- * @return EXIT_CODE_OK if all LTC6813 chips on the daisy chain have completed
- * ADC conversions. EXIT_CODE_TIMEOUT if ADC conversions were unfinished
- * before timing out. EXIT_CODE_UNIMPLEMENTED if the commands sent to the
- * LTC6813 daisy chain were not successfully transmitted or received.
- */
-static ExitCode Io_LTC6813_PollAdcConversion(void);
-
-static void Io_LTC6813_ParseCellsAndPerformPec15Check(
-    size_t current_ic,
-    size_t current_register_group,
-    uint8_t
-        rx_cell_voltages[static NUM_OF_CELL_VOLTAGE_RX_BYTES * NUM_OF_LTC6813]);
-
-static uint16_t Io_CalculatePec15(uint8_t *data_buffer, uint32_t size)
+uint16_t Io_LTC6813_CalculatePec15(uint8_t *data_buffer, uint32_t size)
 {
     size_t pec15_lut_index;
 
@@ -160,32 +72,32 @@ static uint16_t Io_CalculatePec15(uint8_t *data_buffer, uint32_t size)
     for (size_t i = 0U; i < size; i++)
     {
         pec15_lut_index = ((pec15_remainder >> 7) ^ data_buffer[i]) & 0xFF;
-        pec15_remainder = (uint16_t)(
-            (pec15_remainder << 8) ^ lookup_tables.crc[pec15_lut_index]);
+        pec15_remainder =
+            (uint16_t)((pec15_remainder << 8) ^ crc[pec15_lut_index]);
     }
 
     // Set the LSB of the PEC15 remainder to 0.
     return (uint16_t)(pec15_remainder << 1);
 }
 
-static ExitCode Io_LTC6813_EnterReadyState(void)
+ExitCode Io_LTC6813_EnterReadyState(void)
 {
     uint8_t rx_data;
 
     // Generate isoSPI traffic to wake up the daisy chain by sending a command
     // to read a single byte NUM_OF_LTC6813 times.
-    for (size_t i = 0U; i < NUM_OF_LTC6813; i++)
+    for (size_t i = 0U; i < NUM_OF_CELL_MONITOR_ICS; i++)
     {
-        if (Io_SharedSpi_Receive(ltc_6813.spi, &rx_data, 1U) != HAL_OK)
+        if (Io_SharedSpi_Receive(spi_interface, &rx_data, 1U) != HAL_OK)
         {
-            return EXIT_CODE_TIMEOUT;
+            return EXIT_CODE_ERROR;
         }
     }
 
     return EXIT_CODE_OK;
 }
 
-static ExitCode Io_LTC6813_StartADCConversion(void)
+ExitCode Io_LTC6813_StartCellVoltageConversions(void)
 {
     // The command used to start an ADC conversion.
     uint32_t ADCV = (0x260 + (MD << 7) + (DCP << 4) + CH);
@@ -195,17 +107,35 @@ static ExitCode Io_LTC6813_StartADCConversion(void)
     tx_cmd[1] = (uint8_t)ADCV;
 
     uint16_t tx_cmd_pec15 =
-        Io_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
+        Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
     tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
     tx_cmd[3] = (uint8_t)tx_cmd_pec15;
 
-    return (Io_SharedSpi_Transmit(ltc_6813.spi, tx_cmd, NUM_OF_CMD_BYTES) ==
+    return (Io_SharedSpi_Transmit(spi_interface, tx_cmd, NUM_OF_CMD_BYTES) ==
             HAL_OK)
                ? EXIT_CODE_OK
-               : EXIT_CODE_TIMEOUT;
+               : EXIT_CODE_ERROR;
 }
 
-static ExitCode Io_LTC6813_PollAdcConversion(void)
+ExitCode Io_LTC6813_StartInternalDeviceConversions(void)
+{
+    uint32_t ADSTAT = (0x468 + (MD << 7) + CHST);
+
+    uint8_t tx_cmd[NUM_OF_CMD_BYTES];
+    tx_cmd[0] = (uint8_t)(ADSTAT >> 8);
+    tx_cmd[1] = (uint8_t)(ADSTAT);
+    uint16_t tx_cmd_pec15 =
+        Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
+    tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
+    tx_cmd[3] = (uint8_t)tx_cmd_pec15;
+
+    return (Io_SharedSpi_Transmit(spi_interface, tx_cmd, NUM_OF_CMD_BYTES) ==
+            HAL_OK)
+               ? EXIT_CODE_OK
+               : EXIT_CODE_ERROR;
+}
+
+ExitCode Io_LTC6813_PollConversions(void)
 {
     // The command used to determine the status of ADC conversions.
     uint32_t PLADC = 0x1407;
@@ -215,7 +145,7 @@ static ExitCode Io_LTC6813_PollAdcConversion(void)
     tx_cmd[1] = (uint8_t)(PLADC >> 8);
 
     uint16_t tx_cmd_pec15 =
-        Io_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
+        Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
     tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
     tx_cmd[3] = (uint8_t)tx_cmd_pec15;
 
@@ -228,14 +158,15 @@ static ExitCode Io_LTC6813_PollAdcConversion(void)
     do
     {
         if (Io_SharedSpi_TransmitAndReceive(
-                ltc_6813.spi, tx_cmd, NUM_OF_CMD_BYTES, &rx_data, 1U) != HAL_OK)
+                spi_interface, tx_cmd, NUM_OF_CMD_BYTES, &rx_data, 1U) !=
+            HAL_OK)
         {
             return EXIT_CODE_TIMEOUT;
         }
 
         ++adc_conversion_timeout_counter;
 
-        if (adc_conversion_timeout_counter >= ADC_TIMEOUT_THRESHOLD)
+        if (adc_conversion_timeout_counter >= ADC_TIMEOUT_CYCLES_THRESHOLD)
         {
             return EXIT_CODE_TIMEOUT;
         }
@@ -244,67 +175,7 @@ static ExitCode Io_LTC6813_PollAdcConversion(void)
     return EXIT_CODE_OK;
 }
 
-static void Io_LTC6813_ParseCellsAndPerformPec15Check(
-    size_t  current_ic,
-    size_t  current_register_group,
-    uint8_t rx_cell_voltages[])
-{
-    size_t cell_voltage_index = current_ic * NUM_OF_CELL_VOLTAGE_RX_BYTES;
-
-    for (size_t current_cell = 0U;
-         current_cell < NUM_OF_CELLS_PER_LTC6813_REGISTER_GROUP; current_cell++)
-    {
-        assert(
-            cell_voltage_index < NUM_OF_CELL_VOLTAGE_RX_BYTES * NUM_OF_LTC6813);
-        uint32_t cell_voltage =
-            (uint32_t)(rx_cell_voltages[cell_voltage_index]) |
-            (uint32_t)((rx_cell_voltages[cell_voltage_index + 1] << 8));
-
-        ltc_6813.cell_voltages[current_ic]
-                              [current_cell +
-                               current_register_group *
-                                   NUM_OF_CELLS_PER_LTC6813_REGISTER_GROUP] =
-            (uint16_t)cell_voltage;
-
-        // Each cell voltage is represented as a pair of bytes. Therefore,
-        // the cell voltage index is incremented by 2 to retrieve the next cell
-        // voltage.
-        cell_voltage_index += 2U;
-    }
-
-    assert(cell_voltage_index < NUM_OF_CELL_VOLTAGE_RX_BYTES * NUM_OF_LTC6813);
-    uint32_t received_pec15 =
-        (uint32_t)(rx_cell_voltages[cell_voltage_index] << 8) |
-        (uint32_t)(rx_cell_voltages[cell_voltage_index + 1]);
-
-    // Calculate the PEC15 using the first 6 bytes of data received from the
-    // chip.
-    uint32_t calculated_pec15 = Io_CalculatePec15(
-        &rx_cell_voltages[current_ic * NUM_OF_CELL_VOLTAGE_RX_BYTES], 6U);
-
-    if (received_pec15 != calculated_pec15)
-    {
-        ltc_6813.pec15_error_counter++;
-    }
-}
-
-void Io_LTC6813_Init(
-    SPI_HandleTypeDef *spi_handle,
-    GPIO_TypeDef *     nss_port,
-    uint16_t           nss_pin)
-{
-    assert(spi_handle != NULL);
-
-    ltc_6813.spi = Io_SharedSpi_Create(
-        spi_handle, nss_port, nss_pin, LTC6813_SPI_TIMEOUT_MS);
-    ltc_6813.pec15_error_counter = 0U;
-    memset(
-        ltc_6813.cell_voltages, 0U,
-        NUM_OF_LTC6813 * NUM_OF_CELLS_PER_LTC6813 *
-            sizeof(ltc_6813.cell_voltages[0][0]));
-}
-
-ExitCode Io_LTC6813_Configure(void)
+ExitCode Io_LTC6813_ConfigureRegisterA(void)
 {
     // The command used to write to configuration register A.
     uint32_t WRCFGA = 0x01;
@@ -313,7 +184,7 @@ ExitCode Io_LTC6813_Configure(void)
     tx_cmd[0] = (uint8_t)(WRCFGA >> 8);
     tx_cmd[1] = (uint8_t)WRCFGA;
     uint16_t tx_cmd_pec15 =
-        Io_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
+        Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
     tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
     tx_cmd[3] = (uint8_t)tx_cmd_pec15;
 
@@ -327,83 +198,33 @@ ExitCode Io_LTC6813_Configure(void)
     // the payload data transmitted.
     uint8_t tx_payload[8] = { 0 };
     memcpy(tx_payload, DEFAULT_CONFIG_REG, 4U);
-    uint16_t tx_payload_pec15 = Io_CalculatePec15(tx_payload, 6U);
+    uint16_t tx_payload_pec15 = Io_LTC6813_CalculatePec15(tx_payload, 6U);
     tx_payload[6]             = (uint8_t)(tx_payload_pec15 >> 8);
     tx_payload[7]             = (uint8_t)tx_payload_pec15;
 
-    Io_SharedSpi_SetNssLow(ltc_6813.spi);
+    Io_SharedSpi_SetNssLow(spi_interface);
 
     // Write to Configuration Register A.
     if (Io_SharedSpi_TransmitWithoutNssToggle(
-            ltc_6813.spi, tx_cmd, NUM_OF_CMD_BYTES) != HAL_OK)
+            spi_interface, tx_cmd, NUM_OF_CMD_BYTES) != HAL_OK)
     {
-        Io_SharedSpi_SetNssHigh(ltc_6813.spi);
-        return EXIT_CODE_TIMEOUT;
+        Io_SharedSpi_SetNssHigh(spi_interface);
+        return EXIT_CODE_ERROR;
     }
 
     // Transmit the payload data to all devices connected to the daisy chain.
     if (Io_SharedSpi_MultipleTransmitWithoutNssToggle(
-            ltc_6813.spi, tx_payload, 8U, NUM_OF_LTC6813) != HAL_OK)
+            spi_interface, tx_payload, 8U, NUM_OF_CELL_MONITOR_ICS) != HAL_OK)
     {
-        Io_SharedSpi_SetNssHigh(ltc_6813.spi);
-        return EXIT_CODE_TIMEOUT;
+        Io_SharedSpi_SetNssHigh(spi_interface);
+        return EXIT_CODE_ERROR;
     }
 
-    Io_SharedSpi_SetNssHigh(ltc_6813.spi);
+    Io_SharedSpi_SetNssHigh(spi_interface);
     return EXIT_CODE_OK;
 }
 
-ExitCode Io_LTC6813_ReadAllCellRegisterGroups(void)
+struct SharedSpi *Io_LTC6813_GetSpiInterface(void)
 {
-    uint16_t cell_register_group_cmd;
-    uint8_t  tx_cmd[NUM_OF_CMD_BYTES];
-    uint8_t  rx_cell_voltages[NUM_OF_CELL_VOLTAGE_RX_BYTES * NUM_OF_LTC6813] = {
-        0
-    };
-
-    // Reset the value of the PEC15 error counter at the start of each cycle.
-    ltc_6813.pec15_error_counter = 0U;
-
-    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_EnterReadyState())
-    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_StartADCConversion())
-    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_PollAdcConversion())
-
-    for (size_t current_register_group = CELL_VOLTAGE_REGISTER_GROUP_A;
-         current_register_group < NUM_OF_CELL_VOLTAGE_REGISTER_GROUPS;
-         current_register_group++)
-    {
-        cell_register_group_cmd =
-            lookup_tables
-                .cell_voltage_register_group_commands[current_register_group];
-
-        tx_cmd[0] = (uint8_t)cell_register_group_cmd;
-        tx_cmd[1] = (uint8_t)(cell_register_group_cmd >> 8);
-
-        uint16_t tx_cmd_pec15 =
-            Io_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
-        tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
-        tx_cmd[3] = (uint8_t)(tx_cmd_pec15);
-
-        if (Io_SharedSpi_TransmitAndReceive(
-                ltc_6813.spi, tx_cmd, NUM_OF_CMD_BYTES, rx_cell_voltages,
-                NUM_OF_CELL_VOLTAGE_RX_BYTES * NUM_OF_LTC6813) != HAL_OK)
-        {
-            return EXIT_CODE_TIMEOUT;
-        }
-
-        for (size_t current_ic = 0U; current_ic < NUM_OF_LTC6813; current_ic++)
-        {
-            Io_LTC6813_ParseCellsAndPerformPec15Check(
-                current_ic, current_register_group, rx_cell_voltages);
-        }
-    }
-
-    // Return EXIT_CODE_ERROR if PEC15 mismatches occur, else return
-    // EXIT_CODE_OK.
-    return (ltc_6813.pec15_error_counter > 0U) ? EXIT_CODE_ERROR : EXIT_CODE_OK;
-}
-
-uint16_t *Io_LTC6813_GetCellVoltages(void)
-{
-    return &ltc_6813.cell_voltages[0][0];
+    return spi_interface;
 }

--- a/boards/BMS/Src/Io/Io_LTC6813.c
+++ b/boards/BMS/Src/Io/Io_LTC6813.c
@@ -99,7 +99,7 @@ ExitCode Io_LTC6813_EnterReadyState(void)
 
 ExitCode Io_LTC6813_StartCellVoltageConversions(void)
 {
-    // The command used to start an ADC conversion.
+    // The command used to start ADC conversions for battery cell voltages.
     uint32_t ADCV = (0x260 + (MD << 7) + (DCP << 4) + CH);
 
     uint8_t tx_cmd[NUM_OF_CMD_BYTES];
@@ -119,6 +119,7 @@ ExitCode Io_LTC6813_StartCellVoltageConversions(void)
 
 ExitCode Io_LTC6813_StartInternalDeviceConversions(void)
 {
+    // The command used to start internal device conversions.
     uint32_t ADSTAT = (0x468 + (MD << 7) + CHST);
 
     uint8_t tx_cmd[NUM_OF_CMD_BYTES];

--- a/boards/BMS/Src/Io/Io_Temperatures.c
+++ b/boards/BMS/Src/Io/Io_Temperatures.c
@@ -5,9 +5,9 @@
 #include "configs/App_CellConfigs.h"
 #include "configs/Io_LTC6813Configs.h"
 
-static uint16_t internal_die_temperatures[NUM_OF_CELL_MONITOR_ICS];
+static float internal_die_temperatures[NUM_OF_CELL_MONITOR_ICS];
 
-uint16_t *Io_Temperatures_GetDieTemperatures(void)
+float *Io_Temperatures_GetDieTemperatures(void)
 {
     return internal_die_temperatures;
 }
@@ -50,7 +50,11 @@ ExitCode Io_Temperatures_ReadDieTemperatures(void)
             (uint32_t)(rx_internal_die_temp[2 + NUM_OF_RX_BYTES * current_ic]) |
             (uint32_t)(
                 (rx_internal_die_temp[3 + NUM_OF_RX_BYTES * current_ic] << 8));
-        internal_die_temperatures[current_ic] = (uint16_t)internal_die_temp;
+
+        // Calculate the internal die temperature using the following equation:
+        // DIE_TEMP = MEASURED_V * (1°C * 100µV / 7.6mV) - 276°C
+        internal_die_temperatures[current_ic] =
+            (float)internal_die_temp * 100e-6f / 7.6e-3f - 276.0f;
 
         // The received PEC15 bytes are stored in the 6th and 7th index.
         uint32_t received_pec15 =

--- a/boards/BMS/Src/Io/Io_Temperatures.c
+++ b/boards/BMS/Src/Io/Io_Temperatures.c
@@ -1,0 +1,72 @@
+#include <stdint.h>
+#include "Io_LTC6813.h"
+#include "Io_Temperatures.h"
+#include "Io_SharedSpi.h"
+#include "configs/App_CellConfigs.h"
+#include "configs/Io_LTC6813Configs.h"
+
+static uint16_t internal_die_temperatures[NUM_OF_CELL_MONITOR_ICS];
+
+uint16_t *Io_Temperatures_GetDieTemperatures(void)
+{
+    return internal_die_temperatures;
+}
+
+ExitCode Io_Temperatures_ReadDieTemperatures(void)
+{
+    // The command used to read data from status register A.
+    uint32_t RDSTATA = 0x0010;
+
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_EnterReadyState())
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_StartInternalDeviceConversions())
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_PollConversions())
+
+    uint8_t rx_internal_die_temp[NUM_OF_RX_BYTES * NUM_OF_CELL_MONITOR_ICS] = {
+        0
+    };
+    uint8_t tx_cmd[NUM_OF_CMD_BYTES];
+
+    tx_cmd[0] = (uint8_t)(RDSTATA >> 8);
+    tx_cmd[1] = (uint8_t)(RDSTATA);
+    uint16_t tx_cmd_pec15 =
+        Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
+    tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
+    tx_cmd[3] = (uint8_t)(tx_cmd_pec15);
+
+    for (enum CellMonitorICs current_ic = 0U;
+         current_ic < NUM_OF_CELL_MONITOR_ICS; current_ic++)
+    {
+        if (Io_SharedSpi_TransmitAndReceive(
+                Io_LTC6813_GetSpiInterface(), tx_cmd, NUM_OF_CMD_BYTES,
+                rx_internal_die_temp,
+                NUM_OF_CELL_MONITOR_ICS * NUM_OF_RX_BYTES) != HAL_OK)
+        {
+            return EXIT_CODE_ERROR;
+        }
+
+        // The upper 8 bytes of the internal die temperature is stored in the
+        // 3rd index, while the lower bytes are stored in the 2nd index.
+        uint32_t internal_die_temp =
+            (uint32_t)(rx_internal_die_temp[2 + NUM_OF_RX_BYTES * current_ic]) |
+            (uint32_t)(
+                (rx_internal_die_temp[3 + NUM_OF_RX_BYTES * current_ic] << 8));
+        internal_die_temperatures[current_ic] = (uint16_t)internal_die_temp;
+
+        // The received PEC15 bytes are stored in the 6th and 7th index.
+        uint32_t received_pec15 =
+            (uint32_t)(
+                rx_internal_die_temp[6 + NUM_OF_RX_BYTES * current_ic] << 8) |
+            (uint32_t)(rx_internal_die_temp[7 + NUM_OF_RX_BYTES * current_ic]);
+
+        // Calculate the PEC15 using the first 6 bytes of data received from the
+        // chip.
+        uint32_t calculated_pec15 = Io_LTC6813_CalculatePec15(
+            &rx_internal_die_temp[current_ic * NUM_OF_RX_BYTES], 6U);
+        if (received_pec15 != calculated_pec15)
+        {
+            return EXIT_CODE_ERROR;
+        }
+    }
+
+    return EXIT_CODE_OK;
+}

--- a/boards/BMS/Src/Io/Io_Temperatures.c
+++ b/boards/BMS/Src/Io/Io_Temperatures.c
@@ -7,12 +7,12 @@
 
 static float internal_die_temperatures[NUM_OF_CELL_MONITOR_ICS];
 
-float *Io_Temperatures_GetDieTemperatures(void)
+float *Io_Temperatures_GetDieTemperaturesDegC(void)
 {
     return internal_die_temperatures;
 }
 
-ExitCode Io_Temperatures_ReadDieTemperatures(void)
+ExitCode Io_Temperatures_ReadDieTemperaturesDegC(void)
 {
     // The command used to read data from status register A.
     uint32_t RDSTATA = 0x0010;

--- a/boards/BMS/Src/Io/Io_Temperatures.c
+++ b/boards/BMS/Src/Io/Io_Temperatures.c
@@ -33,7 +33,7 @@ ExitCode Io_Temperatures_ReadDieTemperaturesDegC(void)
     tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
     tx_cmd[3] = (uint8_t)(tx_cmd_pec15);
 
-    for (enum CellMonitorICs current_ic = 0U;
+    for (enum CellMonitorICs current_ic = CELL_MONITOR_IC_0;
          current_ic < NUM_OF_CELL_MONITOR_ICS; current_ic++)
     {
         if (Io_SharedSpi_TransmitAndReceive(
@@ -44,19 +44,19 @@ ExitCode Io_Temperatures_ReadDieTemperaturesDegC(void)
             return EXIT_CODE_ERROR;
         }
 
-        // The upper 8 bytes of the internal die temperature is stored in the
-        // 3rd index, while the lower bytes are stored in the 2nd index.
+        // The upper byte of the internal die temperature is stored in the
+        // 3rd byte, while the lower byte is stored in the 2nd byte.
         uint32_t internal_die_temp =
             (uint32_t)(rx_internal_die_temp[2 + NUM_OF_RX_BYTES * current_ic]) |
             (uint32_t)(
                 (rx_internal_die_temp[3 + NUM_OF_RX_BYTES * current_ic] << 8));
 
         // Calculate the internal die temperature using the following equation:
-        // DIE_TEMP = MEASURED_V * (1°C * 100µV / 7.6mV) - 276°C
+        // DIE_TEMP = MEASURED_100UV * (1°C * 100µV / 7.6mV) - 276°C
         internal_die_temperatures[current_ic] =
             (float)internal_die_temp * 100e-6f / 7.6e-3f - 276.0f;
 
-        // The received PEC15 bytes are stored in the 6th and 7th index.
+        // The received PEC15 bytes are stored in the 6th and 7th byte.
         uint32_t received_pec15 =
             (uint32_t)(
                 rx_internal_die_temp[6 + NUM_OF_RX_BYTES * current_ic] << 8) |

--- a/boards/shared/Inc/Io/Io_SharedSpi.h
+++ b/boards/shared/Inc/Io/Io_SharedSpi.h
@@ -27,20 +27,20 @@ struct SharedSpi *Io_SharedSpi_Create(
 
 /**
  * Set the NSS pin low for the given SPI interface.
- * @param spi The given SPI interface.
+ * @param spi_interface The given SPI interface.
  */
-void Io_SharedSpi_SetNssLow(const struct SharedSpi *spi);
+void Io_SharedSpi_SetNssLow(const struct SharedSpi *spi_interface);
 
 /**
  * Set the NSS pin high for the given SPI interface.
- * @param spi The given SPI interface.
+ * @param spi_interface The given SPI interface.
  */
-void Io_SharedSpi_SetNssHigh(const struct SharedSpi *spi);
+void Io_SharedSpi_SetNssHigh(const struct SharedSpi *spi_interface);
 
 /**
  * Transmit data to and receive data from the device connected to the given SPI
  * interface.
- * @param spi The given SPI interface.
+ * @param spi_interface The given SPI interface.
  * @param tx_buffer A pointer to the data buffer containing the data transmitted
  * to the device connected to the SPI interface.
  * @param tx_buffer_size The size of the tx_data buffer.
@@ -51,7 +51,7 @@ void Io_SharedSpi_SetNssHigh(const struct SharedSpi *spi);
  * @return The HAL status of the data transmission and reception.
  */
 HAL_StatusTypeDef Io_SharedSpi_TransmitAndReceive(
-    const struct SharedSpi *spi,
+    const struct SharedSpi *spi_interface,
     uint8_t *               tx_buffer,
     uint16_t                tx_buffer_size,
     uint8_t *               rx_buffer,
@@ -59,34 +59,34 @@ HAL_StatusTypeDef Io_SharedSpi_TransmitAndReceive(
 
 /**
  * Transmit data to the device connected to the given SPI interface.
- * @param spi The given SPI interface.
+ * @param spi_interface The given SPI interface.
  * @param tx_buffer A pointer to the data buffer containing the data transmitted
  * to the device connected to the SPI interface.
  * @param tx_buffer_size The size of the tx_data buffer.
- * @return The HAL status of the data transmission.
+ * @return The HAL status of the data transmission to the SPI interface.
  */
 HAL_StatusTypeDef Io_SharedSpi_Transmit(
-    const struct SharedSpi *spi,
+    const struct SharedSpi *spi_interface,
     uint8_t *               tx_buffer,
     uint16_t                tx_buffer_size);
 
 /**
  * Receive data from the device connected to the given SPI interface.
- * @param spi The given SPI interface.
+ * @param spi_interface The given SPI interface.
  * @param rx_buffer A pointer to the data buffer that stores the data received
  * from the device connected to the SPI interface.
  * @param rx_buffer_size The size of the rx_data buffer.
  * @return The HAL status of the data reception from the SPI interface.
  */
 HAL_StatusTypeDef Io_SharedSpi_Receive(
-    const struct SharedSpi *spi,
+    const struct SharedSpi *spi_interface,
     uint8_t *               rx_buffer,
     uint16_t                rx_buffer_size);
 
 /**
  * Transmit multiple copies of the a data packet to the device connected to the
  * given SPI interface without toggling the NSS pin.
- * @param spi The given SPI interface.
+ * @param spi_interface The given SPI interface.
  * @param tx_buffer A pointer to the data buffer containing the data transmitted
  * to the device connected to the SPI interface.
  * @param tx_buffer_size The size of the tx_data buffer.
@@ -95,7 +95,7 @@ HAL_StatusTypeDef Io_SharedSpi_Receive(
  * @return The HAL status of the data transmission to the SPI interface.
  */
 HAL_StatusTypeDef Io_SharedSpi_MultipleTransmitWithoutNssToggle(
-    const struct SharedSpi *spi,
+    const struct SharedSpi *spi_interface,
     uint8_t *               tx_buffer,
     uint16_t                tx_buffer_size,
     size_t                  num_tx_data_copies);
@@ -103,13 +103,13 @@ HAL_StatusTypeDef Io_SharedSpi_MultipleTransmitWithoutNssToggle(
 /**
  * Transmit data to the device connected to the given SPI interface without
  * toggling the NSS pin.
- * @param spi The given SPI interface.
+ * @param spi_interface The given SPI interface.
  * @param tx_data A pointer to the data buffer containing the data transmitted
  * to the device connected to the SPI interface.
  * @param tx_buffer_size The size of the tx_data buffer.
- * @return The HAL status of the data transmission.
+ * @return The HAL status of the data transmission to the SPI interface.
  */
 HAL_StatusTypeDef Io_SharedSpi_TransmitWithoutNssToggle(
-    const struct SharedSpi *spi,
+    const struct SharedSpi *spi_interface,
     uint8_t *               tx_buffer,
     uint16_t                tx_buffer_size);

--- a/boards/shared/Src/Io/Io_SharedSpi.c
+++ b/boards/shared/Src/Io/Io_SharedSpi.c
@@ -2,13 +2,6 @@
 #include <stdlib.h>
 #include "Io_SharedSpi.h"
 
-#define EXIT_IF_STATUS_NOT_OK(status, nss_port, nss_pin)          \
-    if ((status) != HAL_OK)                                       \
-    {                                                             \
-        HAL_GPIO_WritePin((nss_port), (nss_pin), GPIO_PIN_RESET); \
-        return (status);                                          \
-    }
-
 struct SharedSpi
 {
     SPI_HandleTypeDef *spi_handle;
@@ -25,77 +18,90 @@ struct SharedSpi *Io_SharedSpi_Create(
 {
     assert(spi_handle != NULL);
 
-    struct SharedSpi *spi = malloc(sizeof(struct SharedSpi));
-    assert(spi != NULL);
+    struct SharedSpi *spi_interface = malloc(sizeof(struct SharedSpi));
+    assert(spi_interface != NULL);
 
-    spi->spi_handle = spi_handle;
-    spi->nss_pin    = nss_pin;
-    spi->nss_port   = nss_port;
-    spi->timeout_ms = timeout_ms;
+    spi_interface->spi_handle = spi_handle;
+    spi_interface->nss_pin    = nss_pin;
+    spi_interface->nss_port   = nss_port;
+    spi_interface->timeout_ms = timeout_ms;
 
-    return spi;
+    return spi_interface;
 }
 
-void Io_SharedSpi_SetNssLow(const struct SharedSpi *const spi)
+void Io_SharedSpi_SetNssLow(const struct SharedSpi *const spi_interface)
 {
-    HAL_GPIO_WritePin(spi->nss_port, spi->nss_pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(
+        spi_interface->nss_port, spi_interface->nss_pin, GPIO_PIN_RESET);
 }
 
-void Io_SharedSpi_SetNssHigh(const struct SharedSpi *const spi)
+void Io_SharedSpi_SetNssHigh(const struct SharedSpi *const spi_interface)
 {
-    HAL_GPIO_WritePin(spi->nss_port, spi->nss_pin, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(
+        spi_interface->nss_port, spi_interface->nss_pin, GPIO_PIN_SET);
 }
 
 HAL_StatusTypeDef Io_SharedSpi_TransmitAndReceive(
-    const struct SharedSpi *const spi,
+    const struct SharedSpi *const spi_interface,
     uint8_t *                     tx_buffer,
     uint16_t                      tx_buffer_size,
     uint8_t *                     rx_buffer,
     uint16_t                      rx_buffer_size)
 
 {
-    Io_SharedSpi_SetNssLow(spi);
-    EXIT_IF_STATUS_NOT_OK(
-        HAL_SPI_Transmit(
-            spi->spi_handle, tx_buffer, tx_buffer_size, spi->timeout_ms),
-        spi->nss_port, spi->nss_pin)
-    EXIT_IF_STATUS_NOT_OK(
-        HAL_SPI_Receive(
-            spi->spi_handle, rx_buffer, rx_buffer_size, spi->timeout_ms),
-        spi->nss_port, spi->nss_pin)
-    Io_SharedSpi_SetNssHigh(spi);
+    Io_SharedSpi_SetNssLow(spi_interface);
+    HAL_StatusTypeDef status = HAL_SPI_Transmit(
+        spi_interface->spi_handle, tx_buffer, tx_buffer_size,
+        spi_interface->timeout_ms);
+    if (status != HAL_OK)
+    {
+        Io_SharedSpi_SetNssHigh(spi_interface);
+        return status;
+    }
+
+    status = HAL_SPI_Receive(
+        spi_interface->spi_handle, rx_buffer, rx_buffer_size,
+        spi_interface->timeout_ms);
+    if (status != HAL_OK)
+    {
+        Io_SharedSpi_SetNssHigh(spi_interface);
+        return (status);
+    }
+    Io_SharedSpi_SetNssHigh(spi_interface);
 
     return HAL_OK;
 }
 
 HAL_StatusTypeDef Io_SharedSpi_Transmit(
-    const struct SharedSpi *const spi,
+    const struct SharedSpi *const spi_interface,
     uint8_t *                     tx_buffer,
     uint16_t                      tx_buffer_size)
 {
-    Io_SharedSpi_SetNssLow(spi);
+    Io_SharedSpi_SetNssLow(spi_interface);
     HAL_StatusTypeDef status = HAL_SPI_Transmit(
-        spi->spi_handle, tx_buffer, tx_buffer_size, spi->timeout_ms);
-    Io_SharedSpi_SetNssHigh(spi);
+        spi_interface->spi_handle, tx_buffer, tx_buffer_size,
+        spi_interface->timeout_ms);
+    Io_SharedSpi_SetNssHigh(spi_interface);
 
     return status;
 }
 
 HAL_StatusTypeDef Io_SharedSpi_Receive(
-    const struct SharedSpi *const spi,
+    const struct SharedSpi *const spi_interface,
     uint8_t *                     rx_buffer,
     uint16_t                      rx_buffer_size)
 {
-    Io_SharedSpi_SetNssLow(spi);
+    Io_SharedSpi_SetNssLow(spi_interface);
     HAL_StatusTypeDef status = HAL_SPI_Receive(
-        spi->spi_handle, rx_buffer, rx_buffer_size, spi->timeout_ms);
-    Io_SharedSpi_SetNssHigh(spi);
+        spi_interface->spi_handle, rx_buffer, rx_buffer_size,
+        spi_interface->timeout_ms);
+    Io_SharedSpi_SetNssHigh(spi_interface);
 
     return status;
 }
 
 HAL_StatusTypeDef Io_SharedSpi_MultipleTransmitWithoutNssToggle(
-    const struct SharedSpi *const spi,
+    const struct SharedSpi *const spi_interface,
     uint8_t *                     tx_buffer,
     uint16_t                      tx_buffer_size,
     size_t                        num_tx_data_copies)
@@ -104,7 +110,8 @@ HAL_StatusTypeDef Io_SharedSpi_MultipleTransmitWithoutNssToggle(
     for (size_t i = 0U; i < num_tx_data_copies; i++)
     {
         status = HAL_SPI_Transmit(
-            spi->spi_handle, tx_buffer, tx_buffer_size, spi->timeout_ms);
+            spi_interface->spi_handle, tx_buffer, tx_buffer_size,
+            spi_interface->timeout_ms);
         if (status != HAL_OK)
         {
             return status;
@@ -115,10 +122,11 @@ HAL_StatusTypeDef Io_SharedSpi_MultipleTransmitWithoutNssToggle(
 }
 
 HAL_StatusTypeDef Io_SharedSpi_TransmitWithoutNssToggle(
-    const struct SharedSpi *const spi,
+    const struct SharedSpi *const spi_interface,
     uint8_t *                     tx_data,
     uint16_t                      tx_buffer_size)
 {
     return HAL_SPI_Transmit(
-        spi->spi_handle, tx_data, tx_buffer_size, spi->timeout_ms);
+        spi_interface->spi_handle, tx_data, tx_buffer_size,
+        spi_interface->timeout_ms);
 }


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Added Io code to read internal die temperatures

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
- Refactored IO layer. Broke the Io_LTC6813 down into Io_CellVoltages and Io_CellTemperatures.

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
- Performed hardware tests to read internal die temperatures from a daisy chain of ICs.

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
