### PR TITLE
Add return condition for BMS 100Hz task

### DIFF
--- a/boards/BMS/Inc/App/states/App_AllStates.h
+++ b/boards/BMS/Inc/App/states/App_AllStates.h
@@ -11,5 +11,6 @@ void App_AllStatesRunOnTick1Hz(struct StateMachine *state_machine);
 /**
  * On-tick 100Hz function for every state in the given state machine
  * @param state_machine The state machine to run on-tick function for
+ * @return True if next state is not the fault state, otherwise false
  */
-void App_AllStatesRunOnTick100Hz(struct StateMachine *state_machine);
+bool App_AllStatesRunOnTick100Hz(struct StateMachine *state_machine);

--- a/boards/BMS/Src/App/states/App_AirOpenState.c
+++ b/boards/BMS/Src/App/states/App_AirOpenState.c
@@ -17,15 +17,16 @@ static void AirOpenStateRunOnTick1Hz(struct StateMachine *const state_machine)
 
 static void AirOpenStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_AllStatesRunOnTick100Hz(state_machine);
-
-    struct BmsWorld *world = App_SharedStateMachine_GetWorld(state_machine);
-    struct Airs *    airs  = App_BmsWorld_GetAirs(world);
-
-    // Begin the precharge sequence if AIR- is closed
-    if (App_SharedBinaryStatus_IsActive(App_Airs_GetAirNegative(airs)))
+    if (App_AllStatesRunOnTick100Hz(state_machine))
     {
-        App_SharedStateMachine_SetNextState(state_machine, App_GetPreChargeState());
+        struct BmsWorld *world = App_SharedStateMachine_GetWorld(state_machine);
+        struct Airs *    airs  = App_BmsWorld_GetAirs(world);
+
+        // Begin the precharge sequence if AIR- is closed
+        if (App_SharedBinaryStatus_IsActive(App_Airs_GetAirNegative(airs)))
+        {
+            App_SharedStateMachine_SetNextState(state_machine, App_GetPreChargeState());
+        }
     }
 }
 

--- a/boards/BMS/Src/App/states/App_AllStates.c
+++ b/boards/BMS/Src/App/states/App_AllStates.c
@@ -53,6 +53,8 @@ bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
     const bool  is_min_cell_v_out_of_range = !IS_IN_RANGE(MIN_CELL_VOLTAGE, MAX_CELL_VOLTAGE, curr_min_cell_voltage);
     const bool  is_max_cell_v_out_of_range = !IS_IN_RANGE(MIN_CELL_VOLTAGE, MAX_CELL_VOLTAGE, curr_max_cell_voltage);
     App_SharedErrorTable_SetError(
+        error_table, BMS_AIR_SHUTDOWN_MAX_CELL_VOLTAGE_OUT_OF_RANGE, is_max_cell_v_out_of_range);
+    App_SharedErrorTable_SetError(
         error_table, BMS_AIR_SHUTDOWN_MIN_CELL_VOLTAGE_OUT_OF_RANGE, is_min_cell_v_out_of_range);
     App_SharedErrorTable_SetError(error_table, BMS_AIR_SHUTDOWN_HAS_PEC_ERROR, is_max_cell_v_out_of_range);
 

--- a/boards/BMS/Src/App/states/App_AllStates.c
+++ b/boards/BMS/Src/App/states/App_AllStates.c
@@ -25,7 +25,7 @@ void App_AllStatesRunOnTick1Hz(struct StateMachine *const state_machine)
     App_CanTx_SetPeriodicSignal_IS_CONNECTED(can_tx, charger_is_connected);
 }
 
-void App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
+bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
 {
     struct BmsWorld *         world       = App_SharedStateMachine_GetWorld(state_machine);
     struct BmsCanTxInterface *can_tx      = App_BmsWorld_GetCanTx(world);
@@ -37,7 +37,9 @@ void App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
     struct Accumulator *      accumulator = App_BmsWorld_GetAccumulator(world);
     struct ErrorTable *       error_table = App_BmsWorld_GetErrorTable(world);
 
+    bool           status                = true;
     static uint8_t settling_time_counter = 0U;
+
     App_Accumulator_RunOnTick100Hz(accumulator);
 
     uint8_t min_segment = 0U;
@@ -100,6 +102,9 @@ void App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
     }
     else if (App_SharedErrorTable_HasAnyCriticalErrorSet(error_table))
     {
+        status = false;
         App_SharedStateMachine_SetNextState(state_machine, App_GetFaultState());
     }
+
+    return status;
 }

--- a/boards/BMS/Src/App/states/App_ChargeState.c
+++ b/boards/BMS/Src/App/states/App_ChargeState.c
@@ -19,16 +19,17 @@ static void ChargeStateRunOnTick1Hz(struct StateMachine *const state_machine)
 
 static void ChargeStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_AllStatesRunOnTick100Hz(state_machine);
