### PR TITLE
Add support for differential ADC mode

### DIFF
--- a/boards/BMS/Src/Io/Io_Adc.c
+++ b/boards/BMS/Src/Io/Io_Adc.c
@@ -49,19 +49,19 @@ void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
     {
         adc1_voltages[ADC1_CHANNEL_3] =
             Io_SharedAdc_ConvertRawAdcValueToVoltage(
-                hadc, raw_adc1_values[ADC1_CHANNEL_3]);
+                hadc, false, raw_adc1_values[ADC1_CHANNEL_3]);
     }
     else if (hadc->Instance == ADC2)
     {
         adc2_voltages[ADC2_CHANNEL_1] =
             Io_SharedAdc_ConvertRawAdcValueToVoltage(
-                hadc, raw_adc2_values[ADC2_CHANNEL_1]);
+                hadc, false, raw_adc2_values[ADC2_CHANNEL_1]);
         adc2_voltages[ADC2_CHANNEL_3] =
             Io_SharedAdc_ConvertRawAdcValueToVoltage(
-                hadc, raw_adc2_values[ADC2_CHANNEL_3]);
+                hadc, false, raw_adc2_values[ADC2_CHANNEL_3]);
         adc2_voltages[ADC2_CHANNEL_4] =
             Io_SharedAdc_ConvertRawAdcValueToVoltage(
-                hadc, raw_adc2_values[ADC2_CHANNEL_4]);
+                hadc, false, raw_adc2_values[ADC2_CHANNEL_4]);
     }
 }
 

--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -189,6 +189,8 @@ function(create_arm_binary
             -Wundef
             -fstack-usage
             -Wconversion
+            -Wno-unused-variable
+            -Wno-unused-parameter
         )
     target_link_options(${BOARD_NAME}.elf
         PUBLIC

--- a/boards/DIM/Src/Io/Io_Adc.c
+++ b/boards/DIM/Src/Io/Io_Adc.c
@@ -36,7 +36,7 @@ static float    adc_voltages[NUM_ADC_CHANNELS];
 void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
 {
     adc_voltages[CHANNEL_12] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_12]);
+        hadc, false, raw_adc_values[CHANNEL_12]);
 }
 
 uint16_t *Io_Adc_GetRawAdcValues(void)

--- a/boards/FSM/Src/Io/Io_Adc.c
+++ b/boards/FSM/Src/Io/Io_Adc.c
@@ -37,9 +37,9 @@ static float    adc_voltages[NUM_ADC_CHANNELS];
 void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
 {
     adc_voltages[CHANNEL_1] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_1]);
+        hadc, false, raw_adc_values[CHANNEL_1]);
     adc_voltages[CHANNEL_3] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_3]);
+        hadc, false, raw_adc_values[CHANNEL_3]);
 }
 
 uint16_t *Io_Adc_GetRawAdcValues(void)

--- a/boards/PDM/Src/Io/Io_Adc.c
+++ b/boards/PDM/Src/Io/Io_Adc.c
@@ -42,19 +42,19 @@ static float    adc_voltages[NUM_ADC_CHANNELS];
 void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
 {
     adc_voltages[CHANNEL_1] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_1]);
+        hadc, false, raw_adc_values[CHANNEL_1]);
     adc_voltages[CHANNEL_2] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_2]);
+        hadc, false, raw_adc_values[CHANNEL_2]);
     adc_voltages[CHANNEL_3] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_3]);
+        hadc, false, raw_adc_values[CHANNEL_3]);
     adc_voltages[CHANNEL_6] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_6]);
+        hadc, false, raw_adc_values[CHANNEL_6]);
     adc_voltages[CHANNEL_7] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_7]);
+        hadc, false, raw_adc_values[CHANNEL_7]);
     adc_voltages[CHANNEL_8] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_8]);
+        hadc, false, raw_adc_values[CHANNEL_8]);
     adc_voltages[CHANNEL_9] = Io_SharedAdc_ConvertRawAdcValueToVoltage(
-        hadc, raw_adc_values[CHANNEL_9]);
+        hadc, false, raw_adc_values[CHANNEL_9]);
 }
 
 uint16_t *Io_Adc_GetRawAdcValues(void)

