### PR TITLE
Add Odometer to BMS (using EEPROM)

### DIFF
--- a/boards/BMS/Inc/App/App_BmsWorld.h
+++ b/boards/BMS/Inc/App/App_BmsWorld.h
@@ -14,6 +14,7 @@
 #include "App_TractiveSystem.h"
 #include "App_SharedClock.h"
 #include "App_Eeprom.h"
+#include "App_Odometer.h"
 
 struct BmsWorld;
 
@@ -39,7 +40,8 @@ struct BmsWorld *App_BmsWorld_Create(
     struct PrechargeRelay *  precharge_relay,
     struct TractiveSystem *  tractive_system,
     struct Clock *           clock,
-    struct Eeprom *          eeprom);
+    struct Eeprom *          eeprom,
+    struct Odometer *        odometer);
 
 /**
  * Deallocate the memory used by the given world
@@ -137,3 +139,10 @@ struct Clock *App_BmsWorld_GetClock(const struct BmsWorld *world);
  * @return The EEPROM for the given world
  */
 struct Eeprom *App_BmsWorld_GetEeprom(const struct BmsWorld *world);
+
+/**
+ * Get the Odometer for the given world
+ * @param world The world to get Odometer for
+ * @return The Odometer for the given world
+ */
+struct Odometer *App_BmsWorld_GetOdometer(const struct BmsWorld *const world);

