### PR TITLE
Cleanup DCM state machine

### DIFF
--- a/boards/BMS/Inc/App/states/App_AllStates.h
+++ b/boards/BMS/Inc/App/states/App_AllStates.h
@@ -11,6 +11,6 @@ void App_AllStatesRunOnTick1Hz(struct StateMachine *state_machine);
 /**
  * On-tick 100Hz function for every state in the given state machine
  * @param state_machine The state machine to run on-tick function for
- * @return True if next state is not the fault state, otherwise false
+ * @return True if the next state is not the fault state, otherwise false
  */
 bool App_AllStatesRunOnTick100Hz(struct StateMachine *state_machine);

--- a/boards/DCM/Inc/App/App_SetPeriodicCanSignals.h
+++ b/boards/DCM/Inc/App/App_SetPeriodicCanSignals.h
@@ -1,8 +1,4 @@
 #pragma once
 #include "App_DcmWorld.h"
 
-struct DcmWorld;
-
-void App_SetPeriodicCanSignals_TorqueRequests(const struct DcmWorld *world);
-
 void App_SetPeriodicCanSignals_Imu(const struct DcmWorld *world);

--- a/boards/DCM/Inc/App/configs/App_RegenThresholds.h
+++ b/boards/DCM/Inc/App/configs/App_RegenThresholds.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define REGEN_WHEEL_SPEED_THRESHOLD_KPH 5.0f

--- a/boards/DCM/Inc/App/configs/App_TorqueRequestThresholds.h
+++ b/boards/DCM/Inc/App/configs/App_TorqueRequestThresholds.h
@@ -1,5 +1,0 @@
-#pragma once
-
-// Maximum torque request
-// TODO: Have separate maximum torque requests for motoring and generating
-#define MAX_TORQUE_REQUEST_NM (50.0f);

--- a/boards/DCM/Inc/App/states/App_AllStates.h
+++ b/boards/DCM/Inc/App/states/App_AllStates.h
@@ -40,5 +40,6 @@ void App_AllStatesRunOnTick1Hz(struct StateMachine *state_machine);
 /**
  * On-tick 100Hz function for every state in the given state machine
  * @param state_machine The state machine to run on-tick function for
+ * @return True if the next state is not the fault state, otherwise false
  */
 bool App_AllStatesRunOnTick100Hz(struct StateMachine *state_machine);

--- a/boards/DCM/Inc/App/states/App_AllStates.h
+++ b/boards/DCM/Inc/App/states/App_AllStates.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include "App_SharedStateMachine.h"
-#include "configs/App_RegenThresholds.h"
 
 /**
  * Check if an inverter has faulted
  * @param can_rx_interface The CAN Rx interface to get the CAN signals from
  * @return true if an inverter has faulted, false otherwise
  */
