### PR TITLE
Remove -werror flag

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -199,7 +199,6 @@ function(create_arm_binary
         -fno-common
         -fmessage-length=0
         -Wall
-        -Werror
         -Wextra
         -pedantic
         -specs=nosys.specs
@@ -270,7 +269,6 @@ function(create_fake_library
     target_compile_options(${LIBRARY_NAME}
         PUBLIC
         -Wall
-        -Werror
         -g3
     )
     target_include_directories(${LIBRARY_NAME}
@@ -296,7 +294,6 @@ function(compile_gtest_executable
     target_compile_options(${TEST_EXECUTABLE_NAME}
         PUBLIC
         -Wall
-        -Werror
         -g3
     )
     target_link_libraries(${TEST_EXECUTABLE_NAME} gtest_main)

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -199,6 +199,7 @@ function(create_arm_binary
         -fno-common
         -fmessage-length=0
         -Wall
+        -Werror
         -Wextra
         -pedantic
         -specs=nosys.specs


### PR DESCRIPTION
### Summary

Remove `-werror` flag, which causes all warnings to be treated as build errors. This hasn't been a problem in the past since everyone has been using the same version of `gcc` and `MinGW`, but `clang` on macOS is a bit more picky and tests builds are not compiling on some Macs.

We could either 1) go in and fix all warnings or 2) remove this flag and permit warnings. some of the warnings are related to autogenerated code and are so nontrivial fixes. 

Since Mac users are going to be working on tests in the next few days they need builds to be passing - I think we should just remove this flag. This is just for the test binaries so pretty low risk.