--- a/boards/BMS/Inc/App/App_Eeprom.h
+++ b/boards/BMS/Inc/App/App_Eeprom.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -81,3 +83,20 @@ EEPROM_StatusTypeDef App_Eeprom_Write4CopiesOfAddress(struct Eeprom *eeprom, uin
  * @return EEPROM_StatusTypeDef returns success status for debug
  */
 EEPROM_StatusTypeDef App_Eeprom_Read4CopiesOfAddress(struct Eeprom *eeprom, uint16_t page, uint16_t *addresses);
+
+/**
+ * Read array of 4 identical floats and check for data corruption (check if they do not match)
+ * @param eeprom to read floats from
+ * @param address address on EEPROm to read from
+ * @return float value (0 if error occurs)
+ */
+float App_Eeprom_ReadErrCheckedFloat(struct Eeprom *eeprom, uint16_t address);
+
+/**
+ * Write float 4 times to EEPROM to allow for corruption detection
+ * @param eeprom to write to
+ * @param address on eeprom to write to
+ * @param float_to_write float value to write to EEPROM
+ * @return status of write operation
+ */
+EEPROM_StatusTypeDef App_Eeprom_WriteErrCheckedFloat(struct Eeprom *eeprom, uint16_t address, float float_to_write);

--- a/boards/BMS/Inc/App/App_Odometer.h
+++ b/boards/BMS/Inc/App/App_Odometer.h
@@ -4,7 +4,7 @@
 #include "App_Eeprom.h"
 
 #define ODOMETER_ADDRESS 0U
-#define TIRE_CIRCUMFRANCE_KM 0.001276743f
+#define TIRE_CIRCUMFERENCE_M 1.276743f
 
 struct Odometer;
 

--- a/boards/BMS/Inc/App/App_Odometer.h
+++ b/boards/BMS/Inc/App/App_Odometer.h
@@ -4,6 +4,7 @@
 #include "App_Eeprom.h"
 
 #define ODOMETER_ADDRESS 0U
+#define TIRE_CIRCUMFRANCE_KM 0.001276743f
 
 struct Odometer;
 
@@ -51,10 +52,11 @@ float App_Odometer_UpdateReading(struct Odometer *odometer);
 float App_Odometer_GetReading(struct Odometer *odometer);
 
 /**
- * Reset odometer reading back to zero
- * @param odometer to reset
+ * Set odometer reading back to given value
+ * @param odometer to set reading of
+ * @param odometer_value new value to write to odometer
  */
-void App_Odometer_ResetReading(struct Odometer *odometer);
+void App_Odometer_SetReading(struct Odometer *odometer, float odometer_value);
 
 /**
  * Tick Odometer write counter, this allows the odometer to be written to the EEPROM less frequently, removing the need

--- a/boards/BMS/Inc/App/App_Odometer.h
+++ b/boards/BMS/Inc/App/App_Odometer.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "App_SharedExitCode.h"
+#include "App_Eeprom.h"
+
+#define ODOMETER_ADDRESS 0U
+
+struct Odometer;
+
+/**
+ * Allocate and initialize an Odometer
+ * @return Odometer object pointer
+ */
+struct Odometer *App_Odometer_Create(void);
+
+/**
+ * Destroy Odometer object
+ * @param odometer to be destroyed
+ */
+void App_Odometer_Destroy(struct Odometer *odometer);
+
+/**
+ * Read stored odometer reading into EEPROM, write to odometer object
+ * @param eeprom to read from
+ * @param address Address where odometer can be found
+ * @return odometer reading
+ */
+float App_Odometer_ReadValFromEeprom(struct Eeprom *eeprom, uint16_t address);
+
+/**
+ * Write current odometer reading to EEPROM
+ * @param odometer to get reading from
+ * @param eeprom to write to
+ * @param address where to write odometer reading on EEPROM
+ * @return ExitCode status of write
+ */
+ExitCode App_Odometer_WriteValToEeprom(struct Odometer *odometer, struct Eeprom *eeprom, uint16_t address);
+
+/**
+ * Update odometer reading in km
+ * @param odometer to calculate reading for
+ * @return updated odometer reading in km
+ */
+float App_Odometer_UpdateReading(struct Odometer *odometer);
+
+/**
+ * Get current odometer reading in km
+ * @param odometer to calculate reading for
+ * @return odometer reading in km
+ */
+float App_Odometer_GetReading(struct Odometer *odometer);
+
+/**
+ * Reset odometer reading back to zero
+ * @param odometer to reset
+ */
+void App_Odometer_ResetReading(struct Odometer *odometer);
+
+/**
+ * Tick Odometer write counter, this allows the odometer to be written to the EEPROM less frequently, removing the need
+ * for wear levlling
+ * @param odometer to tick counter for
+ * @return will return true once every SECONDS_BETWEEN_ODOMETER_WRITES ticks, false otherwise
+ */
+bool App_Odometer_TickCounter(struct Odometer *odometer);
+
+/**
+ * Reset Odometer write counter to zero
+ * @param odometer to reset counter for
+ */
+void App_Odometer_ResetCounter(struct Odometer *odometer);

--- a/boards/BMS/Src/App/App_BmsWorld.c
+++ b/boards/BMS/Src/App/App_BmsWorld.c
@@ -18,6 +18,7 @@ struct BmsWorld
     struct TractiveSystem *  ts;
     struct Clock *           clock;
     struct Eeprom *          eeprom;
+    struct Odometer *        odometer;
 };
 
 struct BmsWorld *App_BmsWorld_Create(
@@ -30,10 +31,12 @@ struct BmsWorld *App_BmsWorld_Create(
     struct OkStatus *const         bspd_ok,
     struct Accumulator *const      accumulator,
     struct Airs *const             airs,
-    struct PrechargeRelay *const   precharge_relay,
-    struct TractiveSystem *const   tractive_system,
-    struct Clock *const            clock,
-    struct Eeprom *const           eeprom)
+
+    struct PrechargeRelay *const precharge_relay,
+    struct TractiveSystem *const tractive_system,
+    struct Clock *const          clock,
+    struct Eeprom *const         eeprom,
+    struct Odometer *const       odometer)
 {
     struct BmsWorld *world = (struct BmsWorld *)malloc(sizeof(struct BmsWorld));
     assert(world != NULL);
@@ -51,6 +54,7 @@ struct BmsWorld *App_BmsWorld_Create(
     world->ts                = tractive_system;
     world->clock             = clock;
     world->eeprom            = eeprom;
+    world->odometer          = odometer;
 
     return world;
 }
@@ -123,4 +127,9 @@ struct Clock *App_BmsWorld_GetClock(const struct BmsWorld *const world)
 struct Eeprom *App_BmsWorld_GetEeprom(const struct BmsWorld *const world)
 {
     return world->eeprom;
+}
+
+struct Odometer *App_BmsWorld_GetOdometer(const struct BmsWorld *const world)
+{
+    return world->odometer;
 }

--- a/boards/BMS/Src/App/App_Eeprom.c
+++ b/boards/BMS/Src/App/App_Eeprom.c
@@ -98,9 +98,7 @@ EEPROM_StatusTypeDef
     {
         data[i] = 0;
     }
-    uint8_t read_status;
-
-    read_status = eeprom->read_page(page, offset, data, (uint16_t)(num_floats * sizeof(float)));
+    uint8_t read_status = eeprom->read_page(page, offset, data, (uint16_t)(num_floats * sizeof(float)));
 
     for (uint8_t i = 0; i < num_floats; i++)
     {
@@ -156,7 +154,7 @@ float App_Eeprom_ReadErrCheckedFloat(struct Eeprom *eeprom, uint16_t address)
     // If read unsucessful, reset to 0
     if (read_status != EEPROM_OK)
     {
-        return 0;
+        return 0.0f;
     }
     // If any two read values are the same, return the shared value
     else if (floats_read[0] == floats_read[1])
@@ -186,7 +184,7 @@ float App_Eeprom_ReadErrCheckedFloat(struct Eeprom *eeprom, uint16_t address)
     // if there are no matching pairs, data likely corrupted, reset to 0
     else
     {
-        return 0;
+        return 0.0f;
     }
 }
 

--- a/boards/BMS/Src/App/App_Odometer.c
+++ b/boards/BMS/Src/App/App_Odometer.c
@@ -46,8 +46,10 @@ ExitCode App_Odometer_WriteValToEeprom(struct Odometer *odometer, struct Eeprom 
 
 float App_Odometer_UpdateReading(struct Odometer *odometer)
 {
-    const float avg_wheelspeed =
-        (App_CanRx_FSM_Wheels_LeftWheelSpeed_Get() + App_CanRx_FSM_Wheels_RightWheelSpeed_Get()) / 2.0f;
+    const float avg_wheelspeed = ((float)App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Get() +
+                                  (float)App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Get()) /
+                                 2.0f;
+
     const float delta_distance_travelled = avg_wheelspeed * TIRE_CIRCUMFRANCE_KM;
 
     // Only increase odometer value if distance travelled is forwards

--- a/boards/BMS/Src/App/App_Odometer.c
+++ b/boards/BMS/Src/App/App_Odometer.c
@@ -3,12 +3,13 @@
 #include "App_SharedMacros.h"
 #include "App_CanRx.h"
 
-#define TIME_STEP = 0.01f
+#define TIME_STEP_S (1.0f / 100.0f)
+#define TIME_STEP_M (TIME_STEP_S / 60.0f)
 #define SECONDS_BETWEEN_ODOMETER_WRITES 30
 
 struct Odometer
 {
-    float   distance_travelled_km;
+    float   distance_travelled_m;
     uint8_t odometer_counter;
 };
 
@@ -16,8 +17,8 @@ struct Odometer *App_Odometer_Create(void)
 {
     struct Odometer *odometer = malloc(sizeof(struct Odometer));
     assert(odometer != NULL);
-    odometer->odometer_counter      = 0;
-    odometer->distance_travelled_km = 0;
+    odometer->odometer_counter     = 0;
+    odometer->distance_travelled_m = 0;
 
     return odometer;
 }
@@ -34,7 +35,7 @@ float App_Odometer_ReadValFromEeprom(struct Eeprom *eeprom, uint16_t address)
 
 ExitCode App_Odometer_WriteValToEeprom(struct Odometer *odometer, struct Eeprom *eeprom, uint16_t address)
 {
-    if (App_Eeprom_WriteErrCheckedFloat(eeprom, address, odometer->distance_travelled_km) != EEPROM_OK)
+    if (App_Eeprom_WriteErrCheckedFloat(eeprom, address, odometer->distance_travelled_m) != EEPROM_OK)
     {
         return EXIT_CODE_ERROR;
     }
@@ -50,25 +51,26 @@ float App_Odometer_UpdateReading(struct Odometer *odometer)
                                   (float)App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Get()) /
                                  2.0f;
 
-    const float delta_distance_travelled = avg_wheelspeed * TIRE_CIRCUMFRANCE_KM;
+    // Distace travelled by a wheel is the circumference times the # of rotations
+    const float delta_distance_travelled = avg_wheelspeed * TIME_STEP_M * TIRE_CIRCUMFERENCE_M;
 
     // Only increase odometer value if distance travelled is forwards
     if (delta_distance_travelled > 0.0f)
     {
-        odometer->distance_travelled_km += delta_distance_travelled;
+        odometer->distance_travelled_m += delta_distance_travelled;
     }
 
-    return odometer->distance_travelled_km;
+    return odometer->distance_travelled_m;
 }
 
 float App_Odometer_GetReading(struct Odometer *odometer)
 {
-    return odometer->distance_travelled_km;
+    return odometer->distance_travelled_m;
 }
 
 void App_Odometer_SetReading(struct Odometer *odometer, float odometer_value)
 {
-    odometer->distance_travelled_km = odometer_value;
+    odometer->distance_travelled_m = odometer_value;
 }
 
 bool App_Odometer_TickCounter(struct Odometer *odometer)

--- a/boards/BMS/Src/App/App_Odometer.c
+++ b/boards/BMS/Src/App/App_Odometer.c
@@ -3,7 +3,6 @@
 #include "App_SharedMacros.h"
 #include "App_CanRx.h"
 
-#define TIRE_CIRCUMFRANCE_KM 0.001276743f
 #define TIME_STEP = 0.01f
 #define SECONDS_BETWEEN_ODOMETER_WRITES 30
 
@@ -51,7 +50,11 @@ float App_Odometer_UpdateReading(struct Odometer *odometer)
         (App_CanRx_FSM_Wheels_LeftWheelSpeed_Get() + App_CanRx_FSM_Wheels_RightWheelSpeed_Get()) / 2.0f;
     const float delta_distance_travelled = avg_wheelspeed * TIRE_CIRCUMFRANCE_KM;
 
-    odometer->distance_travelled_km += delta_distance_travelled;
+    // Only increase odometer value if distance travelled is forwards
+    if (delta_distance_travelled > 0.0f)
+    {
+        odometer->distance_travelled_km += delta_distance_travelled;
+    }
 
     return odometer->distance_travelled_km;
 }
@@ -61,9 +64,9 @@ float App_Odometer_GetReading(struct Odometer *odometer)
     return odometer->distance_travelled_km;
 }
 
