### PR TITLE
Start DMA conversion triggered by TIM3 for BMS

### DIFF
--- a/boards/BMS/BMS.ioc
+++ b/boards/BMS/BMS.ioc
@@ -212,6 +212,7 @@ NVIC.PriorityGroup=NVIC_PRIORITYGROUP_4
 NVIC.SVCall_IRQn=true\:0\:0\:false\:false\:false\:false\:false\:false
 NVIC.SysTick_IRQn=true\:15\:0\:false\:false\:false\:true\:false\:true
 NVIC.TIM2_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true
+NVIC.TIM3_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true
 NVIC.TIM6_DAC_IRQn=true\:0\:0\:false\:false\:true\:false\:false\:true
 NVIC.TimeBase=TIM6_DAC_IRQn
 NVIC.TimeBaseIP=TIM6

--- a/boards/BMS/Inc/stm32f3xx_it.h
+++ b/boards/BMS/Inc/stm32f3xx_it.h
@@ -64,6 +64,7 @@ extern "C"
     void USB_LP_CAN_RX0_IRQHandler(void);
     void CAN_RX1_IRQHandler(void);
     void TIM2_IRQHandler(void);
+    void TIM3_IRQHandler(void);
     void TIM6_DAC_IRQHandler(void);
     void DMA2_Channel1_IRQHandler(void);
     /* USER CODE BEGIN EFP */

--- a/boards/BMS/Src/main.c
+++ b/boards/BMS/Src/main.c
@@ -42,6 +42,7 @@
 #include "Io_CellVoltages.h"
 #include "Io_Airs.h"
 #include "Io_PreCharge.h"
+#include "Io_Adc.h"
 
 #include "App_BmsWorld.h"
 #include "App_AccumulatorVoltages.h"
@@ -195,6 +196,15 @@ int main(void)
     MX_TIM3_Init();
     /* USER CODE BEGIN 2 */
     __HAL_DBGMCU_FREEZE_IWDG();
+
+    HAL_ADC_Start_DMA(
+        &hadc1, (uint32_t *)Io_Adc_GetRawAdc1Values(),
+        hadc1.Init.NbrOfConversion);
+    HAL_ADC_Start_DMA(
+        &hadc2, (uint32_t *)Io_Adc_GetRawAdc2Values(),
+        hadc2.Init.NbrOfConversion);
+    HAL_TIM_Base_Start(&htim3);
+
     Io_SharedHardFaultHandler_Init();
 
     Io_Imd_Init();

--- a/boards/BMS/Src/stm32f3xx_hal_msp.c
+++ b/boards/BMS/Src/stm32f3xx_hal_msp.c
@@ -423,6 +423,9 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim_base)
         /* USER CODE END TIM3_MspInit 0 */
         /* Peripheral clock enable */
         __HAL_RCC_TIM3_CLK_ENABLE();
+        /* TIM3 interrupt Init */
+        HAL_NVIC_SetPriority(TIM3_IRQn, 5, 0);
+        HAL_NVIC_EnableIRQ(TIM3_IRQn);
         /* USER CODE BEGIN TIM3_MspInit 1 */
 
         /* USER CODE END TIM3_MspInit 1 */
@@ -463,6 +466,9 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim_base)
         /* USER CODE END TIM3_MspDeInit 0 */
         /* Peripheral clock disable */
         __HAL_RCC_TIM3_CLK_DISABLE();
+
+        /* TIM3 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(TIM3_IRQn);
         /* USER CODE BEGIN TIM3_MspDeInit 1 */
 
         /* USER CODE END TIM3_MspDeInit 1 */

--- a/boards/BMS/Src/stm32f3xx_it.c
+++ b/boards/BMS/Src/stm32f3xx_it.c
@@ -63,6 +63,7 @@ extern DMA_HandleTypeDef hdma_adc1;
 extern DMA_HandleTypeDef hdma_adc2;
 extern CAN_HandleTypeDef hcan;
 extern TIM_HandleTypeDef htim2;
+extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim6;
 
 /* USER CODE BEGIN EV */
@@ -233,6 +234,20 @@ void TIM2_IRQHandler(void)
     /* USER CODE BEGIN TIM2_IRQn 1 */
 
     /* USER CODE END TIM2_IRQn 1 */
+}
+
+/**
+ * @brief This function handles TIM3 global interrupt.
+ */
+void TIM3_IRQHandler(void)
+{
+    /* USER CODE BEGIN TIM3_IRQn 0 */
+
+    /* USER CODE END TIM3_IRQn 0 */
+    HAL_TIM_IRQHandler(&htim3);
+    /* USER CODE BEGIN TIM3_IRQn 1 */
+
+    /* USER CODE END TIM3_IRQn 1 */
 }
 
 /**


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Start DMA conversion for ADC1 and ADC2 triggered by TIM3 for the BMS

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
- No testing done ATM, but since the FSM uses the same code and CUBEMX configs to trigger ADC conversions (tested with HW) I'm confident this should work as well

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
