### PR TITLE
Platform Independent JSONCAN

### DIFF
--- a/firmware/thruna/BMS/Src/main.c
+++ b/firmware/thruna/BMS/Src/main.c
@@ -270,6 +270,7 @@ int main(void)
     Io_SharedHardFaultHandler_Init();
     Io_SharedSoftwareWatchdog_Init(Io_HardwareWatchdog_Refresh, Io_SoftwareWatchdog_TimeoutCallback);
     Io_SharedCan_Init(&hcan1, CanTxQueueOverflowCallBack, CanRxQueueOverflowCallBack);
+    Io_CanTx_Init(Io_SharedCan_TxMessageQueueSendtoBack);
     Io_CanTx_EnableMode(CAN_MODE_DEFAULT, true);
 
     App_CanTx_Init();

--- a/firmware/thruna/DCM/Src/main.c
+++ b/firmware/thruna/DCM/Src/main.c
@@ -218,6 +218,7 @@ int main(void)
     Io_SharedHardFaultHandler_Init();
     Io_SharedSoftwareWatchdog_Init(Io_HardwareWatchdog_Refresh, Io_SoftwareWatchdog_TimeoutCallback);
     Io_SharedCan_Init(&hcan1, CanTxQueueOverflowCallBack, CanRxQueueOverflowCallBack);
+    Io_CanTx_Init(Io_SharedCan_TxMessageQueueSendtoBack);
     Io_CanTx_EnableMode(CAN_MODE_DEFAULT, true);
 
     if (!Io_EllipseImu_Init())

--- a/firmware/thruna/DIM/src/cubemx/Src/main.c
+++ b/firmware/thruna/DIM/src/cubemx/Src/main.c
@@ -351,6 +351,7 @@ int main(void)
     Io_SharedHardFaultHandler_Init();
     Io_SharedSoftwareWatchdog_Init(io_watchdogConfig_refresh, io_watchdogConfig_timeoutCallback);
     Io_SharedCan_Init(&hcan1, CanTxQueueOverflowCallBack, CanRxQueueOverflowCallBack);
+    Io_CanTx_Init(Io_SharedCan_TxMessageQueueSendtoBack);
     Io_CanTx_EnableMode(CAN_MODE_DEFAULT, true);
 
     io_sevenSegDisplays_init(&seven_segs_config);

--- a/firmware/thruna/FSM/Src/main.c
+++ b/firmware/thruna/FSM/Src/main.c
@@ -251,6 +251,7 @@ int main(void)
     Io_SharedHardFaultHandler_Init();
     Io_SharedSoftwareWatchdog_Init(Io_HardwareWatchdog_Refresh, Io_SoftwareWatchdog_TimeoutCallback);
     Io_SharedCan_Init(&hcan1, CanTxQueueOverflowCallBack, CanRxQueueOverflowCallBack);
+    Io_CanTx_Init(Io_SharedCan_TxMessageQueueSendtoBack);
     Io_CanTx_EnableMode(CAN_MODE_DEFAULT, true);
     Io_AcceleratorPedals_Init();
 

--- a/firmware/thruna/PDM/Src/main.c
+++ b/firmware/thruna/PDM/Src/main.c
@@ -248,6 +248,7 @@ int main(void)
     Io_SharedHardFaultHandler_Init();
     Io_SharedSoftwareWatchdog_Init(Io_HardwareWatchdog_Refresh, Io_SoftwareWatchdog_TimeoutCallback);
     Io_SharedCan_Init(&hcan1, CanTxQueueOverflowCallBack, CanRxQueueOverflowCallBack);
+    Io_CanTx_Init(Io_SharedCan_TxMessageQueueSendtoBack);
     Io_CanTx_EnableMode(CAN_MODE_DEFAULT, true);
 
     App_CanTx_Init();

--- a/scripts/code_generation/jsoncan/src/codegen/c_generation/c_config.py
+++ b/scripts/code_generation/jsoncan/src/codegen/c_generation/c_config.py
@@ -7,6 +7,7 @@ from ...utils import *
 
 class CFuncsConfig(StrEnum):
     # Io Tx
+    IO_TX_INIT = "Io_CanTx_Init"
     IO_TX_ENABLE_MODE = "Io_CanTx_EnableMode"
     IO_TX_ENQUEUE_PERIODIC = "Io_CanTx_Enqueue{freq}Msgs"
     IO_TX_ENQUEUE_OTHER_PERIODIC = "Io_CanTx_EnqueueOtherPeriodicMsgs"


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->

Make `jsoncan` platform independent. This is required so @Lucien950 can use it on the dashboard, without our STM32 firmware.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

To use `jsoncan` on any platform, you need to:
- Define the flag `THREAD_SAFE_CAN_PACKING` if you don't want to use the FreeRTOS thread safe guards
- Define a file called `Io_SharedCanMsg.h` that defines the struct: 
```c
struct CanMsg
{
    uint32_t std_id;
    uint32_t dlc;
    uint8_t  data[8];
};
```
- Call `Io_CanTx_Init` and pass the transmit function that actually sends the message (or pushes it to a queue to be sent later). The function returns void and takes a pointer to a `const struct CanMsg`. 

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

None yet.

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
