### PR TITLE
DCM Quick Fixes: Load switches, reverse wheel direction, init->drive checks, torque limit

### DIFF
--- a/boards/DCM/Inc/App/configs/App_TorqueRequestThresholds.h
+++ b/boards/DCM/Inc/App/configs/App_TorqueRequestThresholds.h
@@ -2,4 +2,4 @@
 
 // Maximum torque request
 // TODO: Have separate maximum torque requests for motoring and generating
-#define MAX_TORQUE_REQUEST_NM 50.0f;
+#define MAX_TORQUE_REQUEST_NM (50.0f);

--- a/boards/DCM/Inc/App/configs/App_TorqueRequestThresholds.h
+++ b/boards/DCM/Inc/App/configs/App_TorqueRequestThresholds.h
@@ -1,9 +1,5 @@
 #pragma once
 
-/**
- * @brief Maximum torque request to get the maximum motor current per Emrax
- * specification.
- *
- * @see Setting up the Controller to run with Emrax Motor Rev 1.2 PDF pg. 6
- */
-#define MAX_TORQUE_REQUEST_NM 132.0f;
+// Maximum torque request
+// TODO: Have separate maximum torque requests for motoring and generating
+#define MAX_TORQUE_REQUEST_NM 50.0f;

--- a/boards/DCM/Inc/App/states/App_SharedStates.h
+++ b/boards/DCM/Inc/App/states/App_SharedStates.h
@@ -4,20 +4,6 @@
 #include "configs/App_RegenThresholds.h"
 
 /**
- * Check if both AIRs are closed
- * @param can_rx_interface The CAN Rx interface to get the CAN signals from
- * @return true if both AIRs are closed, false otherwise
- */
-static inline bool App_SharedStates_AreBothAIRsClosed(
-    const struct DcmCanRxInterface *can_rx_interface)
-{
-    return App_CanRx_BMS_AIR_STATES_GetSignal_AIR_POSITIVE(can_rx_interface) ==
-               CANMSGS_BMS_AIR_STATES_AIR_POSITIVE_CLOSED_CHOICE &&
-           App_CanRx_BMS_AIR_STATES_GetSignal_AIR_NEGATIVE(can_rx_interface) ==
-               CANMSGS_BMS_AIR_STATES_AIR_NEGATIVE_CLOSED_CHOICE;
-}
-
-/**
  * Check if an inverter has faulted
  * @param can_rx_interface The CAN Rx interface to get the CAN signals from
  * @return true if an inverter has faulted, false otherwise

--- a/boards/DCM/Src/App/App_SetPeriodicCanSignals.c
+++ b/boards/DCM/Src/App/App_SetPeriodicCanSignals.c
@@ -7,12 +7,26 @@
 STATIC_DEFINE_APP_SET_PERIODIC_CAN_SIGNALS_IN_RANGE_CHECK(DcmCanTxInterface)
 
 /**
+ * Check if both AIRs are closed
+ * @param can_rx_interface The CAN Rx interface to get the CAN signals from
+ * @return true if both AIRs are closed, false otherwise
+ */
+static inline bool
+    App_AreBothAIRsClosed(const struct DcmCanRxInterface *can_rx_interface)
+{
+    return App_CanRx_BMS_AIR_STATES_GetSignal_AIR_POSITIVE(can_rx_interface) ==
+               CANMSGS_BMS_AIR_STATES_AIR_POSITIVE_CLOSED_CHOICE &&
+           App_CanRx_BMS_AIR_STATES_GetSignal_AIR_NEGATIVE(can_rx_interface) ==
+               CANMSGS_BMS_AIR_STATES_AIR_NEGATIVE_CLOSED_CHOICE;
+}
+
+/**
  * Check if vehicle is over the regen threshold defined by vehicle wheel speed
  * (EV.4.1.3)
  * @param can_rx_interface The CAN Rx interface to get the CAN signals from
  * @return true if the vehicle is over the regen threshold, false otherwise
  */
