### PR TITLE
Various DIM updates

### DIFF
--- a/boards/DIM/Src/Io/Io_RgbLeds.c
+++ b/boards/DIM/Src/Io/Io_RgbLeds.c
@@ -74,9 +74,9 @@ void Io_RgbLeds_TurnFsmStatusLedGreen(void)
 
 void Io_RgbLeds_TurnFsmStatusLedBlue(void)
 {
-    HAL_GPIO_WritePin(FSM_RED_GPIO_Port, FSM_RED_Pin, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(FSM_RED_GPIO_Port, FSM_RED_Pin, GPIO_PIN_RESET);
     HAL_GPIO_WritePin(FSM_GREEN_GPIO_Port, FSM_GREEN_Pin, GPIO_PIN_RESET);
-    HAL_GPIO_WritePin(FSM_BLUE_GPIO_Port, FSM_BLUE_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(FSM_BLUE_GPIO_Port, FSM_BLUE_Pin, GPIO_PIN_SET);
 }
 
 void Io_RgbLeds_TurnOffFsmStatusLed(void)
@@ -95,16 +95,16 @@ void Io_RgbLeds_TurnBmsStatusLedRed(void)
 
 void Io_RgbLeds_TurnBmsStatusLedGreen(void)
 {
-    HAL_GPIO_WritePin(BMS_RED_GPIO_Port, BMS_RED_Pin, GPIO_PIN_SET);
-    HAL_GPIO_WritePin(BMS_GREEN_GPIO_Port, BMS_GREEN_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(BMS_RED_GPIO_Port, BMS_RED_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(BMS_GREEN_GPIO_Port, BMS_GREEN_Pin, GPIO_PIN_SET);
     HAL_GPIO_WritePin(BMS_BLUE_GPIO_Port, BMS_BLUE_Pin, GPIO_PIN_RESET);
 }
 
 void Io_RgbLeds_TurnBmsStatusLedBlue(void)
 {
-    HAL_GPIO_WritePin(BMS_RED_GPIO_Port, BMS_RED_Pin, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(BMS_RED_GPIO_Port, BMS_RED_Pin, GPIO_PIN_RESET);
     HAL_GPIO_WritePin(BMS_GREEN_GPIO_Port, BMS_GREEN_Pin, GPIO_PIN_RESET);
-    HAL_GPIO_WritePin(BMS_BLUE_GPIO_Port, BMS_BLUE_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(BMS_BLUE_GPIO_Port, BMS_BLUE_Pin, GPIO_PIN_SET);
 }
 
 void Io_RgbLeds_TurnOffBmsStatusLed(void)
@@ -123,16 +123,16 @@ void Io_RgbLeds_TurnPdmStatusLedRed(void)
 
 void Io_RgbLeds_TurnPdmStatusLedGreen(void)
 {
-    HAL_GPIO_WritePin(PDM_RED_GPIO_Port, PDM_RED_Pin, GPIO_PIN_SET);
-    HAL_GPIO_WritePin(PDM_GREEN_GPIO_Port, PDM_GREEN_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(PDM_RED_GPIO_Port, PDM_RED_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(PDM_GREEN_GPIO_Port, PDM_GREEN_Pin, GPIO_PIN_SET);
     HAL_GPIO_WritePin(PDM_BLUE_GPIO_Port, PDM_BLUE_Pin, GPIO_PIN_RESET);
 }
 
 void Io_RgbLeds_TurnPdmStatusLedBlue(void)
 {
-    HAL_GPIO_WritePin(PDM_RED_GPIO_Port, PDM_RED_Pin, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(PDM_RED_GPIO_Port, PDM_RED_Pin, GPIO_PIN_RESET);
     HAL_GPIO_WritePin(PDM_GREEN_GPIO_Port, PDM_GREEN_Pin, GPIO_PIN_RESET);
-    HAL_GPIO_WritePin(PDM_BLUE_GPIO_Port, PDM_BLUE_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(PDM_BLUE_GPIO_Port, PDM_BLUE_Pin, GPIO_PIN_SET);
 }
 
 void Io_RgbLeds_TurnOffPdmStatusLed(void)

--- a/boards/DIM/Src/main.c
+++ b/boards/DIM/Src/main.c
@@ -49,6 +49,7 @@
 #include "Io_Switches.h"
 #include "Io_Adc.h"
 #include "Io_RgbLeds.h"
+#include "Io_SharedErrorTable.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -711,6 +712,7 @@ void RunTaskCanRx(void const *argument)
         struct CanMsg message;
         Io_SharedCan_DequeueCanRxMessage(&message);
         Io_CanRx_UpdateRxTableWithMessage(App_DimWorld_GetCanRx(world), &message);
+        Io_SharedErrorTable_SetErrorsFromCanMsg(error_table, &message);
     }
     /* USER CODE END RunTaskCanRx */
 }

--- a/boards/DIM/Test/Src/Test_StateMachine.cpp
+++ b/boards/DIM/Test/Src/Test_StateMachine.cpp
@@ -405,17 +405,17 @@ TEST_F(DimStateMachineTest, check_torque_vectoring_switch_is_broadcasted_over_ca
 // DIM-5
 TEST_F(DimStateMachineTest, imd_led_control_in_drive_state)
 {
-    App_CanRx_BMS_IMD_SetSignal_OK_HS(can_rx_interface, CANMSGS_BMS_IMD_OK_HS_NO_FAULT_CHOICE);
+    App_CanRx_BMS_OK_STATUSES_SetSignal_IMD_OK(can_rx_interface, true);
     LetTimePass(state_machine, 10);
     ASSERT_EQ(0, turn_on_imd_led_fake.call_count);
     ASSERT_EQ(1, turn_off_imd_led_fake.call_count);
 
-    App_CanRx_BMS_IMD_SetSignal_OK_HS(can_rx_interface, CANMSGS_BMS_IMD_OK_HS_FAULT_CHOICE);
+    App_CanRx_BMS_OK_STATUSES_SetSignal_IMD_OK(can_rx_interface, false);
     LetTimePass(state_machine, 10);
     ASSERT_EQ(1, turn_on_imd_led_fake.call_count);
     ASSERT_EQ(1, turn_off_imd_led_fake.call_count);
 
-    App_CanRx_BMS_IMD_SetSignal_OK_HS(can_rx_interface, CANMSGS_BMS_IMD_OK_HS_NO_FAULT_CHOICE);
+    App_CanRx_BMS_OK_STATUSES_SetSignal_IMD_OK(can_rx_interface, true);
     LetTimePass(state_machine, 10);
     ASSERT_EQ(1, turn_on_imd_led_fake.call_count);
     ASSERT_EQ(2, turn_off_imd_led_fake.call_count);
@@ -424,17 +424,17 @@ TEST_F(DimStateMachineTest, imd_led_control_in_drive_state)
 // DIM-6
 TEST_F(DimStateMachineTest, bspd_led_control_in_drive_state)
 {
-    App_CanRx_FSM_NON_CRITICAL_ERRORS_SetSignal_BSPD_FAULT(can_rx_interface, false);
+    App_CanRx_BMS_OK_STATUSES_SetSignal_BSPD_OK(can_rx_interface, true);
     LetTimePass(state_machine, 10);
     ASSERT_EQ(0, turn_on_bspd_led_fake.call_count);
     ASSERT_EQ(1, turn_off_bspd_led_fake.call_count);
 
-    App_CanRx_FSM_NON_CRITICAL_ERRORS_SetSignal_BSPD_FAULT(can_rx_interface, true);
+    App_CanRx_BMS_OK_STATUSES_SetSignal_BSPD_OK(can_rx_interface, false);
     LetTimePass(state_machine, 10);
     ASSERT_EQ(1, turn_on_bspd_led_fake.call_count);
     ASSERT_EQ(1, turn_off_bspd_led_fake.call_count);
 
-    App_CanRx_FSM_NON_CRITICAL_ERRORS_SetSignal_BSPD_FAULT(can_rx_interface, false);
+    App_CanRx_BMS_OK_STATUSES_SetSignal_BSPD_OK(can_rx_interface, true);
     LetTimePass(state_machine, 10);
     ASSERT_EQ(1, turn_on_bspd_led_fake.call_count);
     ASSERT_EQ(2, turn_off_bspd_led_fake.call_count);
@@ -579,36 +579,6 @@ TEST_F(DimStateMachineTest, bms_board_status_led_control_with_critical_error)
     App_SharedErrorTable_SetError(error_table, BMS_AIR_SHUTDOWN_CHARGER_DISCONNECTED_IN_CHARGE_STATE, true);
     LetTimePass(state_machine, 10);
     ASSERT_EQ(1, turn_bms_status_led_red_fake.call_count);
-}
-
-// DIM-2
-TEST_F(DimStateMachineTest, bms_board_status_led_control_with_non_critical_error)
-{
-    // Set any non-critical error and check that the BMS LED turns blue
-    App_SharedErrorTable_SetError(error_table, BMS_NON_CRITICAL_STACK_WATERMARK_ABOVE_THRESHOLD_TASK1HZ, true);
-    LetTimePass(state_machine, 10);
-    ASSERT_EQ(1, turn_bms_status_led_blue_fake.call_count);
-}
-
-// DIM-2
-TEST_F(DimStateMachineTest, bms_board_status_led_control_with_no_error)
-{
-    // Don't set any error and check that the BMS LED turns green
-    LetTimePass(state_machine, 10);
-    ASSERT_EQ(1, turn_bms_status_led_green_fake.call_count);
-}
-
-// DIM-2
-TEST_F(DimStateMachineTest, bms_board_status_led_control_with_multiple_errors)
-{
-    // If the error table contains critical and non-critical errors
-    // simultaneously, the critical error should take precedence and turn the
-    // BMS LED red rather than blue
-    App_SharedErrorTable_SetError(error_table, BMS_AIR_SHUTDOWN_CHARGER_DISCONNECTED_IN_CHARGE_STATE, true);
-    App_SharedErrorTable_SetError(error_table, BMS_NON_CRITICAL_STACK_WATERMARK_ABOVE_THRESHOLD_TASK1HZ, true);
-    LetTimePass(state_machine, 10);
-    ASSERT_EQ(1, turn_bms_status_led_red_fake.call_count);
-    ASSERT_EQ(0, turn_bms_status_led_blue_fake.call_count);
 }
 
 // DIM-2

--- a/scripts/codegen/CAN/App_CanMsgs.dbc
+++ b/scripts/codegen/CAN/App_CanMsgs.dbc
@@ -253,9 +253,9 @@ SG_ Is_Connected : 0|1@1+ (1,0) [0|1] "" DEBUG
 SG_ IS_CHARGING_COMPLETE : 1|1@1+ (1,0) [0|1] "" DEBUG
 
 BO_ 111 BMS_OK_STATUSES: 1 BMS
-SG_ BMS_OK : 0|1@1+ (1,0) [0|1] "" DEBUG
-SG_ IMD_OK : 1|1@1+ (1,0) [0|1] "" DEBUG
-SG_ BSPD_OK : 2|1@1+ (1,0) [0|1] "" DEBUG
+SG_ BMS_OK : 0|1@1+ (1,0) [0|1] "" DIM
+SG_ IMD_OK : 1|1@1+ (1,0) [0|1] "" DIM
+SG_ BSPD_OK : 2|1@1+ (1,0) [0|1] "" DIM
 
 BO_ 112 BMS_AIR_STATES: 1 BMS
 SG_ AIR_POSITIVE : 0|1@1+ (1,0) [0|1] "" FSM,DCM,PDM


### PR DESCRIPTION
- Individual board RGB LED set to correct colour
- Set error table periodically within can rx thread
- Turn on red IMD and BSPD LEDs if IMD OK and BMS OK CAN signals from the BMS respectively are false
- AMS/BMS RGB LED only turns red if BMS_OK CAN signal is false, otherwise it is off

### Testing Done
None yet
