### PR TITLE
Configure Heartbeat Monitors on Quadruna Boards

### DIFF
--- a/can_bus/quadruna/BMS/BMS_alerts.json
+++ b/can_bus/quadruna/BMS/BMS_alerts.json
@@ -14,9 +14,8 @@
         "RxOverflow"
     ],
     "faults": [
-        "MissingFSMHeartbeat",
-        "MissingDCMHeartbeat",
-        "MissingPDMHeartbeat",
+        "MissingVCHeartbeat",
+        "MissingRSMHeartbeat",
         "StateMachine",
         "CellUndervoltage",
         "CellOvervoltage",

--- a/can_bus/quadruna/BMS/BMS_rx.json
+++ b/can_bus/quadruna/BMS/BMS_rx.json
@@ -1,6 +1,6 @@
 {
     "messages": [
-        "FSM_Vitals",
+        "RSM_Vitals",
         "VC_Vitals",
         "Debug_Charging",
         "Debug_CanMode",

--- a/can_bus/quadruna/CRIT/CRIT_alerts.json
+++ b/can_bus/quadruna/CRIT/CRIT_alerts.json
@@ -16,7 +16,7 @@
     "faults": [
         "MissingBMSHeartbeat",
         "MissingFSMHeartbeat",
-        "MissingPDMHeartbeat",
-        "MissingDCMHeartbeat"
+        "MissingRSMHeartbeat",
+        "MissingVCHeartbeat"
     ]
 }

--- a/can_bus/quadruna/CRIT/CRIT_rx.json
+++ b/can_bus/quadruna/CRIT/CRIT_rx.json
@@ -1,8 +1,10 @@
 {
 	"messages": [
-		"BMS_Contactors",
 		"BMS_Vitals",
 		"FSM_Vitals",
+		"RSM_Vitals",
+		"VC_Vitals",
+		"BMS_Contactors",
 		"BMS_OkStatuses"
 	]
 }

--- a/can_bus/quadruna/RSM/RSM_alerts.json
+++ b/can_bus/quadruna/RSM/RSM_alerts.json
@@ -19,6 +19,7 @@
     ],
     "faults": [
         "FlowMeterUnderflow",
-        "MissingBMSHeartbeat"
+        "MissingBMSHeartbeat",
+        "MissingFSMHeartbeat"
     ]
 }

