### PR TITLE
VC CAN Alert Code Gen Fix

### DIFF
--- a/scripts/code_generation/jsoncan/example_generated/app/app_canAlerts.c
+++ b/scripts/code_generation/jsoncan/example_generated/app/app_canAlerts.c
@@ -123,7 +123,7 @@ uint8_t app_canAlerts_WarningInfo(Fault_Warning_Info *alert_array)
     {
         alert_array[element_num].name = "FSM_Warning_Warning_Test1";
         alert_array[element_num].description = "Example";
-        alert_array[element_num].id = "1000";
+        alert_array[element_num].id = 1000;
         element_num++;
     }
     
@@ -131,7 +131,7 @@ uint8_t app_canAlerts_WarningInfo(Fault_Warning_Info *alert_array)
     {
         alert_array[element_num].name = "FSM_Warning_Warning_Test2";
         alert_array[element_num].description = "Example";
-        alert_array[element_num].id = "21000";
+        alert_array[element_num].id = 21000;
         element_num++;
     }
     
@@ -139,7 +139,7 @@ uint8_t app_canAlerts_WarningInfo(Fault_Warning_Info *alert_array)
     {
         alert_array[element_num].name = "JCT_Warning_Warning_Test";
         alert_array[element_num].description = "Example";
-        alert_array[element_num].id = "2000";
+        alert_array[element_num].id = 2000;
         element_num++;
     }
     
@@ -155,7 +155,7 @@ uint8_t app_canAlerts_FaultInfo(Fault_Warning_Info *alert_array)
     {
         alert_array[element_num].name = "FSM_Fault_Fault_Test3";
         alert_array[element_num].description = "";
-        alert_array[element_num].id = "0";
+        alert_array[element_num].id = 0;
         element_num++;
     }
     

--- a/scripts/code_generation/jsoncan/src/codegen/c_generation/app_can_alerts_module.py
+++ b/scripts/code_generation/jsoncan/src/codegen/c_generation/app_can_alerts_module.py
@@ -150,7 +150,7 @@ class AppCanAlertsModule(CModule):
                  
                 get_alert.body.add_line(f'alert_array[element_num].name = "{alert}";')
                 get_alert.body.add_line(f'alert_array[element_num].description = "{description}";')
-                get_alert.body.add_line(f'alert_array[element_num].id = "{id}";')
+                get_alert.body.add_line(f'alert_array[element_num].id = {id};')
                 get_alert.body.add_line("element_num++;")
 
                 get_alert.body.end_if()


### PR DESCRIPTION
### Summary
VC tests were not running due to a bug in the code gen python script for can alerts.
Was getting this error:
` error: incompatible pointer to integer conversion assigning to 'uint16_t' (aka 'unsigned short') from 'char[4]' [-Wint-conversion]
alert_array[element_num].id = "311";`

### Testing Done
No errors thrown anymore

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x ] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
