### PR TITLE
Fix JSONCAN signed signal packing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 !/.env
 !**/.clang-format
 !inverter-eeprom-config/
-!/.vscode/settings.json
 
 # User-specific uVision files
 # Need to keep .opt/.uvopt/.uvoptx, or else STM32CubeMX code generation will throw an error

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,4 @@
 	"cmake.buildDirectory": "${workspaceFolder}/${env:BUILD_DIR}",
 	"cmake.configureOnEdit": false,
 	"cmake.configureOnOpen": true,
-	"cortex-debug.variableUseNaturalFormat": false
 }

--- a/firmware/thruna/DCM/Src/App/states/App_InitState.c
+++ b/firmware/thruna/DCM/Src/App/states/App_InitState.c
@@ -9,7 +9,7 @@ static void InitStateRunOnEntry(struct StateMachine *const state_machine)
     // Disable inverters and apply zero torque upon entering init state
     App_CanTx_DCM_LeftInverterEnable_Set(false);
     App_CanTx_DCM_RightInverterEnable_Set(false);
-    App_CanTx_DCM_LeftInverterTorqueCommand_Set(0.0f);
+    App_CanTx_DCM_LeftInverterTorqueCommand_Set(-0.63f);
     App_CanTx_DCM_RightInverterTorqueCommand_Set(0.0f);
 }
 

--- a/firmware/thruna/DCM/Src/App/states/App_InitState.c
+++ b/firmware/thruna/DCM/Src/App/states/App_InitState.c
@@ -9,7 +9,7 @@ static void InitStateRunOnEntry(struct StateMachine *const state_machine)
     // Disable inverters and apply zero torque upon entering init state
     App_CanTx_DCM_LeftInverterEnable_Set(false);
     App_CanTx_DCM_RightInverterEnable_Set(false);
-    App_CanTx_DCM_LeftInverterTorqueCommand_Set(-0.63f);
+    App_CanTx_DCM_LeftInverterTorqueCommand_Set(0.0f);
     App_CanTx_DCM_RightInverterTorqueCommand_Set(0.0f);
 }
 


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->

Fix JSONCAN packing of signals sent as signed integers (via 2's complement). I was casting to a `uint32_t` which was setting all negative values to zero.  

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

- Signed integers are packed as `int32_t`s now to avoid issues with unsigned integers
- `gitignore` VS Code's `settings.json` since we keep accidentally committing it and its getting annoying

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

- [x] Tested TX/RX of signed values on hardware and with PCAN 

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
