### PR TITLE
Add torque derating on DCM

### DIFF
--- a/boards/DCM/Inc/App/configs/App_EfficiencyLUT.h
+++ b/boards/DCM/Inc/App/configs/App_EfficiencyLUT.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#define EFFICIENCY_LUT_RPM_INTERVAL (500U)
+#define EFFICIENCY_LUT_NUM_ENTRIES (14U)
+
+struct EfficiencyLUTEntry
+{
+    float speed_rpm;
+    float efficiency_estimate;
+};
+
+struct EfficiencyLUTEntry EfficiencyLUT[EFFICIENCY_LUT_NUM_ENTRIES] = {
+    [0]  = { .speed_rpm = 500.0f, .efficiency_estimate = 0.80f },
+    [1]  = { .speed_rpm = 1000.0f, .efficiency_estimate = 0.80f },
+    [2]  = { .speed_rpm = 1500.0f, .efficiency_estimate = 0.80f },
+    [3]  = { .speed_rpm = 2000.0f, .efficiency_estimate = 0.80f },
+    [4]  = { .speed_rpm = 2500.0f, .efficiency_estimate = 0.80f },
+    [5]  = { .speed_rpm = 3000.0f, .efficiency_estimate = 0.80f },
+    [6]  = { .speed_rpm = 3500.0f, .efficiency_estimate = 0.80f },
+    [7]  = { .speed_rpm = 4000.0f, .efficiency_estimate = 0.80f },
+    [8]  = { .speed_rpm = 4500.0f, .efficiency_estimate = 0.80f },
+    [9]  = { .speed_rpm = 5000.0f, .efficiency_estimate = 0.80f },
+    [10] = { .speed_rpm = 5500.0f, .efficiency_estimate = 0.80f },
+    [11] = { .speed_rpm = 6000.0f, .efficiency_estimate = 0.80f },
+    [12] = { .speed_rpm = 6500.0f, .efficiency_estimate = 0.80f },
+    [13] = { .speed_rpm = 7000.0f, .efficiency_estimate = 0.80f } // Maximum motor speed = 7000 rpm
+};

--- a/boards/DCM/Src/App/states/App_DriveState.c
+++ b/boards/DCM/Src/App/states/App_DriveState.c
@@ -1,62 +1,30 @@
 #include <stdlib.h>
 #include <math.h>
+#include "App_SharedMacros.h"
 #include "states/App_AllStates.h"
 #include "states/App_InitState.h"
 #include "App_SetPeriodicCanSignals.h"
 
 #define MAX_TORQUE_REQUEST_NM (90.0f)
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define EFFICIENCY_ESTIMATE (0.80f)
 #define RPM_TO_RADS(rpm) ((rpm) * (float)M_PI / 30.0f)
