### PR TITLE
Adding manual control to balancing

### DIFF
--- a/boards/BMS/Inc/App/App_Accumulator.h
+++ b/boards/BMS/Inc/App/App_Accumulator.h
@@ -77,17 +77,6 @@ float App_Accumulator_GetCellVoltage(
     uint8_t                         cell);
 
 /**
- * Get a voltage for a specific cell
- * @param segment The segment containing the cell voltage
- * @param cell The cell location for the voltage
- * @return The voltage at the location given in V
- */
-float App_Accumulator_GetCellVoltage(
-    const struct Accumulator *const accumulator,
-    AccumulatorSegment              segment,
-    uint8_t                         cell);
-
-/**
  * Get min voltage for the accumulator
  * @param accumulator The accumulator to get the min voltage for
  * @param segment The segment containing the min cell voltage

--- a/boards/BMS/Src/App/App_Accumulator.c
+++ b/boards/BMS/Src/App/App_Accumulator.c
@@ -430,7 +430,7 @@ bool App_Accumulator_CheckFaults(struct Accumulator *const accumulator, struct T
     App_CanAlerts_SetFault(BMS_FAULT_CELL_OVERTEMP, overtemp_fault);
     App_CanAlerts_SetFault(BMS_FAULT_MODULE_COMM_ERROR, communication_fault);
 
-    return (undertemp_fault || overvoltage_fault || undervoltage_fault || communication_fault);
+    return (overtemp_fault || undertemp_fault || overvoltage_fault || undervoltage_fault || communication_fault);
 }
 
 void App_Accumulator_EnableBalancing(struct Accumulator *const accumulator, bool enabled)

--- a/can-bus/json/Debug/Debug_tx.json
+++ b/can-bus/json/Debug/Debug_tx.json
@@ -35,6 +35,21 @@
                 "min": 3,
                 "max": 4.2,
                 "unit": "V"
+            },
+            "OverridePWM": {
+                "bits": 1
+            },
+            "OverridePWMFrequency": {
+                "resolution": 0.1,
+                "min": 0,
+                "max": 100,
+                "unit": "Hz"
+            },
+            "OverridePWMDuty": {
+                "resolution": 1,
+                "min": 0,
+                "max": 100,
+                "unit": "%"
             }
         }
     }

--- a/can-bus/json/Debug/Debug_tx.json
+++ b/can-bus/json/Debug/Debug_tx.json
@@ -26,6 +26,15 @@
         "signals": {
             "RequestCellBalancing": {
                 "bits": 1
+            },
+            "OverrideTarget": {
+                "bits": 1
+            },
+            "OverrideTargetValue": {
+                "resolution": 0.0001,
+                "min": 3,
+                "max": 4.2,
+                "unit": "V"
             }
         }
     }


### PR DESCRIPTION
### Summary
Added CAN messages to override the balancing target voltage. Will allow for manual control when needed while balancing is being fixed.

### Changelist 
- Added CAN messages to override balance threshold

### Testing Done
- tested and verified on the pack.

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
