### PR TITLE
Replaced all occurrences of isnanf with isnan to support newer compilers

### DIFF
--- a/boards/BMS/Test/Src/Test_SocVoting.cpp
+++ b/boards/BMS/Test/Src/Test_SocVoting.cpp
@@ -119,5 +119,5 @@ TEST_F(SocVotingTest, difference_is_larger_than_max_difference)
         App_Soc_Vote(
             std::nextafter(TEST_VALUE, std::numeric_limits<float>::lowest()),
             0.0f, TEST_VALUE, 2 * TEST_VALUE, &result));
-    ASSERT_TRUE(isnanf(result));
+    ASSERT_TRUE(isnan(result));
 }

--- a/boards/BMS/Test/Src/Test_VoltageSense.cpp
+++ b/boards/BMS/Test/Src/Test_VoltageSense.cpp
@@ -11,7 +11,7 @@ TEST(VoltageSenseTest, tractive_system_voltage_calculation)
     // Negative ADC voltage
     float adc_voltage =
         std::nextafter(0.0f, std::numeric_limits<float>::lowest());
-    ASSERT_TRUE(isnanf(Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage)));
+    ASSERT_TRUE(isnan(Io_VoltageSense_GetTractiveSystemVoltage(adc_voltage)));
 
     // Zero tractive system voltage (0V)
     adc_voltage = 0.0f;

--- a/boards/PDM/Test/Src/Test_StateMachine.cpp
+++ b/boards/PDM/Test/Src/Test_StateMachine.cpp
@@ -268,21 +268,21 @@ class PdmStateMachineTest : public BaseStateMachineTest
         // Normal Value
         fake_current = (min_current + max_current) / 2;
         LetTimePass(state_machine, 10);
-        EXPECT_TRUE(isnanf(current_can_signal_getter(can_tx_interface)));
+        EXPECT_TRUE(isnan(current_can_signal_getter(can_tx_interface)));
         EXPECT_EQ(ok_choice, out_of_range_can_signal_getter(can_tx_interface));
 
         // Under-current
         fake_current =
             std::nextafter(min_current, std::numeric_limits<float>::lowest());
         LetTimePass(state_machine, 10);
-        EXPECT_TRUE(isnanf(current_can_signal_getter(can_tx_interface)));
+        EXPECT_TRUE(isnan(current_can_signal_getter(can_tx_interface)));
         EXPECT_EQ(ok_choice, out_of_range_can_signal_getter(can_tx_interface));
 
         // Over-current
         fake_current =
             std::nextafter(max_current, std::numeric_limits<float>::max());
         LetTimePass(state_machine, 10);
-        EXPECT_TRUE(isnanf(current_can_signal_getter(can_tx_interface)));
+        EXPECT_TRUE(isnan(current_can_signal_getter(can_tx_interface)));
         EXPECT_EQ(ok_choice, out_of_range_can_signal_getter(can_tx_interface));
     }
 

--- a/scripts/codegen/CAN/cantx_codegen.py
+++ b/scripts/codegen/CAN/cantx_codegen.py
@@ -136,7 +136,7 @@ class AppCanTxFileGenerator(CanFileGenerator):
                         function_prefix, signal.snake_name.upper(), self._sender.capitalize(), signal.type_name),
                         '',
                         '''\
-    if (isnanf(value))
+    if (isnan(value))
     {{
         can_tx_interface->periodic_can_tx_table.{msg_snakecase_name}.{signal_snakecase_name} = value;
     }}


### PR DESCRIPTION
### Summary
Replaced all occurrences of `isnanf` with `isnan` to support newer compilers. This was done because the `isnanf` function is considered obsolete. Instead, the `isnan(float x)` function was declared as a replacement in C99 (see [here](https://linux.die.net/man/3/isnanf) under **Notes**).

### Changelist 
- Renamed all occurrences of `isnanf` with the `isnan(float x)` macro in the source code
- Modified CAN generation Python script to use `isnan` also

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
