### PR TITLE
Don't zero pedal % when brake pressed

### DIFF
--- a/boards/FSM/Src/App/App_SetPeriodicCanSignals.c
+++ b/boards/FSM/Src/App/App_SetPeriodicCanSignals.c
@@ -91,7 +91,6 @@ void App_SetPeriodicSignals_AcceleratorPedal(const struct FsmWorld *world)
 {
     struct FsmCanTxInterface *can_tx = App_FsmWorld_GetCanTx(world);
 
-    struct Brake *            brake           = App_FsmWorld_GetBrake(world);
     struct AcceleratorPedals *papps_and_sapps = App_FsmWorld_GetPappsAndSapps(world);
 
     const float papps_pedal_percentage = App_AcceleratorPedals_GetPrimaryPedalPercentage(papps_and_sapps);
@@ -100,14 +99,7 @@ void App_SetPeriodicSignals_AcceleratorPedal(const struct FsmWorld *world)
     App_CanTx_SetPeriodicSignal_PAPPS_MAPPED_PEDAL_PERCENTAGE(can_tx, papps_pedal_percentage);
     App_CanTx_SetPeriodicSignal_SAPPS_MAPPED_PEDAL_PERCENTAGE(can_tx, sapps_pedal_percentage);
 
-    if (App_Brake_IsBrakeActuated(brake))
-    {
-        App_CanTx_SetPeriodicSignal_MAPPED_PEDAL_PERCENTAGE(can_tx, 0.0f);
-    }
-    else
-    {
-        App_CanTx_SetPeriodicSignal_MAPPED_PEDAL_PERCENTAGE(can_tx, papps_pedal_percentage);
-    }
+    App_CanTx_SetPeriodicSignal_MAPPED_PEDAL_PERCENTAGE(can_tx, papps_pedal_percentage);
 }
 
 void App_SetPeriodicSignals_MotorShutdownFaults(const struct FsmWorld *world)

--- a/boards/FSM/Test/Src/Test_StateMachine.cpp
+++ b/boards/FSM/Test/Src/Test_StateMachine.cpp
@@ -572,31 +572,6 @@ TEST_F(FsmStateMachineTest, check_mapped_pedal_percentage_can_signals_in_all_sta
     }
 }
 
-// FSM-3
-TEST_F(FsmStateMachineTest, brake_is_actuated_sets_mapped_pedal_percentage_to_zero_in_all_states)
-{
-    for (const auto &state : GetAllStates())
-    {
-        SetInitialState(state);
-
-        RESET_FAKE(is_brake_actuated);
-
-        // Start with a non-zero pedal position to avoid false positives. In
-        // addition, the chosen primary brake pedal percentage will not trigger
-        // the APPS and brake plausibility callback function
-        get_papps_encoder_counter_fake.return_val = GetPrimaryEncoderCounterFromPedalPercentage(5);
-        LetTimePass(state_machine, 10);
-        ASSERT_NEAR(5, round(App_CanTx_GetPeriodicSignal_MAPPED_PEDAL_PERCENTAGE(can_tx_interface)), 0.5f);
-
-        is_brake_actuated_fake.return_val = true;
-
-        LetTimePass(state_machine, 9);
-        ASSERT_NEAR(5, round(App_CanTx_GetPeriodicSignal_MAPPED_PEDAL_PERCENTAGE(can_tx_interface)), 0.5f);
-        LetTimePass(state_machine, 1);
-        ASSERT_NEAR(0, App_CanTx_GetPeriodicSignal_MAPPED_PEDAL_PERCENTAGE(can_tx_interface), 0.5f);
-    }
-}
-
 // FSM-16
 TEST_F(
     FsmStateMachineTest,


### PR DESCRIPTION
### Summary
There's no need to zero mapped pedal percentage when the brake is actuated since the FSM will throw an FSM motor shutdown error `Plausibility_Check_Has_Failed` when the brake is actuated and PAPPS > 25%. 