-
-struct EfficiencyLUTEntry
-{
-    float speed_rpm;
-    float efficiency_estimate;
-};
-
-struct EfficiencyLUTEntry EfficiencyLUT[14] = {
-    [0]  = { .speed_rpm = 500.0f, .efficiency_estimate = 80.0f },
-    [1]  = { .speed_rpm = 1000.0f, .efficiency_estimate = 80.0f },
-    [2]  = { .speed_rpm = 1500.0f, .efficiency_estimate = 80.0f },
-    [3]  = { .speed_rpm = 2000.0f, .efficiency_estimate = 80.0f },
-    [4]  = { .speed_rpm = 2500.0f, .efficiency_estimate = 80.0f },
-    [5]  = { .speed_rpm = 3000.0f, .efficiency_estimate = 80.0f },
-    [6]  = { .speed_rpm = 3500.0f, .efficiency_estimate = 80.0f },
-    [7]  = { .speed_rpm = 4000.0f, .efficiency_estimate = 80.0f },
-    [8]  = { .speed_rpm = 4500.0f, .efficiency_estimate = 80.0f },
-    [9]  = { .speed_rpm = 5000.0f, .efficiency_estimate = 80.0f },
-    [10] = { .speed_rpm = 5500.0f, .efficiency_estimate = 80.0f },
-    [11] = { .speed_rpm = 6000.0f, .efficiency_estimate = 80.0f },
-    [12] = { .speed_rpm = 6500.0f, .efficiency_estimate = 80.0f },
-    [13] = { .speed_rpm = 7000.0f, .efficiency_estimate = 80.0f } // Maximum motor speed = 7000 rpm
-};
 
 void App_SetPeriodicCanSignals_TorqueRequests(struct DcmCanTxInterface *can_tx, struct DcmCanRxInterface *can_rx)
 {
-    uint8_t lut_idx;
-    float   efficiency_estimate;
-    float   max_torque_request, torque_request;
-    float   bms_available_power = App_CanRx_BMS_AVAILABLE_POWER_GetSignal_AVAILABLE_POWER(can_rx);
+    float max_torque_request, torque_request;
+    float bms_available_power   = App_CanRx_BMS_AVAILABLE_POWER_GetSignal_AVAILABLE_POWER(can_rx);
     float right_motor_speed_rpm = (float)abs(App_CanRx_INVR_MOTOR_POSITION_INFO_GetSignal_D2_MOTOR_SPEED_INVR(can_rx));
-    float left_motor_speed_rpm  = (float)App_CanRx_INVL_MOTOR_POSITION_INFO_GetSignal_D2_MOTOR_SPEED_INVL(can_rx);
-
-    // Get the estimated efficiency for the current motor speed
-    for (lut_idx = 0U; right_motor_speed_rpm < EfficiencyLUT[lut_idx].speed_rpm; lut_idx++)
-        ;
-    efficiency_estimate = EfficiencyLUT[lut_idx].efficiency_estimate;
+    float left_motor_speed_rpm  = (float)abs(App_CanRx_INVL_MOTOR_POSITION_INFO_GetSignal_D2_MOTOR_SPEED_INVL(can_rx));
 
     // Estimate the maximum torque request to draw the maximum power available from the BMS
     // Note that the motors can not exceed a torque of MAX_TORQUE_REQUEST_NM
-    max_torque_request =
-        MIN(bms_available_power * efficiency_estimate /
-                (RPM_TO_RADS(right_motor_speed_rpm) + RPM_TO_RADS(left_motor_speed_rpm)),
-            MAX_TORQUE_REQUEST_NM);
+    float bms_torque_limit = bms_available_power * EFFICIENCY_ESTIMATE /
+                             (RPM_TO_RADS(right_motor_speed_rpm) + RPM_TO_RADS(left_motor_speed_rpm));
+    max_torque_request = min(bms_torque_limit, MAX_TORQUE_REQUEST_NM);
 
     // Calculate the actual torque request to transmit
     torque_request =
-        MIN(0.01f * App_CanRx_FSM_PEDAL_POSITION_GetSignal_MAPPED_PEDAL_PERCENTAGE(can_rx) * MAX_TORQUE_REQUEST_NM,
-            max_torque_request);
+        0.01f * App_CanRx_FSM_PEDAL_POSITION_GetSignal_MAPPED_PEDAL_PERCENTAGE(can_rx) * max_torque_request;
 
     // Transmit torque command to both inverters
     App_CanTx_SetPeriodicSignal_TORQUE_COMMAND_INVL(

--- a/boards/DCM/Src/App/states/App_DriveState.c
+++ b/boards/DCM/Src/App/states/App_DriveState.c
@@ -1,20 +1,62 @@
+#include <stdlib.h>
+#include <math.h>
 #include "states/App_AllStates.h"
 #include "states/App_InitState.h"
 #include "App_SetPeriodicCanSignals.h"
 
-// TODO: Have separate maximum torque requests for motoring and generating
 #define MAX_TORQUE_REQUEST_NM (90.0f)
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define RPM_TO_RADS(rpm) ((rpm) * (float)M_PI / 30.0f)
+
+struct EfficiencyLUTEntry
+{
+    float speed_rpm;
+    float efficiency_estimate;
+};
+
+struct EfficiencyLUTEntry EfficiencyLUT[14] = {
+    [0]  = { .speed_rpm = 500.0f, .efficiency_estimate = 80.0f },
+    [1]  = { .speed_rpm = 1000.0f, .efficiency_estimate = 80.0f },
+    [2]  = { .speed_rpm = 1500.0f, .efficiency_estimate = 80.0f },
+    [3]  = { .speed_rpm = 2000.0f, .efficiency_estimate = 80.0f },
+    [4]  = { .speed_rpm = 2500.0f, .efficiency_estimate = 80.0f },
+    [5]  = { .speed_rpm = 3000.0f, .efficiency_estimate = 80.0f },
+    [6]  = { .speed_rpm = 3500.0f, .efficiency_estimate = 80.0f },
+    [7]  = { .speed_rpm = 4000.0f, .efficiency_estimate = 80.0f },
+    [8]  = { .speed_rpm = 4500.0f, .efficiency_estimate = 80.0f },
+    [9]  = { .speed_rpm = 5000.0f, .efficiency_estimate = 80.0f },
+    [10] = { .speed_rpm = 5500.0f, .efficiency_estimate = 80.0f },
+    [11] = { .speed_rpm = 6000.0f, .efficiency_estimate = 80.0f },
+    [12] = { .speed_rpm = 6500.0f, .efficiency_estimate = 80.0f },
+    [13] = { .speed_rpm = 7000.0f, .efficiency_estimate = 80.0f } // Maximum motor speed = 7000 rpm
+};
 
 void App_SetPeriodicCanSignals_TorqueRequests(struct DcmCanTxInterface *can_tx, struct DcmCanRxInterface *can_rx)
 {
-    float torque_request = 0.0f;
+    uint8_t lut_idx;
+    float   efficiency_estimate;
+    float   max_torque_request, torque_request;
+    float   bms_available_power = App_CanRx_BMS_AVAILABLE_POWER_GetSignal_AVAILABLE_POWER(can_rx);
+    float right_motor_speed_rpm = (float)abs(App_CanRx_INVR_MOTOR_POSITION_INFO_GetSignal_D2_MOTOR_SPEED_INVR(can_rx));
+    float left_motor_speed_rpm  = (float)App_CanRx_INVL_MOTOR_POSITION_INFO_GetSignal_D2_MOTOR_SPEED_INVL(can_rx);
 
-    //              Accelerator Pedal Percentage
-    //  Torque =  -------------------------------  * MAX_TORQUE_REQUEST_NM
-    //                        100%
-    //
+    // Get the estimated efficiency for the current motor speed
+    for (lut_idx = 0U; right_motor_speed_rpm < EfficiencyLUT[lut_idx].speed_rpm; lut_idx++)
+        ;
+    efficiency_estimate = EfficiencyLUT[lut_idx].efficiency_estimate;
+
+    // Estimate the maximum torque request to draw the maximum power available from the BMS
+    // Note that the motors can not exceed a torque of MAX_TORQUE_REQUEST_NM
+    max_torque_request =
+        MIN(bms_available_power * efficiency_estimate /
+                (RPM_TO_RADS(right_motor_speed_rpm) + RPM_TO_RADS(left_motor_speed_rpm)),
+            MAX_TORQUE_REQUEST_NM);
+
+    // Calculate the actual torque request to transmit
     torque_request =
-        0.01f * App_CanRx_FSM_PEDAL_POSITION_GetSignal_MAPPED_PEDAL_PERCENTAGE(can_rx) * MAX_TORQUE_REQUEST_NM;
+        MIN(0.01f * App_CanRx_FSM_PEDAL_POSITION_GetSignal_MAPPED_PEDAL_PERCENTAGE(can_rx) * MAX_TORQUE_REQUEST_NM,
+            max_torque_request);
 
     // Transmit torque command to both inverters
     App_CanTx_SetPeriodicSignal_TORQUE_COMMAND_INVL(

--- a/scripts/codegen/CAN/App_CanMsgs.dbc
+++ b/scripts/codegen/CAN/App_CanMsgs.dbc
@@ -28,7 +28,7 @@ SG_ D1_RTD4_Temperature_INVL : 0|16@1- (0.1,0) [-3276.8|3276.7] "degC" DEBUG
 BO_ 5 INVL_Motor_Position_Info: 8 INVL
 SG_ D4_Delta_Resolver_Filtered_INVL : 48|16@1- (0.1,0) [-3276.8|3276.7] "deg" DEBUG
 SG_ D3_Electrical_Output_Frequency_INVL : 32|16@1- (0.1,0) [-3276.8|3276.7] "hz" DEBUG
-SG_ D2_Motor_Speed_INVL : 16|16@1- (1,0) [-32768|32767] "rpm" DEBUG
+SG_ D2_Motor_Speed_INVL : 16|16@1- (1,0) [-32768|32767] "rpm" DCM
 SG_ D1_Motor_Angle_Electrical_INVL : 0|16@1+ (0.1,0) [0|6553.5] "deg" DEBUG
 
 BO_ 6 INVL_Current_Info: 8 INVL
@@ -124,7 +124,7 @@ SG_ D1_RTD4_Temperature_INVR : 0|16@1- (0.1,0) [-3276.8|3276.7] "degC" DEBUG
 BO_ 55 INVR_Motor_Position_Info: 8 INVR
 SG_ D4_Delta_Resolver_Filtered_INVR : 48|16@1- (0.1,0) [-3276.8|3276.7] "deg" DEBUG
 SG_ D3_Electrical_Output_Frequency_INVR : 32|16@1- (0.1,0) [-3276.8|3276.7] "hz" DEBUG
-SG_ D2_Motor_Speed_INVR : 16|16@1- (1,0) [-32768|32767] "rpm" DEBUG
+SG_ D2_Motor_Speed_INVR : 16|16@1- (1,0) [-32768|32767] "rpm" DCM
 SG_ D1_Motor_Angle_Electrical_INVR : 0|16@1+ (0.1,0) [0|6553.5] "deg" DEBUG
 
 BO_ 56 INVR_Current_Info: 8 INVR


### PR DESCRIPTION
### Summary
- Limit maximum torque based on power available from BMS
- "Powertrain" efficiency set to conservative value of 0.8 currently for all speed ranges (decrease if exceeding power limit and vice-versa)

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