-void App_Odometer_ResetReading(struct Odometer *odometer)
+void App_Odometer_SetReading(struct Odometer *odometer, float odometer_value)
 {
-    odometer->distance_travelled_km = 0;
+    odometer->distance_travelled_km = odometer_value;
 }
 
 bool App_Odometer_TickCounter(struct Odometer *odometer)

--- a/boards/BMS/Src/App/App_Odometer.c
+++ b/boards/BMS/Src/App/App_Odometer.c
@@ -1,0 +1,86 @@
+#include "App_Odometer.h"
+#include "App_CanUtils.h"
+#include "App_SharedMacros.h"
+#include "App_CanRx.h"
+
+#define TIRE_CIRCUMFRANCE_KM 0.001276743f
+#define TIME_STEP = 0.01f
+#define SECONDS_BETWEEN_ODOMETER_WRITES 30
+
+struct Odometer
+{
+    float   distance_travelled_km;
+    uint8_t odometer_counter;
+};
+
+struct Odometer *App_Odometer_Create(void)
+{
+    struct Odometer *odometer = malloc(sizeof(struct Odometer));
+    assert(odometer != NULL);
+    odometer->odometer_counter      = 0;
+    odometer->distance_travelled_km = 0;
+
+    return odometer;
+}
+
+void App_Odometer_Destroy(struct Odometer *odometer)
+{
+    free(odometer);
+}
+
+float App_Odometer_ReadValFromEeprom(struct Eeprom *eeprom, uint16_t address)
+{
+    return App_Eeprom_ReadErrCheckedFloat(eeprom, address);
+}
+
+ExitCode App_Odometer_WriteValToEeprom(struct Odometer *odometer, struct Eeprom *eeprom, uint16_t address)
+{
+    if (App_Eeprom_WriteErrCheckedFloat(eeprom, address, odometer->distance_travelled_km) != EEPROM_OK)
+    {
+        return EXIT_CODE_ERROR;
+    }
+    else
+    {
+        return EXIT_CODE_OK;
+    }
+}
+
+float App_Odometer_UpdateReading(struct Odometer *odometer)
+{
+    const float avg_wheelspeed =
+        (App_CanRx_FSM_Wheels_LeftWheelSpeed_Get() + App_CanRx_FSM_Wheels_RightWheelSpeed_Get()) / 2.0f;
+    const float delta_distance_travelled = avg_wheelspeed * TIRE_CIRCUMFRANCE_KM;
+
+    odometer->distance_travelled_km += delta_distance_travelled;
+
+    return odometer->distance_travelled_km;
+}
+
+float App_Odometer_GetReading(struct Odometer *odometer)
+{
+    return odometer->distance_travelled_km;
+}
+
+void App_Odometer_ResetReading(struct Odometer *odometer)
+{
+    odometer->distance_travelled_km = 0;
+}
+
+bool App_Odometer_TickCounter(struct Odometer *odometer)
+{
+    if (odometer->odometer_counter >= SECONDS_BETWEEN_ODOMETER_WRITES)
+    {
+        odometer->odometer_counter = 0;
+        return true;
+    }
+    else
+    {
+        odometer->odometer_counter++;
+        return false;
+    }
+}
+
+void App_Odometer_ResetCounter(struct Odometer *odometer)
+{
+    odometer->odometer_counter = 0;
+}

--- a/boards/BMS/Src/App/states/App_AllStates.c
+++ b/boards/BMS/Src/App/states/App_AllStates.c
@@ -108,6 +108,15 @@ void App_AllStatesRunOnTick1Hz(struct StateMachine *const state_machine)
 
     bool charger_is_connected = App_Charger_IsConnected(charger);
     App_CanTx_BMS_Charger_IsConnected_Set(charger_is_connected);
+    //
+    //    if (App_CanRx_Debug_ResetOdometer_ResetOdometer_Get())
+    //    {
+    //        struct Eeprom *  eeprom   = App_BmsWorld_GetEeprom(world);
+    //        struct Odometer *odometer = App_BmsWorld_GetOdometer(world);
+    //
+    //        App_Odometer_ResetReading(odometer);
+    //        App_Odometer_WriteValToEeprom(odometer, eeprom, ODOMETER_ADDRESS);
+    //    }
 }
 
 bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
@@ -122,6 +131,7 @@ bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
     struct HeartbeatMonitor *hb_monitor  = App_BmsWorld_GetHeartbeatMonitor(world);
     struct TractiveSystem *  ts          = App_BmsWorld_GetTractiveSystem(world);
     struct Charger *         charger     = App_BmsWorld_GetCharger(world);
+    struct Odometer *        odometer    = App_BmsWorld_GetOdometer(world);
 
     const bool charger_is_connected = App_Charger_IsConnected(charger);
     bool       status               = true;
@@ -146,6 +156,8 @@ bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
     App_CanTx_BMS_Contactors_AirPositive_Set(
         App_Airs_IsAirPositiveClosed(airs) ? CONTACTOR_STATE_CLOSED : CONTACTOR_STATE_OPEN);
     App_SetPeriodicCanSignals_Imd(imd);
+
+    App_CanTx_BMS_OdometerReading_DistanceTravelled_Set(App_Odometer_GetReading(odometer));
 
     App_AdvertisePackPower(accumulator, ts);
 

--- a/boards/BMS/Src/App/states/App_AllStates.c
+++ b/boards/BMS/Src/App/states/App_AllStates.c
@@ -108,15 +108,15 @@ void App_AllStatesRunOnTick1Hz(struct StateMachine *const state_machine)
 
     bool charger_is_connected = App_Charger_IsConnected(charger);
     App_CanTx_BMS_Charger_IsConnected_Set(charger_is_connected);
-    //
-    //    if (App_CanRx_Debug_ResetOdometer_ResetOdometer_Get())
-    //    {
-    //        struct Eeprom *  eeprom   = App_BmsWorld_GetEeprom(world);
-    //        struct Odometer *odometer = App_BmsWorld_GetOdometer(world);
-    //
-    //        App_Odometer_ResetReading(odometer);
-    //        App_Odometer_WriteValToEeprom(odometer, eeprom, ODOMETER_ADDRESS);
-    //    }
+
+    if (App_CanRx_Debug_ResetOdometer_ResetOdometer_Get())
+    {
+        struct Eeprom *  eeprom   = App_BmsWorld_GetEeprom(world);
+        struct Odometer *odometer = App_BmsWorld_GetOdometer(world);
+
+        App_Odometer_SetReading(odometer, 0.0f);
+        App_Odometer_WriteValToEeprom(odometer, eeprom, ODOMETER_ADDRESS);
+    }
 }
 
 bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)