-static inline bool App_SharedStates_HasInverterFaulted(const struct DcmCanRxInterface *can_rx_interface)
+static inline bool App_HasInverterFault(const struct DcmCanRxInterface *can_rx_interface)
 {
     return App_CanRx_INVL_INTERNAL_STATES_GetSignal_D1_VSM_STATE_INVL(can_rx_interface) ==
                CANMSGS_INVL_INTERNAL_STATES_D1_VSM_STATE_INVL_BLINK_FAULT_CODE_STATE_CHOICE ||
@@ -21,20 +20,25 @@ static inline bool App_SharedStates_HasInverterFaulted(const struct DcmCanRxInte
  * @param can_rx_interface The CAN Rx interface to get the CAN signals from
  * @return true if the start switch is on, false otherwise
  */
-static inline bool App_SharedStates_IsStartSwitchOn(const struct DcmCanRxInterface *can_rx_interface)
+static inline bool App_IsStartSwitchOn(const struct DcmCanRxInterface *can_rx_interface)
 {
     return App_CanRx_DIM_SWITCHES_GetSignal_START_SWITCH(can_rx_interface) ==
            CANMSGS_DIM_SWITCHES_START_SWITCH_ON_CHOICE;
+}
+
+static inline bool App_IsBmsInDriveState(const struct DcmCanRxInterface *can_rx)
+{
+    return App_CanRx_BMS_STATE_MACHINE_GetSignal_STATE(can_rx) == CANMSGS_BMS_STATE_MACHINE_STATE_DRIVE_CHOICE;
 }
 
 /**
  * On-tick 1Hz function for every state in the given state machine
  * @param state_machine The state machine to run on-tick function for
  */
-void App_SharedStatesRunOnTick1Hz(struct StateMachine *state_machine);
+void App_AllStatesRunOnTick1Hz(struct StateMachine *state_machine);
 
 /**
  * On-tick 100Hz function for every state in the given state machine
  * @param state_machine The state machine to run on-tick function for
  */
-void App_SharedStatesRunOnTick100Hz(struct StateMachine *state_machine);
+bool App_AllStatesRunOnTick100Hz(struct StateMachine *state_machine);

--- a/boards/DCM/Src/App/App_SetPeriodicCanSignals.c
+++ b/boards/DCM/Src/App/App_SetPeriodicCanSignals.c
@@ -1,86 +1,8 @@
 #include "App_SharedSetPeriodicCanSignals.h"
 #include "App_SetPeriodicCanSignals.h"
 #include "App_InRangeCheck.h"
-#include "states/App_SharedStates.h"
-#include "configs/App_TorqueRequestThresholds.h"
 
 STATIC_DEFINE_APP_SET_PERIODIC_CAN_SIGNALS_IN_RANGE_CHECK(DcmCanTxInterface)
-
-/**
- * Check if both AIRs are closed
- * @param can_rx_interface The CAN Rx interface to get the CAN signals from
- * @return true if both AIRs are closed, false otherwise
- */
-static inline bool App_AreBothAIRsClosed(const struct DcmCanRxInterface *can_rx_interface)
-{
-    return App_CanRx_BMS_AIR_STATES_GetSignal_AIR_POSITIVE(can_rx_interface) ==
-               CANMSGS_BMS_AIR_STATES_AIR_POSITIVE_CLOSED_CHOICE &&
-           App_CanRx_BMS_AIR_STATES_GetSignal_AIR_NEGATIVE(can_rx_interface) ==
-               CANMSGS_BMS_AIR_STATES_AIR_NEGATIVE_CLOSED_CHOICE;
-}
-
-/**
- * Check if vehicle is over the regen threshold defined by vehicle wheel speed
- * (EV.4.1.3)
- * @param can_rx_interface The CAN Rx interface to get the CAN signals from
- * @return true if the vehicle is over the regen threshold, false otherwise
- */
-static inline bool App_IsVehicleOverRegenThresh(const struct DcmCanRxInterface *can_rx_interface)
-{
-    return (App_CanRx_FSM_WHEEL_SPEED_SENSOR_GetSignal_LEFT_WHEEL_SPEED(can_rx_interface) >
-            REGEN_WHEEL_SPEED_THRESHOLD_KPH) &&
-           (App_CanRx_FSM_WHEEL_SPEED_SENSOR_GetSignal_RIGHT_WHEEL_SPEED(can_rx_interface) >
-            REGEN_WHEEL_SPEED_THRESHOLD_KPH);
-}
-
-// TODO: Implement PID controller to maintain DC bus power at 80kW
-// #680
-void App_SetPeriodicCanSignals_TorqueRequests(const struct DcmWorld *world)
-{
-    struct DcmCanRxInterface *can_rx = App_DcmWorld_GetCanRx(world);
-    struct DcmCanTxInterface *can_tx = App_DcmWorld_GetCanTx(world);
-
-    // Regen allowed when wheel speed > REGEN_WHEEL_SPEED_THRESHOLD_KPH and AIRs
-    // closed
-    const bool is_regen_allowed = App_AreBothAIRsClosed(can_rx) && App_IsVehicleOverRegenThresh(can_rx);
-
-    const float regen_paddle_percentage = (float)App_CanRx_DIM_REGEN_PADDLE_GetSignal_MAPPED_PADDLE_POSITION(can_rx);
-    float       torque_request;
-
-    // Calculating the torque request
-    // 1) If regen is allowed and the regen paddle is actuated, use the regen
-    // paddle percentage 2) If regen is not allowed, use the accelerator pedal
-    // percentage
-    //
-    // Constants:  MAX_TORQUE_REQUEST_NM = 132 Nm,
-    //              - the max torque the motor can provide
-    //
-    // 1) If regen is allowed and the regen paddle is actuated,
-    //         the torque request (in Nm) is negative and given by:
-    //              (-) Regen Paddle Percentage
-    //  Torque  =  -------------------------------  * MAX_TORQUE_REQUEST_NM
-    //                         100%
-    // 2) Otherwise, the torque request (in Nm) is positive and given by:
-    //              Accelerator Pedal Percentage
-    //  Torque =  -------------------------------  * MAX_TORQUE_REQUEST_NM
-    //                        100%
-
-    if (regen_paddle_percentage > 0.0f && is_regen_allowed)
-    {
-        torque_request = -0.01f * regen_paddle_percentage * MAX_TORQUE_REQUEST_NM;
-    }
-    else
-    {
-        torque_request =
-            0.01f * App_CanRx_FSM_PEDAL_POSITION_GetSignal_MAPPED_PEDAL_PERCENTAGE(can_rx) * MAX_TORQUE_REQUEST_NM;
-    }
-
-    // Transmit torque command to both inverters
-    App_CanTx_SetPeriodicSignal_TORQUE_COMMAND_INVL(
-        can_tx, App_CanMsgs_dcm_invl_command_message_torque_command_invl_encode(torque_request));
-    App_CanTx_SetPeriodicSignal_TORQUE_COMMAND_INVR(
-        can_tx, App_CanMsgs_dcm_invr_command_message_torque_command_invr_encode(torque_request));
-}
 
 void App_SetPeriodicCanSignals_Imu(const struct DcmWorld *world)
 {

--- a/boards/DCM/Src/App/states/App_AllStates.c
+++ b/boards/DCM/Src/App/states/App_AllStates.c
@@ -1,6 +1,7 @@
-#include "states/App_SharedStates.h"
+#include "states/App_FaultState.h"
+#include "states/App_AllStates.h"
 
-void App_SharedStatesRunOnTick1Hz(struct StateMachine *const state_machine)
+void App_AllStatesRunOnTick1Hz(struct StateMachine *const state_machine)
 {
     struct DcmWorld *      world            = App_SharedStateMachine_GetWorld(state_machine);
     struct RgbLedSequence *rgb_led_sequence = App_DcmWorld_GetRgbLedSequence(world);
@@ -8,14 +9,17 @@ void App_SharedStatesRunOnTick1Hz(struct StateMachine *const state_machine)
     App_SharedRgbLedSequence_Tick(rgb_led_sequence);
 }
 
-void App_SharedStatesRunOnTick100Hz(struct StateMachine *const state_machine)
+bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
 {
+    bool status = true;
+
     struct DcmWorld *         world             = App_SharedStateMachine_GetWorld(state_machine);
     struct DcmCanTxInterface *can_tx            = App_DcmWorld_GetCanTx(world);
     struct DcmCanRxInterface *can_rx            = App_DcmWorld_GetCanRx(world);
     struct BrakeLight *       brake_light       = App_DcmWorld_GetBrakeLight(world);
     struct InverterSwitches * inverter_switches = App_DcmWorld_GetInverterSwitches(world);
     struct HeartbeatMonitor * hb_monitor        = App_DcmWorld_GetHeartbeatMonitor(world);
+    struct ErrorTable *       error_table       = App_DcmWorld_GetErrorTable(world);
 
     App_CanTx_SetPeriodicSignal_HEARTBEAT(can_tx, true);
     if (App_CanRx_BMS_VITALS_GetSignal_HEARTBEAT(can_rx))
@@ -32,4 +36,12 @@ void App_SharedStatesRunOnTick100Hz(struct StateMachine *const state_machine)
         brake_light, App_CanRx_FSM_BRAKE_GetSignal_BRAKE_IS_ACTUATED(can_rx), is_regen_active);
     App_CanTx_SetPeriodicSignal_RIGHT_INVERTER_SWITCH(can_tx, App_InverterSwitches_IsRightOn(inverter_switches));
     App_CanTx_SetPeriodicSignal_LEFT_INVERTER_SWITCH(can_tx, App_InverterSwitches_IsLeftOn(inverter_switches));
+
+    if (App_SharedErrorTable_HasAnyCriticalErrorSet(error_table) || App_HasInverterFault(can_rx))
+    {
+        status = false;
+        App_SharedStateMachine_SetNextState(state_machine, App_GetFaultState());
+    }
+
+    return status;
 }

--- a/boards/DCM/Src/App/states/App_DriveState.c
+++ b/boards/DCM/Src/App/states/App_DriveState.c
@@ -1,8 +1,54 @@
-#include "states/App_SharedStates.h"
-#include "states/App_DriveState.h"
+#include "states/App_AllStates.h"
 #include "states/App_InitState.h"
-#include "states/App_FaultState.h"
 #include "App_SetPeriodicCanSignals.h"
+
+// TODO: Have separate maximum torque requests for motoring and generating
+#define MAX_TORQUE_REQUEST_NM (50.0f)
+#define REGEN_WHEEL_SPEED_THRESHOLD_KPH 5.0f
+
+void App_SetPeriodicCanSignals_TorqueRequests(struct DcmCanTxInterface *can_tx, struct DcmCanRxInterface *can_rx)
+{
+    const float vehicle_speed_kph = (App_CanRx_FSM_WHEEL_SPEED_SENSOR_GetSignal_LEFT_WHEEL_SPEED(can_rx) +
+                                     App_CanRx_FSM_WHEEL_SPEED_SENSOR_GetSignal_RIGHT_WHEEL_SPEED(can_rx)) /
+                                    2.0f;
+    const float regen_paddle_percentage = (float)App_CanRx_DIM_REGEN_PADDLE_GetSignal_MAPPED_PADDLE_POSITION(can_rx);
+    const bool  is_regen_allowed = vehicle_speed_kph > REGEN_WHEEL_SPEED_THRESHOLD_KPH && App_IsBmsInDriveState(can_rx);
+    float       torque_request   = 0.0f;
+
+    // 1) If regen is allowed and the regen paddle is actuated, use the regen
+    // paddle percentage 2) If regen is not allowed, use the accelerator pedal
+    // percentage
+    //
+    // 1) If regen is allowed and the regen paddle is actuated,
+    //         the torque request (in Nm) is negative and given by:
+    //
+    //              (-) Regen Paddle Percentage
+    //  Torque  =  -------------------------------  * MAX_TORQUE_REQUEST_NM
+    //                         100%
+    //
+    // 2) Otherwise, the torque request (in Nm) is positive and given by:
+    //
+    //              Accelerator Pedal Percentage
+    //  Torque =  -------------------------------  * MAX_TORQUE_REQUEST_NM
+    //                        100%
+    //
+
+    if (regen_paddle_percentage > 0.0f && is_regen_allowed)
+    {
+        torque_request = -0.01f * regen_paddle_percentage * MAX_TORQUE_REQUEST_NM;
+    }
+    else
+    {
+        torque_request =
+            0.01f * App_CanRx_FSM_PEDAL_POSITION_GetSignal_MAPPED_PEDAL_PERCENTAGE(can_rx) * MAX_TORQUE_REQUEST_NM;
+    }
+
+    // Transmit torque command to both inverters
+    App_CanTx_SetPeriodicSignal_TORQUE_COMMAND_INVL(
+        can_tx, App_CanMsgs_dcm_invl_command_message_torque_command_invl_encode(torque_request));
+    App_CanTx_SetPeriodicSignal_TORQUE_COMMAND_INVR(
+        can_tx, App_CanMsgs_dcm_invr_command_message_torque_command_invr_encode(torque_request));
+}
 
 static void DriveStateRunOnEntry(struct StateMachine *const state_machine)
 {
@@ -23,31 +69,25 @@ static void DriveStateRunOnEntry(struct StateMachine *const state_machine)
 
 static void DriveStateRunOnTick1Hz(struct StateMachine *const state_machine)
 {
-    App_SharedStatesRunOnTick1Hz(state_machine);
+    App_AllStatesRunOnTick1Hz(state_machine);
 }
 
 static void DriveStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_SharedStatesRunOnTick100Hz(state_machine);
-
-    struct DcmWorld *         world       = App_SharedStateMachine_GetWorld(state_machine);
-    struct DcmCanRxInterface *can_rx      = App_DcmWorld_GetCanRx(world);
-    struct ErrorTable *       error_table = App_DcmWorld_GetErrorTable(world);
-
-    App_SetPeriodicCanSignals_Imu(world);
-    App_SetPeriodicCanSignals_TorqueRequests(world);
-
-    const struct State *next_state = App_GetDriveState();
-    if (App_SharedStates_HasInverterFaulted(can_rx) || App_SharedErrorTable_HasAnyCriticalErrorSet(error_table))
+    if (App_AllStatesRunOnTick100Hz(state_machine))
     {
-        next_state = App_GetFaultState();
-    }
-    else if (!App_SharedStates_IsStartSwitchOn(can_rx))
-    {
-        next_state = App_GetInitState();
-    }
+        struct DcmWorld *         world  = App_SharedStateMachine_GetWorld(state_machine);
+        struct DcmCanTxInterface *can_tx = App_DcmWorld_GetCanTx(world);
+        struct DcmCanRxInterface *can_rx = App_DcmWorld_GetCanRx(world);
 
-    App_SharedStateMachine_SetNextState(state_machine, next_state);
+        App_SetPeriodicCanSignals_Imu(world);
+        App_SetPeriodicCanSignals_TorqueRequests(can_tx, can_rx);
+
+        if (!App_IsStartSwitchOn(can_rx))
+        {
+            App_SharedStateMachine_SetNextState(state_machine, App_GetInitState());
+        }
+    }
 }
 
 static void DriveStateRunOnExit(struct StateMachine *const state_machine)

--- a/boards/DCM/Src/App/states/App_FaultState.c
+++ b/boards/DCM/Src/App/states/App_FaultState.c
@@ -1,4 +1,4 @@
-#include "states/App_SharedStates.h"
+#include "states/App_AllStates.h"
 #include "states/App_FaultState.h"
 #include "states/App_InitState.h"
 
@@ -23,12 +23,12 @@ static void FaultStateRunOnEntry(struct StateMachine *const state_machine)
 
 static void FaultStateRunOnTick1Hz(struct StateMachine *const state_machine)
 {
-    App_SharedStatesRunOnTick1Hz(state_machine);
+    App_AllStatesRunOnTick1Hz(state_machine);
 }
 
 static void FaultStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_SharedStatesRunOnTick100Hz(state_machine);
+    App_AllStatesRunOnTick100Hz(state_machine);
 
     struct DcmWorld *         world            = App_SharedStateMachine_GetWorld(state_machine);
     struct DcmCanTxInterface *can_tx_interface = App_DcmWorld_GetCanTx(world);
@@ -37,8 +37,7 @@ static void FaultStateRunOnTick100Hz(struct StateMachine *const state_machine)
 
     App_CanTx_SetPeriodicSignal_TORQUE_REQUEST(can_tx_interface, 0.0f);
 
-    if (!App_SharedStates_HasInverterFaulted(can_rx_interface) &&
-        !App_SharedErrorTable_HasAnyCriticalErrorSet(error_table))
+    if (!App_HasInverterFault(can_rx_interface) && !App_SharedErrorTable_HasAnyCriticalErrorSet(error_table))
     {
         App_SharedStateMachine_SetNextState(state_machine, App_GetInitState());
     }

--- a/boards/DCM/Src/App/states/App_FaultState.c
+++ b/boards/DCM/Src/App/states/App_FaultState.c
@@ -28,16 +28,12 @@ static void FaultStateRunOnTick1Hz(struct StateMachine *const state_machine)
 
 static void FaultStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_AllStatesRunOnTick100Hz(state_machine);
-
     struct DcmWorld *         world            = App_SharedStateMachine_GetWorld(state_machine);
     struct DcmCanTxInterface *can_tx_interface = App_DcmWorld_GetCanTx(world);
-    struct DcmCanRxInterface *can_rx_interface = App_DcmWorld_GetCanRx(world);
-    struct ErrorTable *       error_table      = App_DcmWorld_GetErrorTable(world);
 
     App_CanTx_SetPeriodicSignal_TORQUE_REQUEST(can_tx_interface, 0.0f);
 
-    if (!App_HasInverterFault(can_rx_interface) && !App_SharedErrorTable_HasAnyCriticalErrorSet(error_table))
+    if (App_AllStatesRunOnTick100Hz(state_machine))
     {
         App_SharedStateMachine_SetNextState(state_machine, App_GetInitState());
     }

--- a/boards/DCM/Src/App/states/App_InitState.c
+++ b/boards/DCM/Src/App/states/App_InitState.c
@@ -1,32 +1,9 @@
-#include "states/App_SharedStates.h"
+#include "states/App_AllStates.h"
 #include "states/App_InitState.h"
 #include "states/App_DriveState.h"
 #include "states/App_FaultState.h"
 
 #include "App_SharedMacros.h"
-
-/**
- * Check if the BMS is in the DRIVE state (both AIRs closed, pre-charge
- * complete, charge not connected)
- * @param can_rx_interface The CAN Rx interface to get the CAN signals from
- * @return True if the BMS is in the DRIVE state, false otherwise
- */
-static inline bool App_IsBMSInDriveState(const struct DcmCanRxInterface *can_rx_interface)
-{
-    return App_CanRx_BMS_STATE_MACHINE_GetSignal_STATE(can_rx_interface) ==
-           CANMSGS_BMS_STATE_MACHINE_STATE_DRIVE_CHOICE;
-}
-
-/**
- * Check if the brake pedal is actuated
- * @param can_rx_interface The CAN Rx interface to get the CAN signals from
- * @return true if the brake is actuated, false otherwise
- */
-static inline bool App_IsBrakeActuated(const struct DcmCanRxInterface *can_rx_interface)
-{
-    return App_CanRx_FSM_BRAKE_GetSignal_BRAKE_IS_ACTUATED(can_rx_interface) ==
-           CANMSGS_FSM_BRAKE_BRAKE_IS_ACTUATED_TRUE_CHOICE;
-}
 
 static void InitStateRunOnEntry(struct StateMachine *const state_machine)
 {
@@ -53,41 +30,33 @@ static void InitStateRunOnEntry(struct StateMachine *const state_machine)
 
 static void InitStateRunOnTick1Hz(struct StateMachine *const state_machine)
 {
-    App_SharedStatesRunOnTick1Hz(state_machine);
+    App_AllStatesRunOnTick1Hz(state_machine);
 }
 
 static void InitStateRunOnTick100Hz(struct StateMachine *const state_machine)
 {
-    App_SharedStatesRunOnTick100Hz(state_machine);
-
-    struct DcmWorld *         world            = App_SharedStateMachine_GetWorld(state_machine);
-    struct DcmCanRxInterface *can_rx_interface = App_DcmWorld_GetCanRx(world);
-    struct ErrorTable *       error_table      = App_DcmWorld_GetErrorTable(world);
-
-    // Holds previous start switch position (true = UP/ON, false = DOWN/OFF)
-    // Initialize to true to prevent a false start
-    static bool         prev_start_switch_pos      = true;
-    const bool          curr_start_switch_pos      = App_SharedStates_IsStartSwitchOn(can_rx_interface);
-    const bool          was_start_switch_pulled_up = !prev_start_switch_pos && curr_start_switch_pos;
-    const struct State *next_state                 = App_GetInitState();
-
-    if (App_SharedErrorTable_HasAnyCriticalErrorSet(error_table) ||
-        App_SharedStates_HasInverterFaulted(can_rx_interface))
+    if (App_AllStatesRunOnTick100Hz(state_machine))
     {
-        // Transition to fault state if an inverter has faulted or
-        // a critical error has been set
-        next_state = App_GetFaultState();
-    }
-    else if (
-        App_IsBMSInDriveState(can_rx_interface) && App_IsBrakeActuated(can_rx_interface) && was_start_switch_pulled_up)
-    {
-        // Transition to drive state when start-up conditions are passed (see
-        // EV.10.4.3):
-        next_state = App_GetDriveState();
-    }
+        struct DcmWorld *         world            = App_SharedStateMachine_GetWorld(state_machine);
+        struct DcmCanRxInterface *can_rx_interface = App_DcmWorld_GetCanRx(world);
 
-    prev_start_switch_pos = curr_start_switch_pos;
-    App_SharedStateMachine_SetNextState(state_machine, next_state);
+        // Holds previous start switch position (true = UP/ON, false = DOWN/OFF)
+        // Initialize to true to prevent a false start
+        static bool prev_start_switch_pos      = true;
+        const bool  curr_start_switch_pos      = App_IsStartSwitchOn(can_rx_interface);
+        const bool  was_start_switch_pulled_up = !prev_start_switch_pos && curr_start_switch_pos;
+        const bool  is_brake_actuated          = App_CanRx_FSM_BRAKE_GetSignal_BRAKE_IS_ACTUATED(can_rx_interface) ==
+                                       CANMSGS_FSM_BRAKE_BRAKE_IS_ACTUATED_TRUE_CHOICE;
+
+        if (App_IsBmsInDriveState(can_rx_interface) && is_brake_actuated && was_start_switch_pulled_up)
+        {
+            // Transition to drive state when start-up conditions are passed (see
+            // EV.10.4.3):
+            App_SharedStateMachine_SetNextState(state_machine, App_GetDriveState());
+        }
+
+        prev_start_switch_pos = curr_start_switch_pos;
+    }
 }
 
 static void InitStateRunOnExit(struct StateMachine *const state_machine)

--- a/boards/DCM/Test/Src/Test_StateMachine.cpp
+++ b/boards/DCM/Test/Src/Test_StateMachine.cpp
@@ -12,8 +12,6 @@ extern "C"
 #include "configs/App_HeartbeatMonitorConfig.h"
 #include "configs/App_WaitSignalDuration.h"
 #include "configs/App_AccelerationThresholds.h"
-#include "configs/App_TorqueRequestThresholds.h"
-#include "configs/App_RegenThresholds.h"
 }
 
 namespace StateMachineTest


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Clean up DCM state machine code to allow us to handle transitions to fault state correctly

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
- Revert back to App_AllStates. Thought we should be consistent with the rest of the boards
- Move error table check into App_AllStates
- Remove some unnecessary config files used for DCM drive state
- Clean up some unnecessary inline fxns
- regen threshold condition should now be based on vehicle speed (taking the avg of two wheel speeds) and checking to see if the BMS is in drive state instead of checking for both contactors to be closed

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
