### PR TITLE
enabled bootloader preInit on Quadruna BMS

### DIFF
--- a/firmware/quadruna/BMS/CMakeLists.txt
+++ b/firmware/quadruna/BMS/CMakeLists.txt
@@ -33,7 +33,7 @@ list(APPEND HW_SRCS
     "${SHARED_HW_INCLUDE_DIR}/hw_hardFaultHandler.c"
     "${SHARED_HW_INCLUDE_DIR}/hw_fdcan.c"
     "${SHARED_HW_INCLUDE_DIR}/hw_adcConversions.c"
-    # "${SHARED_HW_INCLUDE_DIR}/hw_bootup.c"
+    "${SHARED_HW_INCLUDE_DIR}/hw_bootup.c"
     "${SHARED_HW_INCLUDE_DIR}/hw_gpio.c"
     "${SHARED_HW_INCLUDE_DIR}/hw_spi.c"
     "${SHARED_HW_INCLUDE_DIR}/hw_pwmInput.c"

--- a/firmware/quadruna/BMS/src/tasks.c
+++ b/firmware/quadruna/BMS/src/tasks.c
@@ -6,7 +6,7 @@
 #include "hw_adc.h"
 #include "hw_gpio.h"
 #include "hw_hardFaultHandler.h"
-// #include "hw_bootup.h"
+#include "hw_bootup.h"
 #include "hw_utils.h"
 #include "hw_spi.h"
 #include "hw_pwmInput.h"
@@ -264,7 +264,7 @@ static UART debug_uart = { .handle = &huart1 };
 void tasks_preInit(void)
 {
     // After booting, re-enable interrupts and ensure the core is using the application's vector table.
-    // hw_bootup_enableInterruptsForApp();
+    hw_bootup_enableInterruptsForApp();
 }
 
 void tasks_init(void)


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->
Enabled preInit function for Bootloader on BMS Quadruna, otherwise HAL_Delay() doesn't work.

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [ ] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [ ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
