### PR TITLE
Update Pipfile to point cantools package to forked version with no doubles

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 pylint = "*"
 
 [packages]
-cantools = "~=33.1.1"
+cantools = {ref = "v33.1.1-noDoubles", git = "git://github.com/UBCFormulaElectric/cantools"}
 
 [requires]
 python_version = "3"

--- a/boards/BMS/Inc/stm32f3xx_hal_conf.h
+++ b/boards/BMS/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2021 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2022 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/DCM/Inc/stm32f3xx_hal_conf.h
+++ b/boards/DCM/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2021 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2022 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/DIM/Inc/stm32f3xx_hal_conf.h
+++ b/boards/DIM/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2021 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2022 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/FSM/Inc/stm32f3xx_hal_conf.h
+++ b/boards/FSM/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2021 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2022 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/boards/PDM/Inc/stm32f3xx_hal_conf.h
+++ b/boards/PDM/Inc/stm32f3xx_hal_conf.h
@@ -5,7 +5,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2021 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2022 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:


### PR DESCRIPTION
### Summary
Updated Pipfile to install the cantools package from FormulaE [fork](https://github.com/UBCFormulaElectric/cantools), removing the usage of doubles in `encode()` and `decode()` functions. V33.1.1 is still maintained.

Motivation: Some of the inverter CAN signals have an offset of 0.1 and thus require the encode() and decode() functions. The use of doubles in the autogenerated encode() and decode() functions are unnecessary since it increases the execution time (STM32F4's FPU supports floats only). Therefore, I updated cantools to generate code that uses floats instead of doubles.

Before App_CanMsgs.c:
![image](https://user-images.githubusercontent.com/55927496/152293563-5c590f54-7760-4714-926a-7e7df19942bb.png)

After App_CanMsgs.c:
![image](https://user-images.githubusercontent.com/55927496/152294038-a9450c94-2a57-42f0-9ee4-8d873b12bbc5.png)

### Changelist 
- Updated Pipfile to install the cantools package from FormulaE [fork](https://github.com/UBCFormulaElectric/cantools). 
- Updated year of stm32f3xx_hal_conf.h file in each board folder from 2021 to 2022

### Testing Done

1. Entered  `pipenv uninstall -all` in the command line to uninstall all packages without modifying the Pipfile.  
2. Entered `pipenv install` to re-install all packages including cantools which is now located at the fork.
3. Built .elf file to see that doubles had changed to floats in App_CanMsgs.h and App_CanMsgs.c



### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
