### PR TITLE
Add workspace setting enable format-on-save for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,17 +9,19 @@
 	],
 	"cmake.configureOnEdit": false,
 	"cmake.configureOnOpen": false,
-	"linux": {
-        "C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6",
-    },
-	"win32" : {
-		"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6.exe",
+	"platformSettings.platforms" : {
+		"linux": {
+			"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6",
+		},
+		"win32" : {
+			"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6.exe",
+		},
+		"darwin" : {
+			"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6-mac",
+		}
 	},
-	"darwin" : {
-		"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6-mac",
-	}
 	 
 	"C_Cpp.clang_format_style": "file:${workspaceFolder}/.clang-format",
 	"platformSettings.autoLoad": true,
-	"application.experimental.rendererProfiling": true
+	"application.experimental.rendererProfiling": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
 		}
 	],
 	"cmake.configureOnEdit": false,
-	"cmake.configureOnOpen": false
+	"cmake.configureOnOpen": false,
+	"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,17 @@
 	],
 	"cmake.configureOnEdit": false,
 	"cmake.configureOnOpen": false,
-	"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6"
+	"linux": {
+        "C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6",
+    },
+	"win32" : {
+		"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6.exe",
+	},
+	"darwin" : {
+		"C_Cpp.clang_format_path": "${workspaceFolder}/scripts/clang_format/clang-format-17.0.6-mac",
+	}
+	 
+	"C_Cpp.clang_format_style": "file:${workspaceFolder}/.clang-format",
+	"platformSettings.autoLoad": true,
+	"application.experimental.rendererProfiling": true
 }


### PR DESCRIPTION
### Summary
A small pr that add a new workspace setting to enable format-on-save for vs code

### Changelist 
workspace setting

### Testing Done


### Resolved Issues


### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
