### PR TITLE
Pound define added so we can't enter precharge state during BSPD demo

### DIFF
--- a/boards/BMS/Src/App/states/App_InitState.c
+++ b/boards/BMS/Src/App/states/App_InitState.c
@@ -35,10 +35,14 @@ static void InitStateRunOnTick100Hz(struct StateMachine *const state_machine)
         struct TractiveSystem *ts    = App_BmsWorld_GetTractiveSystem(world);
         struct Airs *          airs  = App_BmsWorld_GetAirs(world);
 
+#ifndef BSPD_DEMO_MODE
+        //don't allow pre_charge if in BSPD_DEMO_MODE
         if (App_Airs_IsAirNegativeClosed(airs) && (App_TractiveSystem_GetVoltage(ts) < TS_DISCHARGED_THRESHOLD_V))
         {
             App_SharedStateMachine_SetNextState(state_machine, App_GetPreChargeState());
         }
+#endif
+
     }
 }
 

--- a/boards/BMS/Src/App/states/App_InitState.c
+++ b/boards/BMS/Src/App/states/App_InitState.c
@@ -36,13 +36,12 @@ static void InitStateRunOnTick100Hz(struct StateMachine *const state_machine)
         struct Airs *          airs  = App_BmsWorld_GetAirs(world);
 
 #ifndef BSPD_DEMO_MODE
-        //don't allow pre_charge if in BSPD_DEMO_MODE
+        // don't allow pre_charge if in BSPD_DEMO_MODE
         if (App_Airs_IsAirNegativeClosed(airs) && (App_TractiveSystem_GetVoltage(ts) < TS_DISCHARGED_THRESHOLD_V))
         {
             App_SharedStateMachine_SetNextState(state_machine, App_GetPreChargeState());
         }
 #endif
-
     }
 }
 


### PR DESCRIPTION
### Summary
Added a pre-processor check that will not compile the code to enter pre_charge state during BSPD demonstration

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
