### PR TITLE
Fix MinGW Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ sudo apt-get install openocd
   * Python 3+ (*Python < 3 will NOT work*): https://www.python.org/downloads/
   * ARM GNU Embedded Toolchain: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads (Check `install_gcc_arm_none_eabi.sh` for which version to download)
   * STM32CubeMX: https://www.st.com/en/development-tools/stm32cubemx.html
-  * MinGW: https://sourceforge.net/projects/mingw-w64/ (**select 32-bit verison/i686 architecture**)
+  * MinGW: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe/download (**select 32-bit verison/i686 architecture**)
 
 ##### Mac OS
 First, install Homebrew and CLion. Then install the following programs using Homebrew:


### PR DESCRIPTION
### Summary
MinGW link pointed to zip file before. Fixed it to link a proper MinGW executable download
