### PR TITLE
Add faults/warnings counts messages to CAN message ID collision check

### DIFF
--- a/can_bus/quadruna/VC/VC_tx.json
+++ b/can_bus/quadruna/VC/VC_tx.json
@@ -150,7 +150,7 @@
         }
     },
     "EllipseStatus": {
-        "msg_id": 208,
+        "msg_id": 223,
         "cycle_time": 100,
         "description": "Status of the SBG Ellipse N sensor.",
         "signals": {
@@ -224,7 +224,7 @@
         }
     },
     "EllipseEulerAngles": {
-        "msg_id": 207,
+        "msg_id": 222,
         "cycle_time": 10,
         "description": "Euler angles from the SBG Ellipse N sensor.",
         "signals": {

--- a/firmware/shared/src/hw/hw_can.c
+++ b/firmware/shared/src/hw/hw_can.c
@@ -113,10 +113,10 @@ bool hw_can_receive(uint32_t rx_fifo, CanMsg *msg)
     return true;
 }
 
-void HAL_FDCAN_RxFifo0Callback(CAN_HandleTypeDef *hcan, uint32_t RxFifo0ITs)
+void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
 {
     CanMsg rx_msg;
-    if (!hw_can_receive(RxFifo0ITs, &rx_msg))
+    if (!hw_can_receive(CAN_RX_FIFO0, &rx_msg))
     {
         // Early return if RX msg is unavailable.
         return;
@@ -125,10 +125,10 @@ void HAL_FDCAN_RxFifo0Callback(CAN_HandleTypeDef *hcan, uint32_t RxFifo0ITs)
     handle->can_msg_received_callback(&rx_msg);
 }
 
-void HAL_FDCAN_RxFifo1Callback(CAN_HandleTypeDef *hcan, uint32_t RxFifo1ITs)
+void HAL_CAN_RxFifo1MsgPendingCallback(CAN_HandleTypeDef *hcan)
 {
     CanMsg rx_msg;
-    if (!hw_can_receive(RxFifo1ITs, &rx_msg))
+    if (!hw_can_receive(CAN_RX_FIFO1, &rx_msg))
     {
         // Early return if RX msg is unavailable.
         return;

--- a/scripts/code_generation/jsoncan/src/json_parsing/json_can_parsing.py
+++ b/scripts/code_generation/jsoncan/src/json_parsing/json_can_parsing.py
@@ -1,6 +1,7 @@
 """
 Module for parsing CAN JSON, and returning a CanDatabase object. 
 """
+
 import os
 from typing import Dict, Tuple
 import json
@@ -447,12 +448,12 @@ class JsonCanParser:
 
         if any(
             msg_id in {msg.id for msg in self._messages.values()}
-            for msg_id in (warnings_id, faults_id)
+            for msg_id in (warnings_id, faults_id, warnings_counts_id, faults_counts_id)
         ):
             conflicting_node = [
                 msg
                 for msg in self._messages.values()
-                for i in (warnings_id, faults_id)
+                for i in (warnings_id, faults_id, warnings_counts_id, faults_counts_id)
                 if msg.id == i
             ][0]
             raise InvalidCanJson(


### PR DESCRIPTION
### Summary
<!-- Quick summary of changes, optional -->

The faults/warnings counts messages in JSONCAN weren't being checked for ID collisions (other messages having the same ID). So, we accidentally declared two messages with the same ID, leading to garbage on the CAN bus. Fixed!

Also there was a typo in the `hw_can.c` interrupt request handlers. Fixed!

### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Issues
<!-- Link any issues that this PR resolved like so: `Resolves #1, #2, and #5` (Note: Using this format, Github will automatically close the issue(s) when this PR is merged in). -->

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