--- a/boards/BMS/Src/App/states/App_AllStates.c
+++ b/boards/BMS/Src/App/states/App_AllStates.c
@@ -157,7 +157,8 @@ bool App_AllStatesRunOnTick100Hz(struct StateMachine *const state_machine)
         App_Airs_IsAirPositiveClosed(airs) ? CONTACTOR_STATE_CLOSED : CONTACTOR_STATE_OPEN);
     App_SetPeriodicCanSignals_Imd(imd);
 
-    App_CanTx_BMS_OdometerReading_DistanceTravelled_Set(App_Odometer_GetReading(odometer));
+    const float odometer_reading_km = App_Odometer_GetReading(odometer) / 1000.0f;
+    App_CanTx_BMS_OdometerReading_DistanceTravelled_Set(odometer_reading_km);
 
     App_AdvertisePackPower(accumulator, ts);
 

--- a/boards/BMS/Src/App/states/App_InitState.c
+++ b/boards/BMS/Src/App/states/App_InitState.c
@@ -15,6 +15,17 @@ static void InitStateRunOnEntry(struct StateMachine *const state_machine)
     struct Clock *      clock         = App_BmsWorld_GetClock(world);
     struct Accumulator *accumulator   = App_BmsWorld_GetAccumulator(world);
     struct OkStatus *   bms_ok_status = App_BmsWorld_GetBmsOkStatus(world);
+    struct Eeprom *     eeprom        = App_BmsWorld_GetEeprom(world);
+    struct Odometer *   odometer      = App_BmsWorld_GetOdometer(world);
+
+    const float stored_odometer_reading  = App_Odometer_ReadValFromEeprom(eeprom, ODOMETER_ADDRESS);
+    const float current_odometer_reading = App_Odometer_GetReading(odometer);
+
+    // If odometer reading is currently blank, load stored value from EEPROM
+    if (current_odometer_reading == 0.0f && stored_odometer_reading > 0.0f)
+    {
+        App_Odometer_SetReading(odometer, stored_odometer_reading);
+    }
 
     App_CanTx_BMS_Vitals_CurrentState_Set(BMS_INIT_STATE);
     App_SharedClock_SetPreviousTimeInMilliseconds(clock, App_SharedClock_GetCurrentTimeInMilliseconds(clock));

--- a/boards/BMS/Src/Io/Io_Eeprom.c
+++ b/boards/BMS/Src/Io/Io_Eeprom.c
@@ -91,7 +91,7 @@ EEPROM_StatusTypeDef Io_Eeprom_PageErase(uint16_t page)
     HAL_StatusTypeDef i2c_status;
 
     // write the data to the EEPROM
-    i2c_status = HAL_I2C_Mem_Write(EEPROM_I2C, EEPROM_ADDR, mem_address, 2, data, PAGE_SIZE, 1000);
+    i2c_status = HAL_I2C_Mem_Write(EEPROM_I2C, EEPROM_ADDR, mem_address, I2C_MEMADD_SIZE_8BIT, data, PAGE_SIZE, 1000);
 
     // If mem write error detected, return error
     if (i2c_status != HAL_OK)

--- a/boards/BMS/Src/main.c
+++ b/boards/BMS/Src/main.c
@@ -127,6 +127,7 @@ struct PrechargeRelay *  precharge_relay;
 struct TractiveSystem *  ts;
 struct Clock *           clock;
 struct Eeprom *          eeprom;
+struct Odometer *        odometer;
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -262,9 +263,13 @@ int main(void)
 
     eeprom = App_Eeprom_Create(Io_Eeprom_WritePage, Io_Eeprom_ReadPage, Io_Eeprom_PageErase);
 
+    odometer = App_Odometer_Create();
+
+    App_Odometer_ReadValFromEeprom(eeprom, ODOMETER_ADDRESS);
+
     world = App_BmsWorld_Create(
         imd, heartbeat_monitor, rgb_led_sequence, charger, bms_ok, imd_ok, bspd_ok, accumulator, airs, precharge_relay,
-        ts, clock, eeprom);
+        ts, clock, eeprom, odometer);
 
     state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
     App_AllStates_Init();

--- a/boards/BMS/Src/main.c
+++ b/boards/BMS/Src/main.c
@@ -265,7 +265,7 @@ int main(void)
 
     odometer = App_Odometer_Create();
 
-    App_Odometer_ReadValFromEeprom(eeprom, ODOMETER_ADDRESS);
+    App_Odometer_SetReading(odometer, App_Odometer_ReadValFromEeprom(eeprom, ODOMETER_ADDRESS));
 
     world = App_BmsWorld_Create(
         imd, heartbeat_monitor, rgb_led_sequence, charger, bms_ok, imd_ok, bspd_ok, accumulator, airs, precharge_relay,

--- a/boards/BMS/Test/Src/Test_Faults.cpp
+++ b/boards/BMS/Test/Src/Test_Faults.cpp
@@ -123,9 +123,11 @@ class BmsFaultTest : public BaseStateMachineTest
 
         eeprom = App_Eeprom_Create(write_page, read_page, page_erase);
 
+        odometer = App_Odometer_Create();
+
         world = App_BmsWorld_Create(
             imd, heartbeat_monitor, rgb_led_sequence, charger, bms_ok, imd_ok, bspd_ok, accumulator, airs,
-            precharge_relay, ts, clock, eeprom);
+            precharge_relay, ts, clock, eeprom, odometer);
 
         // Default to starting the state machine in the `init` state
         state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
@@ -169,6 +171,10 @@ class BmsFaultTest : public BaseStateMachineTest
         // A temperature in [0.0, 60.0] degC to prevent other tests from entering the fault state
         get_min_temp_degc_fake.return_val = 20.0f;
         get_max_temp_degc_fake.return_val = 20.0f;
+
+        read_page_fake.return_val  = EEPROM_OK;
+        write_page_fake.return_val = EEPROM_OK;
+        page_erase_fake.return_val = EEPROM_OK;
     }
 
     void TearDown() override
@@ -188,6 +194,7 @@ class BmsFaultTest : public BaseStateMachineTest
         TearDownObject(ts, App_TractiveSystem_Destroy);
         TearDownObject(clock, App_SharedClock_Destroy);
         TearDownObject(eeprom, App_Eeprom_Destroy);
+        TearDownObject(odometer, App_Odometer_Destroy);
     }
 
     void SetInitialState(const struct State *const initial_state)
@@ -235,6 +242,7 @@ class BmsFaultTest : public BaseStateMachineTest
     struct TractiveSystem *   ts;
     struct Clock *            clock;
     struct Eeprom *           eeprom;
+    struct Odometer *         odometer;
 };
 
 TEST_F(BmsFaultTest, check_state_transition_to_fault_state_from_all_states_overvoltage)

