### PR TITLE
Add missing HB callback for DIM

### DIFF
--- a/boards/DIM/Src/App/states/App_DriveState.c
+++ b/boards/DIM/Src/App/states/App_DriveState.c
@@ -1,8 +1,9 @@
 #include "states/App_DriveState.h"
-
 #include "App_SharedMacros.h"
 #include "App_SevenSegDisplays.h"
 #include "App_SharedExitCode.h"
+
+#define SSEG_HB_NOT_RECEIVED_ERR (888U)
 
 static void App_SetPeriodicCanSignals_DriveMode(struct DimCanTxInterface *can_tx, uint32_t switch_position)
 {
@@ -185,7 +186,11 @@ static void DriveStateRunOnTick100Hz(struct StateMachine *const state_machine)
     struct ErrorList all_errors;
     App_SharedErrorTable_GetAllErrors(error_table, &all_errors);
 
-    if (all_errors.num_errors == 0)
+    if (!App_SharedHeartbeatMonitor_Tick(heartbeat_monitor))
+    {
+        App_SevenSegDisplays_SetUnsignedBase10Value(seven_seg_displays, SSEG_HB_NOT_RECEIVED_ERR);
+    }
+    else if (all_errors.num_errors == 0)
     {
         App_SevenSegDisplays_SetUnsignedBase10Value(
             seven_seg_displays, (uint32_t)App_CanRx_BMS_STATE_OF_CHARGE_GetSignal_STATE_OF_CHARGE(can_rx));

--- a/boards/shared/Src/App/App_SharedHeartbeatMonitor.c
+++ b/boards/shared/Src/App/App_SharedHeartbeatMonitor.c
@@ -46,7 +46,7 @@ bool App_SharedHeartbeatMonitor_Tick(struct HeartbeatMonitor *const heartbeat_mo
 
 #ifdef NDEBUG
         // Check if the board received all the heartbeats it's listening for
-        status = (heartbeat_monitor->heartbeats_to_check == heartbeat_monitor->heartbeats_checked_in);
+        status = heartbeat_monitor->heartbeats_to_check == heartbeat_monitor->heartbeats_checked_in;
 #endif
 
         // Clear the list of boards that have checked in


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Modify heartbeat monitor to support DIM callback when HB is not detected
- Add board IDs. Refer to `App_SharedHeartbeatMonitor.h` to see how these are currently implemented

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
- add #define for NDEBUG, test that we transition into the fault state and that 888 is displayed on the sseg display

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
