### PR TITLE
Fix LTC6813 Transmit Command Function

### DIFF
--- a/boards/BMS/Inc/Io/Io_LTC6813.h
+++ b/boards/BMS/Inc/Io/Io_LTC6813.h
@@ -34,18 +34,13 @@ uint16_t Io_LTC6813_CalculatePec15(uint8_t *data_buffer, uint32_t size);
 ExitCode Io_LTC6813_EnterReadyState(void);
 
 /**
- * Start cell voltage conversions for all LTC6813 chips on the daisy chain.
- * @return EXIT_CODE_OK if the command to start cell voltage conversions is sent
- * successfully. Else, EXIT_CODE_ERROR.
+ * Send a command to all LTC6813 chips on the daisy chain.
+ * @param tx_cmd The given command that is transmitted to the LTC6813 chips on
+ * the daisy chain.
+ * @return EXIT_CODE_OK if the command was transmitted successfully. Else,
+ * EXIT_CODE_ERROR.
  */
-ExitCode Io_LTC6813_StartCellVoltageConversions(void);
-
-/**
- * Start internal device conversions for all LTC6813 chips on the daisy chain.
- * @return EXIT_CODE_OK if the command to start internal device conversions is
- * sent successfully. Else, EXIT_CODE_ERROR.
- */
-ExitCode Io_LTC6813_StartInternalDeviceConversions(void);
+ExitCode Io_LTC6813_SendCommand(uint32_t tx_cmd);
 
 /**
  * Wait for the completion of all ADC conversions for the LTC6813 chips on the

--- a/boards/BMS/Inc/Io/Io_LTC6813.h
+++ b/boards/BMS/Inc/Io/Io_LTC6813.h
@@ -27,9 +27,9 @@ uint16_t Io_LTC6813_CalculatePec15(uint8_t *data_buffer, uint32_t size);
 
 /**
  * Transition all LTC6813 chips on the daisy chain from the IDLE state to the
- * READY state.
+ * READY state
  * @return EXIT_CODE_OK if the SCK and NSS pin can be toggled successfully.
- * Else, EXIT_CODE_ERROR.
+ * Else, EXIT_CODE_ERROR
  */
 ExitCode Io_LTC6813_EnterReadyState(void);
 

--- a/boards/BMS/Inc/Io/Io_LTC6813.h
+++ b/boards/BMS/Inc/Io/Io_LTC6813.h
@@ -34,11 +34,11 @@ uint16_t Io_LTC6813_CalculatePec15(uint8_t *data_buffer, uint32_t size);
 ExitCode Io_LTC6813_EnterReadyState(void);
 
 /**
- * Send a command to all LTC6813 chips on the daisy chain.
+ * Send a command to all LTC6813 chips on the daisy chain
  * @param tx_cmd The given command that is transmitted to the LTC6813 chips on
- * the daisy chain.
+ * the daisy chain
  * @return EXIT_CODE_OK if the command was transmitted successfully. Else,
- * EXIT_CODE_ERROR.
+ * EXIT_CODE_ERROR
  */
 ExitCode Io_LTC6813_SendCommand(uint32_t tx_cmd);
 

--- a/boards/BMS/Inc/Io/configs/Io_LTC6813Configs.h
+++ b/boards/BMS/Inc/Io/configs/Io_LTC6813Configs.h
@@ -9,3 +9,8 @@
 // ADC timeout threshold of 10 was chosen arbitrarily.
 // TODO: Determine the ADC conversion timeout threshold #674
 #define ADC_TIMEOUT_CYCLES_THRESHOLD 10U
+
+#define MD 1U
+#define DCP 0U
+#define CH 0U
+#define CHST 0U

--- a/boards/BMS/Src/Io/Io_CellVoltages.c
+++ b/boards/BMS/Src/Io/Io_CellVoltages.c
@@ -112,8 +112,11 @@ ExitCode Io_CellVoltages_ReadRawCellVoltages(void)
         0
     };
 