--- a/boards/BMS/Test/Src/Test_Odometer.cpp
+++ b/boards/BMS/Test/Src/Test_Odometer.cpp
@@ -120,6 +120,13 @@ class BmsOdometerTest : public BaseStateMachineTest
     {
         BaseStateMachineTest::SetUp();
 
+        RESET_FAKE(read_page);
+        RESET_FAKE(write_page);
+        RESET_FAKE(page_erase);
+
+        write_page_fake.custom_fake = write_byte_callback;
+        read_page_fake.custom_fake  = read_byte_callback;
+
         App_CanTx_Init();
         App_CanRx_Init();
 
@@ -200,9 +207,6 @@ class BmsOdometerTest : public BaseStateMachineTest
         RESET_FAKE(get_max_cell_voltage);
         RESET_FAKE(get_low_res_current);
         RESET_FAKE(get_high_res_current);
-        RESET_FAKE(read_page);
-        RESET_FAKE(write_page);
-        RESET_FAKE(page_erase);
 
         // Set initial voltages to nominal value
         set_all_cell_voltages(3.8);
@@ -229,8 +233,6 @@ class BmsOdometerTest : public BaseStateMachineTest
         App_CanRx_Debug_ChargingSwitch_StartCharging_Update(false);
         has_charger_faulted_fake.return_val = false;
 
-        write_page_fake.custom_fake = write_byte_callback;
-        read_page_fake.custom_fake  = read_byte_callback;
         App_Eeprom_WriteErrCheckedFloat(eeprom, ODOMETER_ADDRESS, STARTING_ODOMETER_READING);
     }
 

