### PR TITLE
changed cycle time of switch signal

### DIFF
--- a/can-bus/json/DIM/DIM_tx.json
+++ b/can-bus/json/DIM/DIM_tx.json
@@ -14,7 +14,7 @@
     },
     "DIM_Switches": {
         "msg_id": 503,
-        "cycle_time": 1000,
+        "cycle_time": 100,
         "description": "States of the switches on the DIM.",
         "signals": {
             "StartSwitch": {


### PR DESCRIPTION
### Summary
Changed cycle time of start switch signal. Before the car would stay in drive state sometimes a full second after flipping the switch to off. I think this could be potentially dangerous if the driver expects the car to turn off right away. 

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
- tested on car

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