--- a/boards/shared/Inc/Io/Io_SharedAdc.h
+++ b/boards/shared/Inc/Io/Io_SharedAdc.h
@@ -1,13 +1,16 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stm32f3xx.h>
 
 /**
  * Convert the given raw ADC value measured by the given ADC handle into voltage
  * @param hadc ADC handle
+ * @param is_differential True if the ADC channel has a differential input
  * @param raw_adc_value Raw ADC value
  * @return The voltage converted from the given raw ADC value
  */
 float Io_SharedAdc_ConvertRawAdcValueToVoltage(
     ADC_HandleTypeDef *hadc,
+    bool               is_differential,
     uint16_t           raw_adc_value);

--- a/boards/shared/Src/Io/Io_SharedAdc.c
+++ b/boards/shared/Src/Io/Io_SharedAdc.c
@@ -48,8 +48,16 @@ float Io_SharedAdc_ConvertRawAdcValueToVoltage(
     //   with 12-bit resolution, it will be 2^12 -1 = 4095 or with 8-bit
     //   resolution, 2^8 - 1 = 255.
 
-    const float v_scale =
-        is_differential ? DIFFERENTIAL_ADC_V_SCALE : SINGLE_ENDED_ADC_V_SCALE;
+    float voltage = 0.0f;
+    if (is_differential)
+    {
+        voltage = DIFFERENTIAL_ADC_V_SCALE * (int16_t)raw_adc_value /
+                  (float)full_scale;
+    }
+    else
+    {
+        voltage = SINGLE_ENDED_ADC_V_SCALE * raw_adc_value / (float)full_scale;
+    }
 
-    return (v_scale * raw_adc_value) / (float)full_scale;
+    return voltage;
 }

--- a/boards/shared/Src/Io/Io_SharedAdc.c
+++ b/boards/shared/Src/Io/Io_SharedAdc.c
@@ -1,47 +1,55 @@
-#include "App_SharedConstants.h"
 #include "Io_SharedAdc.h"
+#include "App_SharedConstants.h"
+
+#define SINGLE_ENDED_ADC_V_SCALE (3.3f)
+#define DIFFERENTIAL_ADC_V_SCALE (6.6f)
 
 float Io_SharedAdc_ConvertRawAdcValueToVoltage(
     ADC_HandleTypeDef *hadc,
+    bool               is_differential,
     uint16_t           raw_adc_value)
 {
-    uint32_t full_scale;
+    uint16_t full_scale = MAX_12_BITS_VALUE;
 
     switch (hadc->Init.Resolution)
     {
         case ADC_RESOLUTION_6B:
-        {
             full_scale = MAX_6_BITS_VALUE;
-        }
-        break;
+            break;
+
         case ADC_RESOLUTION_8B:
-        {
             full_scale = MAX_8_BITS_VALUE;
-        }
-        break;
+            break;
+
         case ADC_RESOLUTION_10B:
-        {
             full_scale = MAX_10_BITS_VALUE;
-        }
-        break;
+            break;
+
         case ADC_RESOLUTION_12B:
-        {
             full_scale = MAX_12_BITS_VALUE;
-        }
-        break;
+            break;
+
+        default:
+            full_scale = MAX_12_BITS_VALUE;
+            break;
     }
 
     // Taken from the STM32 manual, the formula to convert the raw ADC
     // measurements to an absolute voltage value is as follows:
     //
-    //                   VDDA (3.3V) x ADC_DATAx
-    //    V_CHANNELx = ----------------------------
-    //                         FULL_SCALE
+    //                   V_SCALE (VDDA or 2VDDA) x ADC_DATAx
+    //    V_CHANNELx = ---------------------------------------
+    //                               FULL_SCALE
     // where:
+    // - V_SCALE depends on whether the ADC is configured as a single ended or
+    // differential input
     // - ADC_DATAx is the value measured by the ADC on channel x (right-aligned)
     // - FULL_SCALE is the maximum digital value of the ADC output. For example
     //   with 12-bit resolution, it will be 2^12 -1 = 4095 or with 8-bit
     //   resolution, 2^8 - 1 = 255.
 
-    return (3.3f * raw_adc_value) / (float)full_scale;
+    const float v_scale =
+        is_differential ? DIFFERENTIAL_ADC_V_SCALE : SINGLE_ENDED_ADC_V_SCALE;
+
+    return (v_scale * raw_adc_value) / (float)full_scale;
 }


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Wanted this to get merged in before Edwin's precharge branch as we currently dont have a nice way to distinguish differential and single ended ADC modes. This is a quick fix, will try to improve later

- Support ADC differential mode (refer to Io_SharedAdc.c)
- Slight modification to Io_Adc.c (refer to Io_Adc.c for the BMS)
- still need to test and also need to update Io_Adc.c for other boards (updated for only BMS currently), but feel free to review in the meantime

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
