### PR TITLE
BMS Open Wire Check Hotfix

### DIFF
--- a/firmware/quadruna/BMS/src/app/app_accumulator.c
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.c
@@ -372,6 +372,8 @@ bool app_accumulator_openWireCheck(void)
 
             app_accumulator_owcCalculateFaults();
 
+            is_finished = true;
+
             // give away mutex for iso-SPI
 
             break;

--- a/firmware/thruna/BMS/src/app/app_accumulator.c
+++ b/firmware/thruna/BMS/src/app/app_accumulator.c
@@ -372,6 +372,8 @@ bool app_accumulator_openWireCheck(void)
 
             app_accumulator_owcCalculateFaults();
 
+            is_finished = true;
+
             // give away mutex for iso-SPI
 
             break;
@@ -429,9 +431,9 @@ void app_accumulator_broadcast(void)
 
     app_canTx_BMS_AvailablePower_set(available_power);
     app_canTx_BMS_Seg4Cell2Temp_set(
-        io_ltc6813CellTemperatures_getSpecificCellTempDegC(4, SEG4_CELL2_REG_GROUP, SEG4_CELL2_THERMISTOR));
+        io_ltc6813CellTemperatures_getSpecificCellTempDegC(0, SEG4_CELL2_REG_GROUP, SEG4_CELL2_THERMISTOR));
     app_canTx_BMS_Seg4Cell2Temp_set(
-        io_ltc6813CellTemperatures_getSpecificCellTempDegC(4, SEG4_CELL8_REG_GROUP, SEG4_CELL8_THERMISTOR));
+        io_ltc6813CellTemperatures_getSpecificCellTempDegC(0, SEG4_CELL8_REG_GROUP, SEG4_CELL8_THERMISTOR));
 }
 
 bool app_accumulator_checkFaults(void)

--- a/firmware/thruna/BMS/src/app/app_accumulator.c
+++ b/firmware/thruna/BMS/src/app/app_accumulator.c
@@ -431,9 +431,9 @@ void app_accumulator_broadcast(void)
 
     app_canTx_BMS_AvailablePower_set(available_power);
     app_canTx_BMS_Seg4Cell2Temp_set(
-        io_ltc6813CellTemperatures_getSpecificCellTempDegC(0, SEG4_CELL2_REG_GROUP, SEG4_CELL2_THERMISTOR));
+        io_ltc6813CellTemperatures_getSpecificCellTempDegC(4, SEG4_CELL2_REG_GROUP, SEG4_CELL2_THERMISTOR));
     app_canTx_BMS_Seg4Cell2Temp_set(
-        io_ltc6813CellTemperatures_getSpecificCellTempDegC(0, SEG4_CELL8_REG_GROUP, SEG4_CELL8_THERMISTOR));
+        io_ltc6813CellTemperatures_getSpecificCellTempDegC(4, SEG4_CELL8_REG_GROUP, SEG4_CELL8_THERMISTOR));
 }
 
 bool app_accumulator_checkFaults(void)


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
- Fixes bug where OWC logic will not return to normal voltage/temp readings once it has begun open-wire-check

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

Tested on Pseudo segment

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