-
-    struct BmsWorld *         world   = App_SharedStateMachine_GetWorld(state_machine);
-    struct BmsCanTxInterface *can_tx  = App_BmsWorld_GetCanTx(world);
-    struct Charger *          charger = App_BmsWorld_GetCharger(world);
-
-    if (!App_Charger_IsConnected(charger))
+    if (App_AllStatesRunOnTick100Hz(state_machine))
     {
-        App_CanTx_SetPeriodicSignal_CHARGER_DISCONNECTED_IN_CHARGE_STATE(can_tx, true);
-        App_SharedStateMachine_SetNextState(state_machine, App_GetFaultState());
+        struct BmsWorld *         world   = App_SharedStateMachine_GetWorld(state_machine);
+        struct BmsCanTxInterface *can_tx  = App_BmsWorld_GetCanTx(world);
+        struct Charger *          charger = App_BmsWorld_GetCharger(world);
+
+        if (!App_Charger_IsConnected(charger))
+        {
+            App_CanTx_SetPeriodicSignal_CHARGER_DISCONNECTED_IN_CHARGE_STATE(can_tx, true);
+            App_SharedStateMachine_SetNextState(state_machine, App_GetFaultState());
+        }
     }
 }
 

--- a/boards/BMS/Src/App/states/App_DriveState.c
+++ b/boards/BMS/Src/App/states/App_DriveState.c
@@ -18,13 +18,14 @@ static void DriveStateRunOnTick1Hz(struct StateMachine *const state_machine)
 
 static void DriveStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_AllStatesRunOnTick100Hz(state_machine);
+    if (App_AllStatesRunOnTick100Hz(state_machine))
+    {
+        struct BmsWorld *         world  = App_SharedStateMachine_GetWorld(state_machine);
+        struct BmsCanTxInterface *can_tx = App_BmsWorld_GetCanTx(world);
+        struct Imd *              imd    = App_BmsWorld_GetImd(world);
 
-    struct BmsWorld *         world  = App_SharedStateMachine_GetWorld(state_machine);
-    struct BmsCanTxInterface *can_tx = App_BmsWorld_GetCanTx(world);
-    struct Imd *              imd    = App_BmsWorld_GetImd(world);
-
-    App_SetPeriodicCanSignals_Imd(can_tx, imd);
+        App_SetPeriodicCanSignals_Imd(can_tx, imd);
+    }
 }
 
 static void DriveStateRunOnExit(struct StateMachine *const state_machine)

--- a/boards/BMS/Src/App/states/App_InitState.c
+++ b/boards/BMS/Src/App/states/App_InitState.c
@@ -27,16 +27,18 @@ static void InitStateRunOnTick1Hz(struct StateMachine *const state_machine)
 
 static void InitStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_AllStatesRunOnTick100Hz(state_machine);
-
-    struct BmsWorld *world = App_SharedStateMachine_GetWorld(state_machine);
-    struct Clock *   clock = App_BmsWorld_GetClock(world);
-
-    // After entering the init state for 5 seconds, enter the AIR open state
-    if (App_SharedClock_GetCurrentTimeInMilliseconds(clock) - App_SharedClock_GetPreviousTimeInMilliseconds(clock) >=
-        5000U)
+    if (App_AllStatesRunOnTick100Hz(state_machine))
     {
-        App_SharedStateMachine_SetNextState(state_machine, App_GetAirOpenState());
+        struct BmsWorld *world = App_SharedStateMachine_GetWorld(state_machine);
+        struct Clock *   clock = App_BmsWorld_GetClock(world);
+
+        // After entering the init state for 5 seconds, enter the AIR open state
+        if (App_SharedClock_GetCurrentTimeInMilliseconds(clock) -
+                App_SharedClock_GetPreviousTimeInMilliseconds(clock) >=
+            5000U)
+        {
+            App_SharedStateMachine_SetNextState(state_machine, App_GetAirOpenState());
+        }
     }
 }
 

--- a/boards/BMS/Test/Src/Test_StateMachine.cpp
+++ b/boards/BMS/Test/Src/Test_StateMachine.cpp
@@ -652,4 +652,17 @@ TEST_F(BmsStateMachineTest, check_state_transition_from_fault_to_init_with_air_n
     ASSERT_EQ(CANMSGS_BMS_STATE_MACHINE_STATE_INIT_CHOICE, App_CanTx_GetPeriodicSignal_STATE(can_tx_interface));
 }
 
+// TODO: update test when AIR open state is removed
+TEST_F(BmsStateMachineTest, check_fault_state_transition_from_all_states)
+{
+    SetInitialState(App_GetAirOpenState());
+
+    LetTimePass(state_machine, 4999);
+    ASSERT_EQ(CANMSGS_BMS_STATE_MACHINE_STATE_AIR_OPEN_CHOICE, App_CanTx_GetPeriodicSignal_STATE(can_tx_interface));
+
+    get_max_cell_voltage_fake.return_val = 4.5;
+    LetTimePass(state_machine, 1);
+    ASSERT_EQ(CANMSGS_BMS_STATE_MACHINE_STATE_FAULT_CHOICE, App_CanTx_GetPeriodicSignal_STATE(can_tx_interface));
+}
+
 } // namespace StateMachineTest


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Currently fault conditions may get overwritten somewhere in the 100hz state machine
- Address this by providing a return condition in AllStates, skip the rest of the state machine code if AllStates returns false

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->
Refer to unit test diff 

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
