### PR TITLE
Write to LTC-6813 config registers starting from the last segment

### DIFF
--- a/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
+++ b/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
@@ -176,8 +176,8 @@ static void Io_PrepareCfgRegBytes(
     {
         // Configuration registers are written to serially starting from the
         // last segment
-        const int32_t tx_cfg_idx =
-            NUM_OF_ACCUMULATOR_SEGMENTS - (int32_t)curr_segment - 1;
+        const uint8_t tx_cfg_idx =
+            (uint8_t)(NUM_OF_ACCUMULATOR_SEGMENTS - curr_segment - 1);
 
         // Set default tx_cfg for each segment
         memcpy(

--- a/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
+++ b/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
@@ -171,7 +171,7 @@ static void Io_PrepareCfgRegBytes(
         &min_cell_segment, &min_cell_index);
 
     // Write to the configuration registers of each segment
-    for (uint8_t curr_segment = 0;
+    for (uint8_t curr_segment = 0U;
          (int8_t)curr_segment < NUM_OF_ACCUMULATOR_SEGMENTS; curr_segment++)
     {
         // Configuration registers are written to serially starting from the

--- a/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
+++ b/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
@@ -171,11 +171,11 @@ static void Io_PrepareCfgRegBytes(
         &min_cell_segment, &min_cell_index);
 
     // Write to the configuration registers of each segment
-    for (uint8_t curr_segment = 0U;
-         curr_segment < NUM_OF_ACCUMULATOR_SEGMENTS; curr_segment++)
+    for (uint8_t curr_segment = 0U; curr_segment < NUM_OF_ACCUMULATOR_SEGMENTS;
+         curr_segment++)
     {
-        // Configuration registers are written to serially starting from the
-        // last segment
+        // Data used to configure the last segment on the daisy chain needs to
+        // be sent first
         const uint8_t tx_cfg_idx =
             (uint8_t)(NUM_OF_ACCUMULATOR_SEGMENTS - curr_segment - 1);
 

--- a/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
+++ b/boards/BMS/Src/Io/Io_LTC6813/Io_LTC6813Shared.c
@@ -172,7 +172,7 @@ static void Io_PrepareCfgRegBytes(
 
     // Write to the configuration registers of each segment
     for (uint8_t curr_segment = 0U;
-         (int8_t)curr_segment < NUM_OF_ACCUMULATOR_SEGMENTS; curr_segment++)
+         curr_segment < NUM_OF_ACCUMULATOR_SEGMENTS; curr_segment++)
     {
         // Configuration registers are written to serially starting from the
         // last segment


### PR DESCRIPTION
### Summary
Quick index adjustment so that the BMS core does in fact write to the LTC config registers starting from the last segment to the first segment as expected from pg. 56 in the datasheet.

### Changelist 
- `Io_LTC6813Shared.c` : change indexing to reflect above statement  

### Testing Done
- Tested using accumulator segments, all discharge LEDs are on **except** for the first cell of the first segment on start-up since `min_cell_segment` = 0 and `min_cell_index` = 0

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