-static inline bool App_SharedStates_IsVehicleOverRegenThresh(
+static inline bool App_IsVehicleOverRegenThresh(
     const struct DcmCanRxInterface *can_rx_interface)
 {
     return (App_CanRx_FSM_WHEEL_SPEED_SENSOR_GetSignal_LEFT_WHEEL_SPEED(
@@ -31,8 +45,7 @@ void App_SetPeriodicCanSignals_TorqueRequests(const struct DcmWorld *world)
     // Regen allowed when wheel speed > REGEN_WHEEL_SPEED_THRESHOLD_KPH and AIRs
     // closed
     const bool is_regen_allowed =
-        App_SharedStates_AreBothAIRsClosed(can_rx) &&
-        App_SharedStates_IsVehicleOverRegenThresh(can_rx);
+        App_AreBothAIRsClosed(can_rx) && App_IsVehicleOverRegenThresh(can_rx);
 
     const float regen_paddle_percentage =
         (float)App_CanRx_DIM_REGEN_PADDLE_GetSignal_MAPPED_PADDLE_POSITION(

--- a/boards/DCM/Src/App/states/App_InitState.c
+++ b/boards/DCM/Src/App/states/App_InitState.c
@@ -6,12 +6,25 @@
 #include "App_SharedMacros.h"
 
 /**
+ * Check if the BMS is in the DRIVE state (both AIRs closed, pre-charge
+ * complete, charge not connected)
+ * @param can_rx_interface The CAN Rx interface to get the CAN signals from
+ * @return True if the BMS is in the DRIVE state, false otherwise
+ */
+static inline bool
+    App_IsBMSInDriveState(const struct DcmCanRxInterface *can_rx_interface)
+{
+    return App_CanRx_BMS_STATE_MACHINE_GetSignal_STATE(can_rx_interface) ==
+           CANMSGS_BMS_STATE_MACHINE_STATE_DRIVE_CHOICE;
+}
+
+/**
  * Check if the brake pedal is actuated
  * @param can_rx_interface The CAN Rx interface to get the CAN signals from
  * @return true if the brake is actuated, false otherwise
  */
-static inline bool App_InitState_IsBrakeActuated(
-    const struct DcmCanRxInterface *can_rx_interface)
+static inline bool
+    App_IsBrakeActuated(const struct DcmCanRxInterface *can_rx_interface)
 {
     return App_CanRx_FSM_BRAKE_GetSignal_BRAKE_IS_ACTUATED(can_rx_interface) ==
            CANMSGS_FSM_BRAKE_BRAKE_IS_ACTUATED_TRUE_CHOICE;
@@ -21,6 +34,8 @@ static void InitStateRunOnEntry(struct StateMachine *const state_machine)
 {
     struct DcmWorld *world = App_SharedStateMachine_GetWorld(state_machine);
     struct DcmCanTxInterface *can_tx_interface = App_DcmWorld_GetCanTx(world);
+    struct InverterSwitches * inverter_switches =
+        App_DcmWorld_GetInverterSwitches(world);
 
     App_CanTx_SetPeriodicSignal_STATE(
         can_tx_interface, CANMSGS_DCM_STATE_MACHINE_STATE_INIT_CHOICE);
@@ -38,6 +53,10 @@ static void InitStateRunOnEntry(struct StateMachine *const state_machine)
     App_CanTx_SetPeriodicSignal_TORQUE_COMMAND_INVR(
         can_tx_interface,
         App_CanMsgs_dcm_invr_command_message_torque_command_invr_encode(0.0f));
+
+    // Turn on inverter load switches
+    App_InverterSwitches_TurnOnRight(inverter_switches);
+    App_InverterSwitches_TurnOnLeft(inverter_switches);
 }
 
 static void InitStateRunOnTick1Hz(struct StateMachine *const state_machine)
@@ -52,26 +71,6 @@ static void InitStateRunOnTick100Hz(struct StateMachine *const state_machine)
     struct DcmWorld *world = App_SharedStateMachine_GetWorld(state_machine);
     struct DcmCanRxInterface *can_rx_interface = App_DcmWorld_GetCanRx(world);
     struct ErrorTable *       error_table = App_DcmWorld_GetErrorTable(world);
-    struct InverterSwitches * inverter_switches =
-        App_DcmWorld_GetInverterSwitches(world);
-
-#ifdef DEBUG // Enter drive state directly from init state
-    App_SharedStateMachine_SetNextState(state_machine, App_GetDriveState());
-    return;
-#endif
-
-    // Provide LV to inverters when both AIRS are closed and DC bus voltage ~
-    // 400 V
-    if (App_SharedStates_AreBothAIRsClosed(can_rx_interface) &&
-        !App_InverterSwitches_IsRightOn(inverter_switches))
-    {
-        App_InverterSwitches_TurnOnRight(inverter_switches);
-    }
-    if (App_SharedStates_AreBothAIRsClosed(can_rx_interface) &&
-        !App_InverterSwitches_IsLeftOn(inverter_switches))
-    {
-        App_InverterSwitches_TurnOnLeft(inverter_switches);
-    }
 
     // Holds previous start switch position (true = UP/ON, false = DOWN/OFF)
     // Initialize to true to prevent a false start
@@ -90,9 +89,8 @@ static void InitStateRunOnTick100Hz(struct StateMachine *const state_machine)
         next_state = App_GetFaultState();
     }
     else if (
-        App_SharedStates_AreBothAIRsClosed(can_rx_interface) &&
-        App_InitState_IsBrakeActuated(can_rx_interface) &&
-        was_start_switch_pulled_up)
+        App_IsBMSInDriveState(can_rx_interface) &&
+        App_IsBrakeActuated(can_rx_interface) && was_start_switch_pulled_up)
     {
         // Transition to drive state when start-up conditions are passed (see
         // EV.10.4.3):

--- a/boards/DCM/Test/Src/Test_StateMachine.cpp
+++ b/boards/DCM/Test/Src/Test_StateMachine.cpp
@@ -193,18 +193,13 @@ TEST_F(
         App_GetInitState(),
         App_SharedStateMachine_GetCurrentState(state_machine));
 
-    // Close AIR+ and AIR-, expect no transition and inverter switches to be
-    // closed
-    App_CanRx_BMS_AIR_STATES_SetSignal_AIR_POSITIVE(
-        can_rx_interface, CANMSGS_BMS_AIR_STATES_AIR_POSITIVE_CLOSED_CHOICE);
-    App_CanRx_BMS_AIR_STATES_SetSignal_AIR_NEGATIVE(
-        can_rx_interface, CANMSGS_BMS_AIR_STATES_AIR_NEGATIVE_CLOSED_CHOICE);
+    // Transition BMS to drive state, expect no transition
+    App_CanRx_BMS_STATE_MACHINE_SetSignal_STATE(
+        can_rx_interface, CANMSGS_BMS_STATE_MACHINE_STATE_DRIVE_CHOICE);
     LetTimePass(state_machine, 10);
     EXPECT_EQ(
         App_GetInitState(),
         App_SharedStateMachine_GetCurrentState(state_machine));
-    ASSERT_EQ(turn_on_right_inverter_fake.call_count, 1);
-    ASSERT_EQ(turn_on_left_inverter_fake.call_count, 1);
 
     // Actuate brake pedal
     App_CanRx_FSM_BRAKE_SetSignal_BRAKE_IS_ACTUATED(
@@ -715,35 +710,6 @@ TEST_F(
         0.0f,
         App_CanMsgs_dcm_invr_command_message_torque_command_invr_decode(
             App_CanTx_GetPeriodicSignal_TORQUE_COMMAND_INVR(can_tx_interface)));
-}
-
-// DCM21
-TEST_F(DcmStateMachineTest, inverter_switches_closed_when_AIRS_closed)
-{
-    // Both inverter switches are open to begin with
-    ASSERT_EQ(turn_on_right_inverter_fake.call_count, 0);
-    ASSERT_EQ(turn_on_left_inverter_fake.call_count, 0);
-
-    // Close AIR-, both inverter switches should still be open
-    App_CanRx_BMS_AIR_STATES_SetSignal_AIR_NEGATIVE(
-        can_rx_interface, CANMSGS_BMS_AIR_STATES_AIR_NEGATIVE_CLOSED_CHOICE);
-    LetTimePass(state_machine, 10);
-    ASSERT_EQ(turn_on_right_inverter_fake.call_count, 0);
-    ASSERT_EQ(turn_on_left_inverter_fake.call_count, 0);
-
-    // Close AIR+, both inverter switches should now be closed
-    App_CanRx_BMS_AIR_STATES_SetSignal_AIR_POSITIVE(
-        can_rx_interface, CANMSGS_BMS_AIR_STATES_AIR_POSITIVE_CLOSED_CHOICE);
-    LetTimePass(state_machine, 10);
-    ASSERT_EQ(turn_on_right_inverter_fake.call_count, 1);
-    ASSERT_EQ(turn_on_left_inverter_fake.call_count, 1);
-
-    // Left and right inverter should be closed once
-    is_right_inverter_on_fake.return_val = true;
-    is_left_inverter_on_fake.return_val  = true;
-    LetTimePass(state_machine, 10);
-    ASSERT_EQ(turn_on_right_inverter_fake.call_count, 1);
-    ASSERT_EQ(turn_on_left_inverter_fake.call_count, 1);
 }
 
 TEST_F(DcmStateMachineTest, init_to_fault_state_on_left_inverter_fault)

--- a/scripts/codegen/CAN/App_CanMsgs.dbc
+++ b/scripts/codegen/CAN/App_CanMsgs.dbc
@@ -330,7 +330,7 @@ SG_ Duty_Cycle : 0|32@1- (1,0) [0|1E2] "%" DEBUG
 SG_ Frequency : 32|32@1- (1,0) [0|1E4] "Hz" DEBUG
 
 BO_ 107 BMS_STATE_MACHINE : 1 BMS
-SG_ State : 0|8@1+ (1,0) [0|255] "" DEBUG
+SG_ State : 0|8@1+ (1,0) [0|255] "" DCM
 
 BO_ 108 BMS_STATE_OF_CHARGE: 4 BMS
 SG_ State_Of_Charge : 0|32@1- (1,0) [0|1E2] "%" DIM
@@ -588,6 +588,7 @@ BA_DEF_DEF_  "GenSigStartValue" 0;
 BA_ "BusType" "CAN";
 
 BA_ "GenSigStartValue" SG_ 507 Start_Switch 1; 
+BA_ "GenSigStartValue" SG_ 82 Direction_Command_INVR 1; 
 
 BA_ "GenMsgCycleTime" BO_ 0 100;
 BA_ "GenMsgCycleTime" BO_ 1 100;

--- a/scripts/codegen/CAN/App_CanMsgs.dbc
+++ b/scripts/codegen/CAN/App_CanMsgs.dbc
@@ -587,8 +587,8 @@ BA_DEF_DEF_  "GenSigStartValue" 0;
 
 BA_ "BusType" "CAN";
 
-BA_ "GenSigStartValue" SG_ 507 Start_Switch 1; 
 BA_ "GenSigStartValue" SG_ 82 Direction_Command_INVR 1; 
+BA_ "GenSigStartValue" SG_ 507 Start_Switch 1; 
 
 BA_ "GenMsgCycleTime" BO_ 0 100;
 BA_ "GenMsgCycleTime" BO_ 1 100;


### PR DESCRIPTION
### Summary
-  DCM can only enter drive state if the BMS is in the drive state (AIRs closed, charger disconnected, pre-charge completed) + other checks
-  Turn on inverter load switches directly on entry to init state since inverter fault no longer occurs if the inverters see LV before HV as the `Precharge_Bypassed_EEPROM` parameter is now set to 1
-  Reverse wheel direction of the right inverter (both motors need to be spinning in the same direction)
-  Lower maximum torque request limit to 50.0 Nm for safety until proper current-torque algo is determined

### Testing Done
- Tested on car, faking signals using PCAN

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