+    // The command used to start ADC conversions for battery cell voltages.
+    const uint32_t ADCV = (0x260 + (MD << 7) + (DCP << 4) + CH);
+
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_EnterReadyState())
-    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_StartCellVoltageConversions())
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_SendCommand(ADCV))
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_PollConversions())
 
     for (enum CellVoltageRegisterGroup current_register_group =

--- a/boards/BMS/Src/Io/Io_LTC6813.c
+++ b/boards/BMS/Src/Io/Io_LTC6813.c
@@ -12,11 +12,6 @@
 #define VUV 0x4E1
 #define VOV 0x8CA
 
-#define MD 1U
-#define DCP 0U
-#define CH 0U
-#define CHST 0U
-
 static struct SharedSpi *spi_interface;
 
 static const uint16_t crc[UINT8_MAX + 1] = {
@@ -97,40 +92,18 @@ ExitCode Io_LTC6813_EnterReadyState(void)
     return EXIT_CODE_OK;
 }
 
-ExitCode Io_LTC6813_StartCellVoltageConversions(void)
+ExitCode Io_LTC6813_SendCommand(uint32_t tx_cmd)
 {
-    // The command used to start ADC conversions for battery cell voltages.
-    const uint32_t ADCV = (0x260 + (MD << 7) + (DCP << 4) + CH);
-
-    uint8_t tx_cmd[NUM_OF_CMD_BYTES];
-    tx_cmd[0] = (uint8_t)(ADCV >> 8);
-    tx_cmd[1] = (uint8_t)ADCV;
+    uint8_t _tx_cmd[NUM_OF_CMD_BYTES];
+    _tx_cmd[0] = (uint8_t)(tx_cmd >> 8);
+    _tx_cmd[1] = (uint8_t)(tx_cmd);
 
     uint16_t tx_cmd_pec15 =
-        Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
-    tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
-    tx_cmd[3] = (uint8_t)tx_cmd_pec15;
+        Io_LTC6813_CalculatePec15(_tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
+    _tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
+    _tx_cmd[3] = (uint8_t)(tx_cmd_pec15);
 
-    return (Io_SharedSpi_Transmit(spi_interface, tx_cmd, NUM_OF_CMD_BYTES) ==
-            HAL_OK)
-               ? EXIT_CODE_OK
-               : EXIT_CODE_ERROR;
-}
-
-ExitCode Io_LTC6813_StartInternalDeviceConversions(void)
-{
-    // The command used to start internal device conversions.
-    const uint32_t ADSTAT = (0x468 + (MD << 7) + CHST);
-
-    uint8_t tx_cmd[NUM_OF_CMD_BYTES];
-    tx_cmd[0] = (uint8_t)(ADSTAT >> 8);
-    tx_cmd[1] = (uint8_t)(ADSTAT);
-    uint16_t tx_cmd_pec15 =
-        Io_LTC6813_CalculatePec15(tx_cmd, NUM_OF_PEC15_BYTES_PER_CMD);
-    tx_cmd[2] = (uint8_t)(tx_cmd_pec15 >> 8);
-    tx_cmd[3] = (uint8_t)tx_cmd_pec15;
-
-    return (Io_SharedSpi_Transmit(spi_interface, tx_cmd, NUM_OF_CMD_BYTES) ==
+    return (Io_SharedSpi_Transmit(spi_interface, _tx_cmd, NUM_OF_CMD_BYTES) ==
             HAL_OK)
                ? EXIT_CODE_OK
                : EXIT_CODE_ERROR;

--- a/boards/BMS/Src/Io/Io_Temperatures.c
+++ b/boards/BMS/Src/Io/Io_Temperatures.c
@@ -9,11 +9,11 @@ static float internal_die_temperatures[NUM_OF_CELL_MONITOR_CHIPS];
 
 ExitCode Io_Temperatures_ReadDieTemperaturesDegC(void)
 {
-    // The command used to read data from status register A.
-    const uint32_t RDSTATA = 0x0010;
+    // The command used to start internal device conversions.
+    const uint32_t ADSTAT = (0x468 + (MD << 7) + CHST);
 
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_EnterReadyState())
-    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_StartInternalDeviceConversions())
+    RETURN_IF_EXIT_NOT_OK(Io_LTC6813_SendCommand(ADSTAT))
     RETURN_IF_EXIT_NOT_OK(Io_LTC6813_PollConversions())
 
     uint8_t
@@ -21,6 +21,9 @@ ExitCode Io_Temperatures_ReadDieTemperaturesDegC(void)
             0
         };
     uint8_t tx_cmd[NUM_OF_CMD_BYTES];
+
+    // The command used to read data from status register A.
+    const uint32_t RDSTATA = 0x0010;
 
     tx_cmd[0] = (uint8_t)(RDSTATA >> 8);
     tx_cmd[1] = (uint8_t)(RDSTATA);


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Removed Io_LTC6813_StartInternalDeviceConversions, Io_LTC6813_StartCellVoltageConversions, and replacing with Io_LTC6813_SendCommand.
- The command sent to the LTC6813 will be sent Io_CellVoltages and Io_Temperatures instead

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
