### PR TITLE
Fix Io_VoltageSense

### DIFF
--- a/boards/BMS/Inc/Io/Io_VoltageSense.h
+++ b/boards/BMS/Inc/Io/Io_VoltageSense.h
@@ -1,15 +1,8 @@
 #pragma once
 
-#include "App_SharedExitCode.h"
-
 /**
  * Convert the given ADC voltage to tractive system voltage
  * @param adc_voltage The ADC voltage to convert
- * @param tractive_system_voltage This will be set to the tractive system
- *                                voltage, in volts
- * @return EXIT_CODE_OUT_OF_RANGE if adc_voltage is negative
- *         EXIT_CODE_INVALID_ARGS if tractive_system_voltage is NULL
+ * @return The tractive system voltage in V
  */
-ExitCode Io_VoltageSense_GetTractiveSystemVoltage(
-    float  adc_voltage,
-    float *tractive_system_voltage);
+float Io_VoltageSense_GetTractiveSystemVoltage(float adc_voltage);

--- a/boards/BMS/Src/Io/Io_VoltageSense.c
+++ b/boards/BMS/Src/Io/Io_VoltageSense.c
@@ -1,24 +1,21 @@
-#include <stddef.h>
+#include <math.h>
 #include "Io_VoltageSense.h"
 
-ExitCode Io_VoltageSense_GetTractiveSystemVoltage(
-    float  adc_voltage,
-    float *tractive_system_voltage)
+float Io_VoltageSense_GetTractiveSystemVoltage(float adc_voltage)
 {
     if (adc_voltage < 0.0f)
-        return EXIT_CODE_OUT_OF_RANGE;
-
-    if (tractive_system_voltage == NULL)
-        return EXIT_CODE_INVALID_ARGS;
+    {
+        return NAN;
+    }
 
     // The tractive system voltage is divided down by several resistors, then
     // fed through an amplifier.
     //
     // TS Voltage
     //   -+-
-    //    |                                     +----------+  +-------------+
-    //    +--<499k>--<499k>--<499k>--<499k>--+--| Amplifier|--| ADC Channel |
-    //                                       |  +----------+  +-------------+
+    //    |                                     +-----------+  +-------------+
+    //    +--<499k>--<499k>--<499k>--<499k>--+--| Amplifier |--| ADC Channel |
+    //                                       |  +-----------+  +-------------+
     //                                       |
     //                                    <1.24k>
     //                                       |
@@ -43,7 +40,5 @@ ExitCode Io_VoltageSense_GetTractiveSystemVoltage(
         1.024e+3f / (499e+3f + 499e+3f + 499e+3f + 499e+3f + 1.024e+3f);
     const float amplifier_gain = 8.0f;
 
-    *tractive_system_voltage = adc_voltage / (voltage_ratio * amplifier_gain);
-
-    return EXIT_CODE_OK;
+    return adc_voltage / (voltage_ratio * amplifier_gain);
 }

--- a/boards/BMS/Src/Io/Io_VoltageSense.c
+++ b/boards/BMS/Src/Io/Io_VoltageSense.c
@@ -13,9 +13,9 @@ float Io_VoltageSense_GetTractiveSystemVoltage(float adc_voltage)
     //
     // TS Voltage
     //   -+-
-    //    |                                     +-----------+  +-------------+
-    //    +--<499k>--<499k>--<499k>--<499k>--+--| Amplifier |--| ADC Channel |
-    //                                       |  +-----------+  +-------------+
+    //    |                                     +----------+  +-------------+
+    //    +--<499k>--<499k>--<499k>--<499k>--+--| Amplifier|--| ADC Channel |
+    //                                       |  +----------+  +-------------+
     //                                       |
     //                                    <1.24k>
     //                                       |

--- a/boards/BMS/Test/Src/Test_VoltageSense.cpp
+++ b/boards/BMS/Test/Src/Test_VoltageSense.cpp
@@ -11,29 +11,16 @@ TEST(VoltageSenseTest, tractive_system_voltage_calculation)
     // Negative ADC voltage
     float adc_voltage =
         std::nextafter(0.0f, std::numeric_limits<float>::lowest());
-    float tractive_system_voltage = 0.0f;
-    ASSERT_EQ(
-        EXIT_CODE_OUT_OF_RANGE, Io_VoltageSense_GetTractiveSystemVoltage(
-                                    adc_voltage, &tractive_system_voltage));
+    ASSERT_TRUE(isnanf(Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage)));
 
     // Zero tractive system voltage (0V)
     adc_voltage = 0.0f;
     ASSERT_EQ(
-        EXIT_CODE_OK, Io_VoltageSense_GetTractiveSystemVoltage(
-                          adc_voltage, &tractive_system_voltage));
-    ASSERT_EQ(0.0f, tractive_system_voltage);
+        adc_voltage, Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage));
 
     // Nominal tractive system voltage (400V)
     adc_voltage =
         400.0f * 8.0f *
         (1.024e+3f / (1.024e+3f + 499e+3f + 499e+3f + 499e+3f + 499e+3f));
-    ASSERT_EQ(
-        EXIT_CODE_OK, Io_VoltageSense_GetTractiveSystemVoltage(
-                          adc_voltage, &tractive_system_voltage));
-    ASSERT_EQ(400.0f, tractive_system_voltage);
-
-    // Null pointer
-    ASSERT_EQ(
-        EXIT_CODE_INVALID_ARGS,
-        Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage, NULL));
+    ASSERT_EQ(400.0f, Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage));
 }

--- a/boards/BMS/Test/Src/Test_VoltageSense.cpp
+++ b/boards/BMS/Test/Src/Test_VoltageSense.cpp
@@ -19,8 +19,11 @@ TEST(VoltageSenseTest, tractive_system_voltage_calculation)
         adc_voltage, Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage));
 
     // Nominal tractive system voltage (400V)
+    constexpr float nominal_ts_voltage = 400.0f;
     adc_voltage =
-        400.0f * 8.0f *
+        nominal_ts_voltage * 8.0f *
         (1.024e+3f / (1.024e+3f + 499e+3f + 499e+3f + 499e+3f + 499e+3f));
-    ASSERT_EQ(400.0f, Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage));
+    ASSERT_EQ(
+        nominal_ts_voltage,
+        Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage));
 }


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Fix Io_VoltageSense

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
- Return floating point value instead of an ExitCode. This is done so that we can generate fake TS+ values when testing BMS-12

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