--- a/boards/BMS/Test/Src/Test_Odometer.cpp
+++ b/boards/BMS/Test/Src/Test_Odometer.cpp
@@ -346,10 +346,10 @@ TEST_F(BmsOdometerTest, test_odometer_val_read_from_eeprom)
 
 TEST_F(BmsOdometerTest, test_odometer_val_increases)
 {
-    float wheelspeed_km = 10.0f;
+    float wheelspeed = 10.0f;
 
-    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
-    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Update(wheelspeed);
+    App_CanRx_INVL_MotorPositionInfo_MotorAngle_Update(wheelspeed);
 
     SetInitialState(App_GetInitState());
 
@@ -366,10 +366,10 @@ TEST_F(BmsOdometerTest, test_odometer_val_increases)
 
 TEST_F(BmsOdometerTest, test_odometer_val_constant_with_negative_wheelspin)
 {
-    float wheelspeed_km = -10.0f;
+    float wheelspeed = -10.0f;
 
-    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
-    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Update(wheelspeed);
+    App_CanRx_INVL_MotorPositionInfo_MotorAngle_Update(wheelspeed);
 
     SetInitialState(App_GetInitState());
 
@@ -386,10 +386,10 @@ TEST_F(BmsOdometerTest, test_odometer_val_constant_with_negative_wheelspin)
 
 TEST_F(BmsOdometerTest, test_odometer_val_resets_with_can_message)
 {
-    float wheelspeed_km = 10.0f;
+    float wheelspeed = 10.0f;
 
-    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
-    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Update(wheelspeed);
+    App_CanRx_INVL_MotorPositionInfo_MotorAngle_Update(wheelspeed);
 
     SetInitialState(App_GetInitState());
 
@@ -404,9 +404,11 @@ TEST_F(BmsOdometerTest, test_odometer_val_resets_with_can_message)
     ASSERT_GT(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
 
     App_CanRx_Debug_ResetOdometer_ResetOdometer_Update(true);
-    wheelspeed_km = 0.0f;
-    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
-    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+
+    wheelspeed = 0.0f;
+
+    App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Update(wheelspeed);
+    App_CanRx_INVL_MotorPositionInfo_MotorAngle_Update(wheelspeed);
 
     LetTimePass(state_machine, 1000);
 
@@ -415,11 +417,11 @@ TEST_F(BmsOdometerTest, test_odometer_val_resets_with_can_message)
 
 TEST_F(BmsOdometerTest, test_odometer_val_written_to_eeprom)
 {
-    float wheelspeed_km   = 10.0f;
+    float wheelspeed      = 10.0f;
     int   time_to_wait_ms = 31000; // 30s write interval + 1s to give time for write
 
-    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
-    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_INVR_MotorPositionInfo_MotorSpeed_Update(wheelspeed);
+    App_CanRx_INVL_MotorPositionInfo_MotorAngle_Update(wheelspeed);
 
     SetInitialState(App_GetInitState());
 

--- a/boards/BMS/Test/Src/Test_Odometer.cpp
+++ b/boards/BMS/Test/Src/Test_Odometer.cpp
@@ -1,0 +1,439 @@
+#include "Test_StateMachine.h"
+
+#define STARTING_ODOMETER_READING 1000.0f
+#define FLOATS_PER_PAGE 4
+
+namespace OdometerTest
+{
+FAKE_VALUE_FUNC(float, get_pwm_frequency);
+FAKE_VALUE_FUNC(float, get_pwm_duty_cycle);
+FAKE_VALUE_FUNC(uint16_t, get_seconds_since_power_on);
+FAKE_VALUE_FUNC(uint32_t, get_current_ms);
+FAKE_VOID_FUNC(turn_on_red_led);
+FAKE_VOID_FUNC(turn_on_green_led);
+FAKE_VOID_FUNC(turn_on_blue_led);
+FAKE_VOID_FUNC(enable_charger);
+FAKE_VOID_FUNC(disable_charger);
+FAKE_VALUE_FUNC(bool, is_charger_connected);
+FAKE_VALUE_FUNC(bool, has_charger_faulted);
+FAKE_VALUE_FUNC(ExitCode, enable_bms_ok);
+FAKE_VALUE_FUNC(ExitCode, disable_bms_ok);
+FAKE_VALUE_FUNC(bool, is_bms_ok_enabled);
+FAKE_VALUE_FUNC(ExitCode, enable_imd_ok);
+FAKE_VALUE_FUNC(ExitCode, disable_imd_ok);
+FAKE_VALUE_FUNC(bool, is_imd_ok_enabled);
+FAKE_VALUE_FUNC(ExitCode, enable_bspd_ok);
+FAKE_VALUE_FUNC(ExitCode, disable_bspd_ok);
+FAKE_VALUE_FUNC(bool, is_bspd_ok_enabled);
+FAKE_VALUE_FUNC(bool, is_air_negative_closed);
+FAKE_VALUE_FUNC(bool, is_air_positive_closed);
+FAKE_VALUE_FUNC(ExitCode, read_die_temperatures);
+FAKE_VALUE_FUNC(bool, is_air_negative_on);
+FAKE_VALUE_FUNC(bool, is_air_positive_on);
+FAKE_VOID_FUNC(open_air_positive);
+FAKE_VOID_FUNC(close_air_positive);
+FAKE_VOID_FUNC(enable_pre_charge);
+FAKE_VOID_FUNC(disable_pre_charge);
+FAKE_VALUE_FUNC(bool, configure_cell_monitors);
+FAKE_VALUE_FUNC(bool, write_cfg_registers);
+FAKE_VALUE_FUNC(bool, start_voltage_conv);
+FAKE_VALUE_FUNC(float, get_min_cell_voltage, uint8_t *, uint8_t *);
+FAKE_VALUE_FUNC(float, get_max_cell_voltage, uint8_t *, uint8_t *);
+FAKE_VALUE_FUNC(float, get_segment_voltage, AccumulatorSegment);
+FAKE_VALUE_FUNC(float, get_pack_voltage);
+FAKE_VALUE_FUNC(float, get_avg_cell_voltage);
+FAKE_VALUE_FUNC(float, get_ts_voltage);
+FAKE_VALUE_FUNC(float, get_low_res_current);
+FAKE_VALUE_FUNC(float, get_high_res_current);
+FAKE_VALUE_FUNC(bool, start_temp_conv);
+FAKE_VALUE_FUNC(bool, read_cell_temperatures);
+FAKE_VALUE_FUNC(float, get_min_temp_degc, uint8_t *, uint8_t *);
+FAKE_VALUE_FUNC(float, get_max_temp_degc, uint8_t *, uint8_t *);
+FAKE_VALUE_FUNC(float, get_avg_temp_degc);
+FAKE_VALUE_FUNC(bool, enable_discharge);
+FAKE_VALUE_FUNC(bool, disable_discharge);
+FAKE_VALUE_FUNC(EEPROM_StatusTypeDef, read_page, uint16_t, uint8_t, uint8_t *, uint16_t);
+FAKE_VALUE_FUNC(EEPROM_StatusTypeDef, write_page, uint16_t, uint8_t, uint8_t *, uint16_t);
+FAKE_VALUE_FUNC(EEPROM_StatusTypeDef, page_erase, uint16_t);
+
+static float cell_voltages[ACCUMULATOR_NUM_SEGMENTS][ACCUMULATOR_NUM_SERIES_CELLS_PER_SEGMENT];
+
+static bool read_cell_voltages(float voltages[ACCUMULATOR_NUM_SEGMENTS][ACCUMULATOR_NUM_SERIES_CELLS_PER_SEGMENT])
+{
+    for (uint8_t segment = 0; segment < ACCUMULATOR_NUM_SEGMENTS; segment++)
+    {
+        for (uint8_t cell = 0; cell < ACCUMULATOR_NUM_SERIES_CELLS_PER_SEGMENT; cell++)
+        {
+            voltages[segment][cell] = cell_voltages[segment][cell];
+        }
+    }
+
+    return true;
+}
+
+static void set_cell_voltage(AccumulatorSegment segment, uint8_t cell, float voltage)
+{
+    if (segment < ACCUMULATOR_NUM_SEGMENTS && cell < ACCUMULATOR_NUM_SERIES_CELLS_PER_SEGMENT)
+    {
+        cell_voltages[segment][cell] = voltage;
+    }
+}
+
+static void set_all_cell_voltages(float voltage)
+{
+    for (uint8_t segment = 0; segment < ACCUMULATOR_NUM_SEGMENTS; segment++)
+    {
+        for (uint8_t cell = 0; cell < ACCUMULATOR_NUM_SERIES_CELLS_PER_SEGMENT; cell++)
+        {
+            set_cell_voltage((AccumulatorSegment)segment, cell, voltage);
+        }
+    }
+}
+
+static uint8_t static_byte_array[PAGE_SIZE];
+
+// callback stores byte_array input into Io_Eeprom_WriteByte in static_byte_array to mimic writing to memory
+static EEPROM_StatusTypeDef write_byte_callback(uint16_t page, uint8_t offset, uint8_t *byte_arr, uint16_t size)
+{
+    for (int i = 0; i < size; i++)
+    {
+        static_byte_array[i] = byte_arr[i];
+    }
+    return EEPROM_OK;
+}
+
+// callback stores copies stored static_byte_array into array pointed to in argument list of Io_Eeprom_ReadByte
+// to mimic reading from memory
+static EEPROM_StatusTypeDef read_byte_callback(uint16_t page, uint8_t offset, uint8_t *byte_arr, uint16_t size)
+{
+    for (int i = 0; i < size; i++)
+    {
+        byte_arr[i] = static_byte_array[i];
+    }
+    return EEPROM_OK;
+}
+
+class BmsOdometerTest : public BaseStateMachineTest
+{
+  protected:
+    void SetUp() override
+    {
+        BaseStateMachineTest::SetUp();
+
+        App_CanTx_Init();
+        App_CanRx_Init();
+
+        imd =
+            App_Imd_Create(get_pwm_frequency, IMD_FREQUENCY_TOLERANCE, get_pwm_duty_cycle, get_seconds_since_power_on);
+
+        heartbeat_monitor = App_SharedHeartbeatMonitor_Create(
+            get_current_ms, HEARTBEAT_MONITOR_TIMEOUT_PERIOD_MS, HEARTBEAT_MONITOR_BOARDS_TO_CHECK);
+
+        rgb_led_sequence = App_SharedRgbLedSequence_Create(turn_on_red_led, turn_on_green_led, turn_on_blue_led);
+
+        charger = App_Charger_Create(enable_charger, disable_charger, is_charger_connected, has_charger_faulted);
+
+        bms_ok = App_OkStatus_Create(enable_bms_ok, disable_bms_ok, is_bms_ok_enabled);
+
+        imd_ok = App_OkStatus_Create(enable_imd_ok, disable_imd_ok, is_imd_ok_enabled);
+
+        bspd_ok = App_OkStatus_Create(enable_bspd_ok, disable_bspd_ok, is_bspd_ok_enabled);
+
+        accumulator = App_Accumulator_Create(
+            configure_cell_monitors, write_cfg_registers, start_voltage_conv, read_cell_voltages, start_temp_conv,
+            read_cell_temperatures, get_min_temp_degc, get_max_temp_degc, get_avg_temp_degc, enable_discharge,
+            disable_discharge);
+
+        precharge_relay = App_PrechargeRelay_Create(enable_pre_charge, disable_pre_charge);
+
+        ts = App_TractiveSystem_Create(get_ts_voltage, get_high_res_current, get_low_res_current);
+
+        airs = App_Airs_Create(is_air_positive_closed, is_air_negative_closed, close_air_positive, open_air_positive);
+
+        clock = App_SharedClock_Create();
+
+        eeprom = App_Eeprom_Create(write_page, read_page, page_erase);
+
+        odometer = App_Odometer_Create();
+
+        world = App_BmsWorld_Create(
+            imd, heartbeat_monitor, rgb_led_sequence, charger, bms_ok, imd_ok, bspd_ok, accumulator, airs,
+            precharge_relay, ts, clock, eeprom, odometer);
+
+        // Default to starting the state machine in the `init` state
+        state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
+        App_AllStates_Init();
+
+        RESET_FAKE(get_pwm_frequency);
+        RESET_FAKE(get_pwm_duty_cycle);
+        RESET_FAKE(get_seconds_since_power_on);
+        RESET_FAKE(get_current_ms);
+        RESET_FAKE(turn_on_red_led);
+        RESET_FAKE(turn_on_green_led);
+        RESET_FAKE(turn_on_blue_led);
+        RESET_FAKE(enable_charger);
+        RESET_FAKE(disable_charger);
+        RESET_FAKE(enable_bms_ok);
+        RESET_FAKE(disable_bms_ok);
+        RESET_FAKE(is_bms_ok_enabled);
+        RESET_FAKE(enable_imd_ok);
+        RESET_FAKE(disable_imd_ok);
+        RESET_FAKE(is_imd_ok_enabled);
+        RESET_FAKE(enable_bspd_ok);
+        RESET_FAKE(disable_bspd_ok);
+        RESET_FAKE(is_bspd_ok_enabled);
+        RESET_FAKE(is_air_negative_closed);
+        RESET_FAKE(is_air_positive_closed);
+        RESET_FAKE(close_air_positive);
+        RESET_FAKE(configure_cell_monitors);
+        RESET_FAKE(write_cfg_registers);
+        RESET_FAKE(start_voltage_conv);
+        RESET_FAKE(get_min_cell_voltage);
+        RESET_FAKE(get_max_cell_voltage);
+        RESET_FAKE(get_segment_voltage);
+        RESET_FAKE(get_pack_voltage);
+        RESET_FAKE(get_avg_cell_voltage);
+        RESET_FAKE(get_min_cell_voltage);
+        RESET_FAKE(get_max_cell_voltage);
+        RESET_FAKE(get_avg_cell_voltage);
+        RESET_FAKE(get_min_cell_voltage);
+        RESET_FAKE(get_max_cell_voltage);
+        RESET_FAKE(get_low_res_current);
+        RESET_FAKE(get_high_res_current);
+        RESET_FAKE(read_page);
+        RESET_FAKE(write_page);
+        RESET_FAKE(page_erase);
+
+        // Set initial voltages to nominal value
+        set_all_cell_voltages(3.8);
+        start_voltage_conv_fake.return_val = true;
+
+        // A voltage in [3.0, 4.2] was arbitrarily chosen to prevent other
+        // tests from entering the fault state
+        get_min_cell_voltage_fake.return_val = 4.0f;
+        get_max_cell_voltage_fake.return_val = 4.0f;
+
+        // A temperature in [0.0, 60.0] degC to prevent other tests from entering the fault state
+        get_min_temp_degc_fake.return_val = 20.0f;
+        get_max_temp_degc_fake.return_val = 20.0f;
+
+        read_page_fake.return_val  = EEPROM_OK;
+        write_page_fake.return_val = EEPROM_OK;
+        page_erase_fake.return_val = EEPROM_OK;
+
+        is_air_negative_closed_fake.return_val = true;
+        get_ts_voltage_fake.return_val         = 1;
+
+        // Disable charging
+        is_charger_connected_fake.return_val = false;
+        App_CanRx_Debug_ChargingSwitch_StartCharging_Update(false);
+        has_charger_faulted_fake.return_val = false;
+
+        write_page_fake.custom_fake = write_byte_callback;
+        read_page_fake.custom_fake  = read_byte_callback;
+        App_Eeprom_WriteErrCheckedFloat(eeprom, ODOMETER_ADDRESS, STARTING_ODOMETER_READING);
+    }
+
+    void TearDown() override
+    {
+        TearDownObject(world, App_BmsWorld_Destroy);
+        TearDownObject(state_machine, App_SharedStateMachine_Destroy);
+        TearDownObject(imd, App_Imd_Destroy);
+        TearDownObject(heartbeat_monitor, App_SharedHeartbeatMonitor_Destroy);
+        TearDownObject(rgb_led_sequence, App_SharedRgbLedSequence_Destroy);
+        TearDownObject(charger, App_Charger_Destroy);
+        TearDownObject(bms_ok, App_OkStatus_Destroy);
+        TearDownObject(imd_ok, App_OkStatus_Destroy);
+        TearDownObject(bspd_ok, App_OkStatus_Destroy);
+        TearDownObject(accumulator, App_Accumulator_Destroy);
+        TearDownObject(airs, App_Airs_Destroy);
+        TearDownObject(precharge_relay, App_PrechargeRelay_Destroy);
+        TearDownObject(ts, App_TractiveSystem_Destroy);
+        TearDownObject(clock, App_SharedClock_Destroy);
+        TearDownObject(eeprom, App_Eeprom_Destroy);
+        TearDownObject(odometer, App_Odometer_Destroy);
+    }
+
+    void SetInitialState(const struct State *const initial_state)
+    {
+        TearDownObject(state_machine, App_SharedStateMachine_Destroy);
+        state_machine = App_SharedStateMachine_Create(world, initial_state);
+        ASSERT_EQ(initial_state, App_SharedStateMachine_GetCurrentState(state_machine));
+    }
+
+    std::vector<const struct State *> GetAllStates(void)
+    {
+        return std::vector<const struct State *>{
+            App_GetInitState(), App_GetPreChargeState(), App_GetDriveState(), App_GetChargeState(), App_GetFaultState(),
+        };
+    }
+
+    void CheckInRangeCanSignalsInGivenState(
+        const State *state,
+        float        min_value,
+        float        max_value,
+        float &      fake_value,
+        float (*value_can_signal_getter)(const struct BmsCanTxInterface *),
+        uint8_t (*out_of_range_can_signal_getter)(const struct BmsCanTxInterface *),
+        uint8_t ok_choice,
+        uint8_t underflow_choice,
+        uint8_t overflow_choice)
+    {
+        SetInitialState(state);
+
+        // Normal range
+        fake_value = (min_value + max_value) / 2;
+        LetTimePass(state_machine, 1000);
+        ASSERT_EQ(fake_value, value_can_signal_getter(can_tx_interface));
+        ASSERT_EQ(ok_choice, out_of_range_can_signal_getter(can_tx_interface));
+
+        // Underflow range
+        fake_value = std::nextafter(min_value, std::numeric_limits<float>::lowest());
+        LetTimePass(state_machine, 1000);
+        ASSERT_EQ(underflow_choice, out_of_range_can_signal_getter(can_tx_interface));
+
+        // Overflow range
+        fake_value = std::nextafter(max_value, std::numeric_limits<float>::max());
+        LetTimePass(state_machine, 1000);
+        ASSERT_EQ(overflow_choice, out_of_range_can_signal_getter(can_tx_interface));
+    }
+
+    void UpdateClock(struct StateMachine *state_machine, uint32_t current_time_ms) override
+    {
+        struct BmsWorld *world = App_SharedStateMachine_GetWorld(state_machine);
+        struct Clock *   clock = App_BmsWorld_GetClock(world);
+        App_SharedClock_SetCurrentTimeInMilliseconds(clock, current_time_ms);
+    }
+
+    void UpdateSignals(struct StateMachine *state_machine, uint32_t current_time_ms) override
+    {
+        // BMS doesn't use any signals currently
+        UNUSED(state_machine);
+        UNUSED(current_time_ms);
+    }
+
+    struct World *            world;
+    struct StateMachine *     state_machine;
+    struct BmsCanTxInterface *can_tx_interface;
+    struct BmsCanRxInterface *can_rx_interface;
+    struct Imd *              imd;
+    struct HeartbeatMonitor * heartbeat_monitor;
+    struct RgbLedSequence *   rgb_led_sequence;
+    struct Charger *          charger;
+    struct OkStatus *         bms_ok;
+    struct OkStatus *         imd_ok;
+    struct OkStatus *         bspd_ok;
+    struct Accumulator *      accumulator;
+    struct Airs *             airs;
+    struct PrechargeRelay *   precharge_relay;
+    struct TractiveSystem *   ts;
+    struct Clock *            clock;
+    struct Eeprom *           eeprom;
+    struct Odometer *         odometer;
+};
+
+TEST_F(BmsOdometerTest, test_odometer_val_read_from_eeprom)
+{
+    SetInitialState(App_GetInitState());
+
+    // Let accumulator startup count expire
+    LetTimePass(state_machine, 1000);
+
+    ASSERT_EQ(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+}
+
+TEST_F(BmsOdometerTest, test_odometer_val_increases)
+{
+    float wheelspeed_km = 10.0f;
+
+    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+
+    SetInitialState(App_GetInitState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_EQ(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+
+    App_SharedStateMachine_SetNextState(state_machine, App_GetDriveState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_GT(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+}
+
+TEST_F(BmsOdometerTest, test_odometer_val_constant_with_negative_wheelspin)
+{
+    float wheelspeed_km = -10.0f;
+
+    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+
+    SetInitialState(App_GetInitState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_EQ(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+
+    App_SharedStateMachine_SetNextState(state_machine, App_GetDriveState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_EQ(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+}
+
+TEST_F(BmsOdometerTest, test_odometer_val_resets_with_can_message)
+{
+    float wheelspeed_km = 10.0f;
+
+    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+
+    SetInitialState(App_GetInitState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_EQ(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+
+    App_SharedStateMachine_SetNextState(state_machine, App_GetDriveState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_GT(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+
+    App_CanRx_Debug_ResetOdometer_ResetOdometer_Update(true);
+    wheelspeed_km = 0.0f;
+    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+
+    LetTimePass(state_machine, 1000);
+
+    ASSERT_EQ(App_Odometer_GetReading(odometer), 0.0f);
+}
+
+TEST_F(BmsOdometerTest, test_odometer_val_written_to_eeprom)
+{
+    float wheelspeed_km   = 10.0f;
+    int   time_to_wait_ms = 31000; // 30s write interval + 1s to give time for write
+
+    App_CanRx_FSM_Wheels_LeftWheelSpeed_Update(wheelspeed_km);
+    App_CanRx_FSM_Wheels_RightWheelSpeed_Update(wheelspeed_km);
+
+    SetInitialState(App_GetInitState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_EQ(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+
+    App_SharedStateMachine_SetNextState(state_machine, App_GetDriveState());
+
+    LetTimePass(state_machine, 100);
+
+    ASSERT_GT(App_Odometer_GetReading(odometer), STARTING_ODOMETER_READING);
+
+    LetTimePass(state_machine, time_to_wait_ms);
+
+    ASSERT_GT(App_Odometer_ReadValFromEeprom(eeprom, ODOMETER_ADDRESS), STARTING_ODOMETER_READING);
+}
+
+} // namespace OdometerTest

--- a/boards/BMS/Test/Src/Test_StateMachine.cpp
+++ b/boards/BMS/Test/Src/Test_StateMachine.cpp
@@ -128,9 +128,11 @@ class BmsStateMachineTest : public BaseStateMachineTest
 
         eeprom = App_Eeprom_Create(write_page, read_page, page_erase);
 
+        odometer = App_Odometer_Create();
+
         world = App_BmsWorld_Create(
             imd, heartbeat_monitor, rgb_led_sequence, charger, bms_ok, imd_ok, bspd_ok, accumulator, airs,
-            precharge_relay, ts, clock, eeprom);
+            precharge_relay, ts, clock, eeprom, odometer);
 
         // Default to starting the state machine in the `init` state
         state_machine = App_SharedStateMachine_Create(world, App_GetInitState());
@@ -212,6 +214,7 @@ class BmsStateMachineTest : public BaseStateMachineTest
         TearDownObject(ts, App_TractiveSystem_Destroy);
         TearDownObject(clock, App_SharedClock_Destroy);
         TearDownObject(eeprom, App_Eeprom_Destroy);
+        TearDownObject(odometer, App_Odometer_Destroy);
     }
 
     void SetInitialState(const struct State *const initial_state)
@@ -289,6 +292,7 @@ class BmsStateMachineTest : public BaseStateMachineTest
     struct TractiveSystem *   ts;
     struct Clock *            clock;
     struct Eeprom *           eeprom;
+    struct Odometer *         odometer;
 };
 
 TEST_F(BmsStateMachineTest, check_init_state_is_broadcasted_over_can)

--- a/can-bus/json/BMS/BMS_rx.json
+++ b/can-bus/json/BMS/BMS_rx.json
@@ -5,6 +5,8 @@
         "PDM_Vitals",
         "DIM_Vitals",
         "Debug_ChargingSwitch",
-        "Debug_CanModes"
+        "Debug_CanModes",
+        "Debug_ResetOdometer",
+        "FSM_Wheels"
     ]
 }

--- a/can-bus/json/BMS/BMS_rx.json
+++ b/can-bus/json/BMS/BMS_rx.json
@@ -7,6 +7,7 @@
         "Debug_ChargingSwitch",
         "Debug_CanModes",
         "Debug_ResetOdometer",
-        "FSM_Wheels"
+        "INVL_MotorPositionInfo",
+        "INVR_MotorPositionInfo"
     ]
 }

--- a/can-bus/json/BMS/BMS_tx.json
+++ b/can-bus/json/BMS/BMS_tx.json
@@ -286,5 +286,18 @@
                 "unit": "W"
             }
         }
+    },
+    "BMS_OdometerReading": {
+        "msg_id": 121,
+        "cycle_time": 100,
+        "description": "Vehicle Distance Travelled",
+        "signals": {
+            "DistanceTravelled": {
+                "resolution": 0.1,
+                "min": 0,
+                "max": 1000,
+                "unit": "km"
+            }
+        }
     }
 }

--- a/can-bus/json/Debug/Debug_tx.json
+++ b/can-bus/json/Debug/Debug_tx.json
@@ -18,5 +18,15 @@
                 "bits": 1
             }
         }
+    },
+    "Debug_ResetOdometer": {
+        "msg_id": 703,
+        "cycle_time": 100,
+        "description": "Value set by user to reset odometer value.",
+        "signals": {
+            "ResetOdometer": {
+                "bits": 1
+            }
+        }
     }
 }


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Implement Odometer that calculates distance travelled and saves it periodically to the EEPROM.

Function takes in wheel speed from FSM, takes average of both wheels (maybe should take max of two wheels instead?), and uses the circumfrance of the tires to calculate distance travelled.

Saves to EEPROM once every 30 seconds so we don't need to deal with wear levelling for now (could be a longer interval, this isn't a mission-critical statistic in the case of a sudden shutdown)

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
Added App_Odometer.c and App_Odometer.h, Added function in App_Eeprom.c to read/write 4 floats with error checking (reset to 0 if error detected, this makes sense for odometer but might not in the future for other uses)

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