--- a/can_bus/quadruna/VC/VC_alerts.json
+++ b/can_bus/quadruna/VC/VC_alerts.json
@@ -23,7 +23,7 @@
     "faults": [
         "MissingBMSHeartbeat",
         "MissingFSMHeartbeat",
-        "MissingDIMHeartbeat",
+        "MissingRSMHeartbeat",
         "MissingCRITHeartbeat",
         "LeftInverterFault",
         "RightInverterFault",

--- a/can_bus/quadruna/VC/VC_rx.json
+++ b/can_bus/quadruna/VC/VC_rx.json
@@ -2,6 +2,7 @@
     "messages": [
         "BMS_Vitals",
         "FSM_Vitals",
+        "RSM_Vitals",
         "CRIT_Vitals",
         "FSM_Apps",
         "FSM_Steering",

--- a/firmware/quadruna/BMS/src/tasks.c
+++ b/firmware/quadruna/BMS/src/tasks.c
@@ -200,6 +200,7 @@ static const GlobalsConfig globals_config = {
 };
 
 // config for heartbeat monitor (can funcs and flags)
+// BMS relies on RSM, VC
 bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
     [BMS_HEARTBEAT_BOARD] = false, [VC_HEARTBEAT_BOARD] = true,   [RSM_HEARTBEAT_BOARD] = true,
     [FSM_HEARTBEAT_BOARD] = false, [DIM_HEARTBEAT_BOARD] = false, [CRIT_HEARTBEAT_BOARD] = false

--- a/firmware/quadruna/BMS/src/tasks.c
+++ b/firmware/quadruna/BMS/src/tasks.c
@@ -208,19 +208,19 @@ bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
 
 // heartbeatGetters - get heartbeat signals from other boards
 bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = { [BMS_HEARTBEAT_BOARD]  = NULL,
-                                                        [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_get,
-                                                        [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
-                                                        [FSM_HEARTBEAT_BOARD]  = NULL,
-                                                        [DIM_HEARTBEAT_BOARD]  = NULL,
-                                                        [CRIT_HEARTBEAT_BOARD] = NULL };
+                                                      [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_get,
+                                                      [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
+                                                      [FSM_HEARTBEAT_BOARD]  = NULL,
+                                                      [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                      [CRIT_HEARTBEAT_BOARD] = NULL };
 
 // heartbeatUpdaters - update local CAN table with heartbeat status
 void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = { [BMS_HEARTBEAT_BOARD]  = NULL,
-                                                            [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_update,
-                                                            [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
-                                                            [FSM_HEARTBEAT_BOARD]  = NULL,
-                                                            [DIM_HEARTBEAT_BOARD]  = NULL,
-                                                            [CRIT_HEARTBEAT_BOARD] = NULL };
+                                                           [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_update,
+                                                           [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
+                                                           [FSM_HEARTBEAT_BOARD]  = NULL,
+                                                           [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                           [CRIT_HEARTBEAT_BOARD] = NULL };
 
 // heartbeatFaultSetters - broadcast heartbeat faults over CAN
 void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {

--- a/firmware/quadruna/BMS/src/tasks.c
+++ b/firmware/quadruna/BMS/src/tasks.c
@@ -200,34 +200,45 @@ static const GlobalsConfig globals_config = {
 };
 
 // config for heartbeat monitor (can funcs and flags)
-// TODO: fill out these configs
 bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
-    [BMS_HEARTBEAT_BOARD] = false, [VC_HEARTBEAT_BOARD] = false,  [RSM_HEARTBEAT_BOARD] = false,
+    [BMS_HEARTBEAT_BOARD] = false, [VC_HEARTBEAT_BOARD] = true,   [RSM_HEARTBEAT_BOARD] = true,
     [FSM_HEARTBEAT_BOARD] = false, [DIM_HEARTBEAT_BOARD] = false, [CRIT_HEARTBEAT_BOARD] = false
 };
 
 // heartbeatGetters - get heartbeat signals from other boards
-bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = {
-    [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-    [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
-};
+bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = { [BMS_HEARTBEAT_BOARD]  = NULL,
+                                                        [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_get,
+                                                        [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
+                                                        [FSM_HEARTBEAT_BOARD]  = NULL,
+                                                        [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                        [CRIT_HEARTBEAT_BOARD] = NULL };
 
 // heartbeatUpdaters - update local CAN table with heartbeat status
-void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = {
-    [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-    [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
-};
+void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = { [BMS_HEARTBEAT_BOARD]  = NULL,
+                                                            [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_update,
+                                                            [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
+                                                            [FSM_HEARTBEAT_BOARD]  = NULL,
+                                                            [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                            [CRIT_HEARTBEAT_BOARD] = NULL };
 
 // heartbeatFaultSetters - broadcast heartbeat faults over CAN
 void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
-    [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-    [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
+    [BMS_HEARTBEAT_BOARD]  = NULL,
+    [VC_HEARTBEAT_BOARD]   = app_canAlerts_BMS_Fault_MissingVCHeartbeat_set,
+    [RSM_HEARTBEAT_BOARD]  = app_canAlerts_BMS_Fault_MissingRSMHeartbeat_set,
+    [FSM_HEARTBEAT_BOARD]  = NULL,
+    [DIM_HEARTBEAT_BOARD]  = NULL,
+    [CRIT_HEARTBEAT_BOARD] = NULL
 };
 
 // heartbeatFaultGetters - gets fault statuses over CAN
 bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
-    [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-    [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
+    [BMS_HEARTBEAT_BOARD]  = NULL,
+    [VC_HEARTBEAT_BOARD]   = app_canAlerts_BMS_Fault_MissingVCHeartbeat_get,
+    [RSM_HEARTBEAT_BOARD]  = app_canAlerts_BMS_Fault_MissingRSMHeartbeat_get,
+    [FSM_HEARTBEAT_BOARD]  = NULL,
+    [DIM_HEARTBEAT_BOARD]  = NULL,
+    [CRIT_HEARTBEAT_BOARD] = NULL
 };
 
 const Gpio *id_to_gpio[] = { [BMS_GpioNetName_ACCEL_BRAKE_OK_3V3]     = &accel_brake_ok_pin,

--- a/firmware/quadruna/BMS/test/test_bmsBaseStateMachineTest.h
+++ b/firmware/quadruna/BMS/test/test_bmsBaseStateMachineTest.h
@@ -126,34 +126,45 @@ class BmsBaseStateMachineTest : public BaseStateMachineTest
     const FaultLatch           bspd_ok_latch      = {};
 
     // config for heartbeat monitor (can funcs and flags)
-    // TODO: fill out these configs
     bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
-        [BMS_HEARTBEAT_BOARD] = false, [VC_HEARTBEAT_BOARD] = false,  [RSM_HEARTBEAT_BOARD] = false,
+        [BMS_HEARTBEAT_BOARD] = false, [VC_HEARTBEAT_BOARD] = true,   [RSM_HEARTBEAT_BOARD] = true,
         [FSM_HEARTBEAT_BOARD] = false, [DIM_HEARTBEAT_BOARD] = false, [CRIT_HEARTBEAT_BOARD] = false
     };
 
     // heartbeatGetters - get heartbeat signals from other boards
-    bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = {
-        [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-        [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
-    };
+    bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = { [BMS_HEARTBEAT_BOARD]  = NULL,
+                                                          [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_get,
+                                                          [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
+                                                          [FSM_HEARTBEAT_BOARD]  = NULL,
+                                                          [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                          [CRIT_HEARTBEAT_BOARD] = NULL };
 
     // heartbeatUpdaters - update local CAN table with heartbeat status
-    void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = {
-        [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-        [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
-    };
+    void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = { [BMS_HEARTBEAT_BOARD]  = NULL,
+                                                               [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_update,
+                                                               [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
+                                                               [FSM_HEARTBEAT_BOARD]  = NULL,
+                                                               [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                               [CRIT_HEARTBEAT_BOARD] = NULL };
 
     // heartbeatFaultSetters - broadcast heartbeat faults over CAN
     void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
-        [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-        [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
+        [BMS_HEARTBEAT_BOARD]  = NULL,
+        [VC_HEARTBEAT_BOARD]   = app_canAlerts_BMS_Fault_MissingVCHeartbeat_set,
+        [RSM_HEARTBEAT_BOARD]  = app_canAlerts_BMS_Fault_MissingRSMHeartbeat_set,
+        [FSM_HEARTBEAT_BOARD]  = NULL,
+        [DIM_HEARTBEAT_BOARD]  = NULL,
+        [CRIT_HEARTBEAT_BOARD] = NULL
     };
 
     // heartbeatFaultGetters - gets fault statuses over CAN
     bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
-        [BMS_HEARTBEAT_BOARD] = NULL, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-        [FSM_HEARTBEAT_BOARD] = NULL, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
+        [BMS_HEARTBEAT_BOARD]  = NULL,
+        [VC_HEARTBEAT_BOARD]   = app_canAlerts_BMS_Fault_MissingVCHeartbeat_get,
+        [RSM_HEARTBEAT_BOARD]  = app_canAlerts_BMS_Fault_MissingRSMHeartbeat_get,
+        [FSM_HEARTBEAT_BOARD]  = NULL,
+        [DIM_HEARTBEAT_BOARD]  = NULL,
+        [CRIT_HEARTBEAT_BOARD] = NULL
     };
 
     const GlobalsConfig globals_config = {

--- a/firmware/quadruna/BMS/test/test_bmsBaseStateMachineTest.h
+++ b/firmware/quadruna/BMS/test/test_bmsBaseStateMachineTest.h
@@ -126,6 +126,7 @@ class BmsBaseStateMachineTest : public BaseStateMachineTest
     const FaultLatch           bspd_ok_latch      = {};
 
     // config for heartbeat monitor (can funcs and flags)
+    // BMS relies on RSM, VC
     bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
         [BMS_HEARTBEAT_BOARD] = false, [VC_HEARTBEAT_BOARD] = true,   [RSM_HEARTBEAT_BOARD] = true,
         [FSM_HEARTBEAT_BOARD] = false, [DIM_HEARTBEAT_BOARD] = false, [CRIT_HEARTBEAT_BOARD] = false

--- a/firmware/quadruna/CRIT/src/tasks.c
+++ b/firmware/quadruna/CRIT/src/tasks.c
@@ -325,30 +325,34 @@ static const GlobalsConfig globals_config = { .imd_led          = &imd_led,
                                               .vc_status_led    = &vc_status_led,
                                               .shdn_sen_pin     = &shdn_sen_pin };
 
-// CRIT rellies on all boards but AUX & CRIT
 // TODO: add heartbeat for VC and RSM
+// CRIT rellies on BMS, VC, RSM, FSM
 bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
-    [BMS_HEARTBEAT_BOARD] = true, [VC_HEARTBEAT_BOARD] = false,  [RSM_HEARTBEAT_BOARD] = false,
+    [BMS_HEARTBEAT_BOARD] = true, [VC_HEARTBEAT_BOARD] = true,   [RSM_HEARTBEAT_BOARD] = true,
     [FSM_HEARTBEAT_BOARD] = true, [DIM_HEARTBEAT_BOARD] = false, [CRIT_HEARTBEAT_BOARD] = false
 };
 
 // heartbeatGetters - get heartbeat signals from other boards
-bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = {
-    [BMS_HEARTBEAT_BOARD] = app_canRx_BMS_Heartbeat_get, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-    [FSM_HEARTBEAT_BOARD] = app_canRx_FSM_Heartbeat_get, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
-};
+bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = { [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_get,
+                                                      [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_get,
+                                                      [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
+                                                      [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_get,
+                                                      [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                      [CRIT_HEARTBEAT_BOARD] = NULL };
 
 // heartbeatUpdaters - update local CAN table with heartbeat status
-void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = {
-    [BMS_HEARTBEAT_BOARD] = app_canRx_BMS_Heartbeat_update, [VC_HEARTBEAT_BOARD] = NULL,  [RSM_HEARTBEAT_BOARD] = NULL,
-    [FSM_HEARTBEAT_BOARD] = app_canRx_FSM_Heartbeat_update, [DIM_HEARTBEAT_BOARD] = NULL, [CRIT_HEARTBEAT_BOARD] = NULL
-};
+void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = { [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_update,
+                                                           [VC_HEARTBEAT_BOARD]   = app_canRx_VC_Heartbeat_update,
+                                                           [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
+                                                           [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_update,
+                                                           [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                           [CRIT_HEARTBEAT_BOARD] = NULL };
 
 // heartbeatFaultSetters - broadcast heartbeat faults over CAN
 void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
     [BMS_HEARTBEAT_BOARD]  = app_canAlerts_CRIT_Fault_MissingBMSHeartbeat_set,
-    [VC_HEARTBEAT_BOARD]   = NULL,
-    [RSM_HEARTBEAT_BOARD]  = NULL,
+    [VC_HEARTBEAT_BOARD]   = app_canAlerts_CRIT_Fault_MissingVCHeartbeat_set,
+    [RSM_HEARTBEAT_BOARD]  = app_canAlerts_CRIT_Fault_MissingRSMHeartbeat_set,
     [FSM_HEARTBEAT_BOARD]  = app_canAlerts_CRIT_Fault_MissingFSMHeartbeat_set,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = NULL
@@ -357,8 +361,8 @@ void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
 // heartbeatFaultGetters - gets fault statuses over CAN
 bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
     [BMS_HEARTBEAT_BOARD]  = app_canAlerts_CRIT_Fault_MissingBMSHeartbeat_get,
-    [VC_HEARTBEAT_BOARD]   = NULL,
-    [RSM_HEARTBEAT_BOARD]  = NULL,
+    [VC_HEARTBEAT_BOARD]   = app_canAlerts_CRIT_Fault_MissingVCHeartbeat_get,
+    [RSM_HEARTBEAT_BOARD]  = app_canAlerts_CRIT_Fault_MissingRSMHeartbeat_get,
     [FSM_HEARTBEAT_BOARD]  = app_canAlerts_CRIT_Fault_MissingFSMHeartbeat_get,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = NULL

--- a/firmware/quadruna/RSM/src/tasks.c
+++ b/firmware/quadruna/RSM/src/tasks.c
@@ -120,7 +120,7 @@ void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
     [BMS_HEARTBEAT_BOARD]  = app_canAlerts_RSM_Fault_MissingBMSHeartbeat_set,
     [VC_HEARTBEAT_BOARD]   = NULL,
     [RSM_HEARTBEAT_BOARD]  = NULL,
-    [FSM_HEARTBEAT_BOARD]  = app_canAlerts_RSM_Fault_MissingBMSHeartbeat_set,
+    [FSM_HEARTBEAT_BOARD]  = app_canAlerts_RSM_Fault_MissingFSMHeartbeat_set,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = NULL
 };
@@ -130,7 +130,7 @@ bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
     [BMS_HEARTBEAT_BOARD]  = app_canAlerts_RSM_Fault_MissingBMSHeartbeat_get,
     [VC_HEARTBEAT_BOARD]   = NULL,
     [RSM_HEARTBEAT_BOARD]  = NULL,
-    [FSM_HEARTBEAT_BOARD]  = app_canAlerts_RSM_Fault_MissingBMSHeartbeat_get,
+    [FSM_HEARTBEAT_BOARD]  = app_canAlerts_RSM_Fault_MissingFSMHeartbeat_get,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = NULL
 };

--- a/firmware/quadruna/VC/src/tasks.c
+++ b/firmware/quadruna/VC/src/tasks.c
@@ -232,21 +232,19 @@ bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
 
 // heartbeatGetters - get heartbeat signals from other boards
 bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = { [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_get,
-                                                        [VC_HEARTBEAT_BOARD]   = NULL,
-                                                        [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
-                                                        [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_get,
-                                                        [DIM_HEARTBEAT_BOARD]  = NULL,
-                                                        [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_get };
+                                                      [VC_HEARTBEAT_BOARD]   = NULL,
+                                                      [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
+                                                      [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_get,
+                                                      [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                      [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_get };
 
 // heartbeatUpdaters - update local CAN table with heartbeat status
-void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = {
-    [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_update,
-    [VC_HEARTBEAT_BOARD]   = NULL,
-    [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
-    [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_update,
-    [DIM_HEARTBEAT_BOARD]  = NULL,
-    [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_update
-};
+void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = { [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_update,
+                                                           [VC_HEARTBEAT_BOARD]   = NULL,
+                                                           [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
+                                                           [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_update,
+                                                           [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                           [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_update };
 
 // heartbeatFaultSetters - broadcast heartbeat faults over CAN
 void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
@@ -262,7 +260,7 @@ void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
 bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
     [BMS_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingBMSHeartbeat_get,
     [VC_HEARTBEAT_BOARD]   = NULL,
-    [RSM_HEARTBEAT_BOARD]  =  app_canAlerts_VC_Fault_MissingRSMHeartbeat_get,
+    [RSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingRSMHeartbeat_get,
     [FSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingFSMHeartbeat_get,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = app_canAlerts_VC_Fault_MissingCRITHeartbeat_get

--- a/firmware/quadruna/VC/src/tasks.c
+++ b/firmware/quadruna/VC/src/tasks.c
@@ -222,9 +222,9 @@ static void (*efuse_current_can_setters[NUM_EFUSE_CHANNELS])(float) = {
 static Buzzer buzzer     = { .gpio = buzzer_pwr_en };
 static UART   debug_uart = { .handle = &huart7 };
 static UART   imu_uart   = { .handle = &huart2 };
+
 // config for heartbeat monitor (can funcs and flags)
 // VC relies on FSM, RSM, BMS, CRIT
-// TODO: add RSM to config when boards are ready, also add vitals to canRx json
 bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
     [BMS_HEARTBEAT_BOARD] = true, [VC_HEARTBEAT_BOARD] = false, [RSM_HEARTBEAT_BOARD] = true,
     [FSM_HEARTBEAT_BOARD] = true, [DIM_HEARTBEAT_BOARD] = true, [CRIT_HEARTBEAT_BOARD] = true
@@ -232,17 +232,17 @@ bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
 
 // heartbeatGetters - get heartbeat signals from other boards
 bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = { [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_get,
-                                                      [VC_HEARTBEAT_BOARD]   = NULL,
-                                                      [RSM_HEARTBEAT_BOARD]  = NULL, // app_canRx_RSM_Heartbeat_get
-                                                      [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_get,
-                                                      [DIM_HEARTBEAT_BOARD]  = NULL,
-                                                      [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_get };
+                                                        [VC_HEARTBEAT_BOARD]   = NULL,
+                                                        [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
+                                                        [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_get,
+                                                        [DIM_HEARTBEAT_BOARD]  = NULL,
+                                                        [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_get };
 
 // heartbeatUpdaters - update local CAN table with heartbeat status
 void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = {
     [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_update,
     [VC_HEARTBEAT_BOARD]   = NULL,
-    [RSM_HEARTBEAT_BOARD]  = NULL, // app_canRx_RSM_Heartbeat_update
+    [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
     [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_update,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_update
@@ -252,7 +252,7 @@ void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = {
 void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
     [BMS_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingBMSHeartbeat_set,
     [VC_HEARTBEAT_BOARD]   = NULL,
-    [RSM_HEARTBEAT_BOARD]  = NULL, // app_canAlerts_VC_Fault_MissingRSMHeartbeat_set
+    [RSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingRSMHeartbeat_set,
     [FSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingFSMHeartbeat_set,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = app_canAlerts_VC_Fault_MissingCRITHeartbeat_set
@@ -262,7 +262,7 @@ void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
 bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
     [BMS_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingBMSHeartbeat_get,
     [VC_HEARTBEAT_BOARD]   = NULL,
-    [RSM_HEARTBEAT_BOARD]  = NULL, // app_canAlerts_VC_Fault_MissingRSMHeartbeat_get
+    [RSM_HEARTBEAT_BOARD]  =  app_canAlerts_VC_Fault_MissingRSMHeartbeat_get,
     [FSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingFSMHeartbeat_get,
     [DIM_HEARTBEAT_BOARD]  = NULL,
     [CRIT_HEARTBEAT_BOARD] = app_canAlerts_VC_Fault_MissingCRITHeartbeat_get

--- a/firmware/quadruna/VC/test/test_vcBaseStateMachineTest.h
+++ b/firmware/quadruna/VC/test/test_vcBaseStateMachineTest.h
@@ -146,7 +146,7 @@ class VcBaseStateMachineTest : public BaseStateMachineTest
     bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
         [BMS_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingBMSHeartbeat_get,
         [VC_HEARTBEAT_BOARD]   = NULL,
-        [RSM_HEARTBEAT_BOARD]  =  app_canAlerts_VC_Fault_MissingRSMHeartbeat_get,
+        [RSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingRSMHeartbeat_get,
         [FSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingFSMHeartbeat_get,
         [DIM_HEARTBEAT_BOARD]  = NULL,
         [CRIT_HEARTBEAT_BOARD] = app_canAlerts_VC_Fault_MissingCRITHeartbeat_get

--- a/firmware/quadruna/VC/test/test_vcBaseStateMachineTest.h
+++ b/firmware/quadruna/VC/test/test_vcBaseStateMachineTest.h
@@ -109,7 +109,6 @@ class VcBaseStateMachineTest : public BaseStateMachineTest
 
     // config for heartbeat monitor (can funcs and flags)
     // VC relies on FSM, RSM, BMS, CRIT
-    // TODO: add RSM to config when boards are ready, also add vitals to canRx json
     bool heartbeatMonitorChecklist[HEARTBEAT_BOARD_COUNT] = {
         [BMS_HEARTBEAT_BOARD] = true, [VC_HEARTBEAT_BOARD] = false, [RSM_HEARTBEAT_BOARD] = true,
         [FSM_HEARTBEAT_BOARD] = true, [DIM_HEARTBEAT_BOARD] = true, [CRIT_HEARTBEAT_BOARD] = true
@@ -118,7 +117,7 @@ class VcBaseStateMachineTest : public BaseStateMachineTest
     // heartbeatGetters - get heartbeat signals from other boards
     bool (*heartbeatGetters[HEARTBEAT_BOARD_COUNT])() = { [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_get,
                                                           [VC_HEARTBEAT_BOARD]   = NULL,
-                                                          [RSM_HEARTBEAT_BOARD]  = NULL, // app_canRx_RSM_Heartbeat_get
+                                                          [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_get,
                                                           [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_get,
                                                           [DIM_HEARTBEAT_BOARD]  = NULL,
                                                           [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_get };
@@ -127,7 +126,7 @@ class VcBaseStateMachineTest : public BaseStateMachineTest
     void (*heartbeatUpdaters[HEARTBEAT_BOARD_COUNT])(bool) = {
         [BMS_HEARTBEAT_BOARD]  = app_canRx_BMS_Heartbeat_update,
         [VC_HEARTBEAT_BOARD]   = NULL,
-        [RSM_HEARTBEAT_BOARD]  = NULL, // app_canRx_RSM_Heartbeat_update
+        [RSM_HEARTBEAT_BOARD]  = app_canRx_RSM_Heartbeat_update,
         [FSM_HEARTBEAT_BOARD]  = app_canRx_FSM_Heartbeat_update,
         [DIM_HEARTBEAT_BOARD]  = NULL,
         [CRIT_HEARTBEAT_BOARD] = app_canRx_CRIT_Heartbeat_update
@@ -137,7 +136,7 @@ class VcBaseStateMachineTest : public BaseStateMachineTest
     void (*heartbeatFaultSetters[HEARTBEAT_BOARD_COUNT])(bool) = {
         [BMS_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingBMSHeartbeat_set,
         [VC_HEARTBEAT_BOARD]   = NULL,
-        [RSM_HEARTBEAT_BOARD]  = NULL, // app_canAlerts_VC_Fault_MissingRSMHeartbeat_set
+        [RSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingRSMHeartbeat_set,
         [FSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingFSMHeartbeat_set,
         [DIM_HEARTBEAT_BOARD]  = NULL,
         [CRIT_HEARTBEAT_BOARD] = app_canAlerts_VC_Fault_MissingCRITHeartbeat_set
@@ -147,7 +146,7 @@ class VcBaseStateMachineTest : public BaseStateMachineTest
     bool (*heartbeatFaultGetters[HEARTBEAT_BOARD_COUNT])() = {
         [BMS_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingBMSHeartbeat_get,
         [VC_HEARTBEAT_BOARD]   = NULL,
-        [RSM_HEARTBEAT_BOARD]  = NULL, // app_canAlerts_VC_Fault_MissingRSMHeartbeat_get
+        [RSM_HEARTBEAT_BOARD]  =  app_canAlerts_VC_Fault_MissingRSMHeartbeat_get,
         [FSM_HEARTBEAT_BOARD]  = app_canAlerts_VC_Fault_MissingFSMHeartbeat_get,
         [DIM_HEARTBEAT_BOARD]  = NULL,
         [CRIT_HEARTBEAT_BOARD] = app_canAlerts_VC_Fault_MissingCRITHeartbeat_get


### PR DESCRIPTION
### Summary
Fixes up heartbeat monitor configs/canTx/canRx on quadruna boards. See https://ubcformulaelectric.atlassian.net/l/cp/4b2W1duN for specification.

### Changelist 
- Fixed configs on
  - BMS
  - RSM
  - CRIT
  - VC

### Testing Done
- None

### Resolved Issues

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
