### PR TITLE
VC State Machine Transitions

### DIFF
--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -8,6 +8,7 @@
 #include "app_powerManager.h"
 #include "states/app_initState.h"
 #include "states/app_driveState.h"
+#include "states/app_inverterOnState.h"
 #include "app_globals.h"
 #include "app_torqueVectoring.h"
 #include "app_faultCheck.h"
@@ -120,7 +121,7 @@ static void driveStateRunOnTick100Hz(void)
     }
     else if (exit_drive_to_inverterOn)
     {
-        app_stateMachine_setNextState(app_inverterOn_get());
+        app_stateMachine_setNextState(app_inverterOnState_get());
         return;
     }
 

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -118,6 +118,7 @@ static void driveStateRunOnTick100Hz(void)
     if (exit_drive_to_init)
     {
         app_stateMachine_setNextState(app_initState_get());
+        return;
     }
     else if (exit_drive_to_inverterOn)
     {

--- a/firmware/quadruna/VC/src/app/states/app_initState.c
+++ b/firmware/quadruna/VC/src/app/states/app_initState.c
@@ -35,11 +35,11 @@ static void initStateRunOnTick100Hz(void)
     const bool inverter_has_fault  = app_inverterFaultCheck();
     const bool all_states_ok       = !(any_board_has_fault || inverter_has_fault);
 
-    bool is_inverter_on_or_drive_state = app_canRx_BMS_State_get() == BMS_INVERTER_ON_STATE ||
-                                         app_canRx_BMS_State_get() == BMS_PRECHARGE_STATE ||
-                                         app_canRx_BMS_State_get() == BMS_DRIVE_STATE;
+    bool is_bms_in_correct_state = app_canRx_BMS_State_get() == BMS_INVERTER_ON_STATE ||
+                                   app_canRx_BMS_State_get() == BMS_PRECHARGE_STATE ||
+                                   app_canRx_BMS_State_get() == BMS_DRIVE_STATE;
 
-    if (is_inverter_on_or_drive_state && all_states_ok)
+    if (is_bms_in_correct_state && all_states_ok)
     {
         app_stateMachine_setNextState(app_inverterOnState_get());
     }

--- a/firmware/quadruna/VC/src/app/states/app_initState.c
+++ b/firmware/quadruna/VC/src/app/states/app_initState.c
@@ -39,7 +39,7 @@ static void initStateRunOnTick100Hz(void)
                                          app_canRx_BMS_State_get() == BMS_PRECHARGE_STATE ||
                                          app_canRx_BMS_State_get() == BMS_DRIVE_STATE;
 
-    if (is_inverter_on_or_drive_state)
+    if (is_inverter_on_or_drive_state && all_states_ok)
     {
         app_stateMachine_setNextState(app_inverterOnState_get());
     }

--- a/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
+++ b/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
@@ -29,6 +29,8 @@ static void inverterOnStateRunOnTick100Hz(void)
     prev_start_switch_pos                 = curr_start_switch_pos;
     const bool is_brake_actuated          = app_canRx_FSM_BrakeActuated_get();
     const bool bms_in_drive_state         = app_canRx_BMS_State_get() == BMS_DRIVE_STATE;
+    const bool bms_in_inverterOn_state    = app_canRx_BMS_State_get() == BMS_INVERTER_ON_STATE;
+    const bool bms_in_precharge_state     = app_canRx_BMS_State_get() == BMS_PRECHARGE_STATE;
 
     if (bms_in_drive_state && is_brake_actuated && was_start_switch_pulled_up && all_states_ok)
     {
@@ -39,8 +41,7 @@ static void inverterOnStateRunOnTick100Hz(void)
         // Thus, re-test IO, app, and vehicle dynamics before going HV up or driving again.
         app_stateMachine_setNextState(app_driveState_get());
     }
-
-    else if (!all_states_ok)
+    else if (!all_states_ok || (!bms_in_drive_state && !bms_in_inverterOn_state && !bms_in_precharge_state))
     {
         app_stateMachine_setNextState(app_initState_get());
     }

--- a/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
+++ b/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
@@ -29,8 +29,9 @@ static void inverterOnStateRunOnTick100Hz(void)
     prev_start_switch_pos                 = curr_start_switch_pos;
     const bool is_brake_actuated          = app_canRx_FSM_BrakeActuated_get();
     const bool bms_in_drive_state         = app_canRx_BMS_State_get() == BMS_DRIVE_STATE;
-    const bool exit = !all_states_ok || (!bms_in_drive_state && app_canRx_BMS_State_get() != BMS_INVERTER_ON_STATE &&
-                                         app_canRx_BMS_State_get() != BMS_PRECHARGE_STATE);
+    const bool inverters_off_exit =
+        !all_states_ok || (!bms_in_drive_state && app_canRx_BMS_State_get() != BMS_INVERTER_ON_STATE &&
+                           app_canRx_BMS_State_get() != BMS_PRECHARGE_STATE);
 
     if (bms_in_drive_state && is_brake_actuated && was_start_switch_pulled_up && all_states_ok)
     {
@@ -41,7 +42,7 @@ static void inverterOnStateRunOnTick100Hz(void)
         // Thus, re-test IO, app, and vehicle dynamics before going HV up or driving again.
         app_stateMachine_setNextState(app_driveState_get());
     }
-    else if (exit)
+    else if (inverters_off_exit)
     {
         app_stateMachine_setNextState(app_initState_get());
     }

--- a/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
+++ b/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
@@ -29,8 +29,8 @@ static void inverterOnStateRunOnTick100Hz(void)
     prev_start_switch_pos                 = curr_start_switch_pos;
     const bool is_brake_actuated          = app_canRx_FSM_BrakeActuated_get();
     const bool bms_in_drive_state         = app_canRx_BMS_State_get() == BMS_DRIVE_STATE;
-    const bool bms_in_inverterOn_state    = app_canRx_BMS_State_get() == BMS_INVERTER_ON_STATE;
-    const bool bms_in_precharge_state     = app_canRx_BMS_State_get() == BMS_PRECHARGE_STATE;
+    const bool exit = !all_states_ok || (!bms_in_drive_state && app_canRx_BMS_State_get() != BMS_INVERTER_ON_STATE &&
+                                         app_canRx_BMS_State_get() != BMS_PRECHARGE_STATE);
 
     if (bms_in_drive_state && is_brake_actuated && was_start_switch_pulled_up && all_states_ok)
     {
@@ -41,7 +41,7 @@ static void inverterOnStateRunOnTick100Hz(void)
         // Thus, re-test IO, app, and vehicle dynamics before going HV up or driving again.
         app_stateMachine_setNextState(app_driveState_get());
     }
-    else if (!all_states_ok || (!bms_in_drive_state && !bms_in_inverterOn_state && !bms_in_precharge_state))
+    else if (exit)
     {
         app_stateMachine_setNextState(app_initState_get());
     }

--- a/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
+++ b/firmware/quadruna/VC/src/app/states/app_inverterOnState.c
@@ -29,9 +29,9 @@ static void inverterOnStateRunOnTick100Hz(void)
     prev_start_switch_pos                 = curr_start_switch_pos;
     const bool is_brake_actuated          = app_canRx_FSM_BrakeActuated_get();
     const bool bms_in_drive_state         = app_canRx_BMS_State_get() == BMS_DRIVE_STATE;
-    const bool inverters_off_exit =
-        !all_states_ok || (!bms_in_drive_state && app_canRx_BMS_State_get() != BMS_INVERTER_ON_STATE &&
-                           app_canRx_BMS_State_get() != BMS_PRECHARGE_STATE);
+    const bool bms_in_correct_state       = bms_in_drive_state || app_canRx_BMS_State_get() == BMS_INVERTER_ON_STATE ||
+                                      app_canRx_BMS_State_get() == BMS_PRECHARGE_STATE;
+    const bool inverters_off_exit = !all_states_ok || !bms_in_correct_state;
 
     if (bms_in_drive_state && is_brake_actuated && was_start_switch_pulled_up && all_states_ok)
     {

--- a/firmware/quadruna/VC/test/test_stateMachine.cpp
+++ b/firmware/quadruna/VC/test/test_stateMachine.cpp
@@ -34,7 +34,22 @@ class VCStateMachineTest : public VcBaseStateMachineTest
         LetTimePass(20);
         EXPECT_EQ(VC_DRIVE_STATE, app_canTx_VC_State_get());
     }
+
+    void SetStateToDrive()
+    {
+        app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
+        app_canRx_BMS_State_update(BMS_DRIVE_STATE);
+        app_canRx_FSM_BrakeActuated_update(true);
+        SetInitialState(app_driveState_get());
+    }
 };
+
+TEST_F(VCStateMachineTest, test_SetStateToDrive)
+{
+    SetStateToDrive();
+    LetTimePass(1000);
+    EXPECT_EQ(app_driveState_get(), app_stateMachine_getCurrentState());
+}
 
 TEST_F(VCStateMachineTest, check_init_transitions_to_drive_if_conditions_met_and_start_switch_pulled_up)
 {
@@ -169,7 +184,7 @@ TEST_F(VCStateMachineTest, check_if_buzzer_stays_on_for_two_seconds_only_after_e
 
 TEST_F(VCStateMachineTest, no_torque_requests_when_accelerator_pedal_is_not_pressed)
 {
-    SetInitialState(app_driveState_get());
+    SetStateToDrive();
 
     // Set the CRIT start switch to on, and the BMS to drive state, to prevent state transitions in
     // the drive state.
@@ -233,10 +248,7 @@ TEST_F(VCStateMachineTest, drive_to_init_state_on_CRIT_fault)
 
 TEST_F(VCStateMachineTest, drive_to_init_inverter_fault)
 {
-    app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
-    app_canRx_BMS_State_update(BMS_DRIVE_STATE);
-    app_canRx_FSM_BrakeActuated_update(true);
-    SetInitialState(app_driveState_get());
+    SetStateToDrive();
     LetTimePass(100);
     EXPECT_EQ(app_driveState_get(), app_stateMachine_getCurrentState());
 
@@ -248,10 +260,7 @@ TEST_F(VCStateMachineTest, drive_to_init_inverter_fault)
 
 TEST_F(VCStateMachineTest, BMS_causes_drive_to_inverterOn)
 {
-    app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
-    app_canRx_BMS_State_update(BMS_DRIVE_STATE);
-    app_canRx_FSM_BrakeActuated_update(true);
-    SetInitialState(app_driveState_get());
+    SetStateToDrive();
     LetTimePass(100);
     EXPECT_EQ(app_driveState_get(), app_stateMachine_getCurrentState());
 
@@ -262,10 +271,7 @@ TEST_F(VCStateMachineTest, BMS_causes_drive_to_inverterOn)
 
 TEST_F(VCStateMachineTest, BMS_causes_drive_to_inverterOn_to_init)
 {
-    app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
-    app_canRx_BMS_State_update(BMS_DRIVE_STATE);
-    app_canRx_FSM_BrakeActuated_update(true);
-    SetInitialState(app_driveState_get());
+    SetStateToDrive();
     LetTimePass(100);
     EXPECT_EQ(app_driveState_get(), app_stateMachine_getCurrentState());
 

--- a/firmware/quadruna/VC/test/test_stateMachine.cpp
+++ b/firmware/quadruna/VC/test/test_stateMachine.cpp
@@ -84,6 +84,13 @@ TEST_F(VCStateMachineTest, check_drive_state_is_broadcasted_over_can)
     EXPECT_EQ(VC_DRIVE_STATE, app_canTx_VC_State_get());
 }
 
+TEST_F(VCStateMachineTest, check_inverterOn_state_is_broadcasted_over_can)
+{
+    SetInitialState(app_inverterOnState_get());
+
+    EXPECT_EQ(VC_INVERTER_ON_STATE, app_canTx_VC_State_get());
+}
+
 TEST_F(VCStateMachineTest, disable_inverters_in_init_state)
 {
     SetInitialState(app_initState_get());

--- a/firmware/quadruna/VC/test/test_stateMachine.cpp
+++ b/firmware/quadruna/VC/test/test_stateMachine.cpp
@@ -129,7 +129,7 @@ TEST_F(VCStateMachineTest, start_switch_off_transitions_drive_state_to_init_stat
     app_canRx_CRIT_StartSwitch_update(SWITCH_OFF);
     LetTimePass(10);
 
-    ASSERT_EQ(VC_INIT_STATE, app_canTx_VC_State_get());
+    ASSERT_EQ(VC_INVERTER_ON_STATE, app_canTx_VC_State_get());
 }
 
 TEST_F(VCStateMachineTest, check_if_buzzer_stays_on_for_two_seconds_only_after_entering_drive_state)

--- a/firmware/quadruna/VC/test/test_stateMachine.cpp
+++ b/firmware/quadruna/VC/test/test_stateMachine.cpp
@@ -231,21 +231,6 @@ TEST_F(VCStateMachineTest, drive_to_init_state_on_CRIT_fault)
     TestFaultBlocksDrive(set_fault, clear_fault);
 }
 
-TEST_F(VCStateMachineTest, check_drive_to_init)
-{
-    app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
-    app_canRx_BMS_State_update(BMS_DRIVE_STATE);
-    app_canRx_FSM_BrakeActuated_update(true);
-    SetInitialState(app_driveState_get());
-    LetTimePass(100);
-    EXPECT_EQ(app_driveState_get(), app_stateMachine_getCurrentState());
-
-    app_canRx_INVL_VsmState_update(INVERTER_VSM_BLINK_FAULT_CODE_STATE);
-
-    LetTimePass(100);
-    EXPECT_EQ(app_initState_get(), app_stateMachine_getCurrentState());
-}
-
 TEST_F(VCStateMachineTest, drive_to_init_inverter_fault)
 {
     app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
@@ -261,7 +246,7 @@ TEST_F(VCStateMachineTest, drive_to_init_inverter_fault)
     EXPECT_EQ(app_initState_get(), app_stateMachine_getCurrentState());
 }
 
-TEST_F(VCStateMachineTest, BMS_causes_drive_inverterOn)
+TEST_F(VCStateMachineTest, BMS_causes_drive_to_inverterOn)
 {
     app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
     app_canRx_BMS_State_update(BMS_DRIVE_STATE);

--- a/firmware/quadruna/VC/test/test_stateMachine.cpp
+++ b/firmware/quadruna/VC/test/test_stateMachine.cpp
@@ -28,10 +28,10 @@ class VCStateMachineTest : public VcBaseStateMachineTest
 
         app_canRx_FSM_BrakeActuated_update(true);
         app_canRx_CRIT_StartSwitch_update(SWITCH_OFF);
-        // had to increase time from 10 to 20 to allow transition from init to inverterOnState to drivestate
-        LetTimePass(20);
+        // had to increase time from 10 to 50 to allow transition from init to inverterOnState to drivestate
+        LetTimePass(50);
         app_canRx_CRIT_StartSwitch_update(SWITCH_ON);
-        LetTimePass(20);
+        LetTimePass(50);
         EXPECT_EQ(VC_DRIVE_STATE, app_canTx_VC_State_get());
     }
 


### PR DESCRIPTION
### Summary
Made some minor changes to the state machine transitions on the VC. Since we don't want the inverters to turn off if the start switch is off or the BMS is not in `BMS_Drive_State` but still may be in `BMS_Inverter_On_State` or `BMS_Precharge_State`.

### Testing Done
Created some new unit tests

### Checklist
*Please change `[ ]` to `[x]` when you are ready.*
- [x] I have read and followed the code conventions detailed in [README.md](../README.md) (*This will save time for both you and the reviewer!*).
- [x] If this pull request is longer then **500** lines, I have provided *explicit* justification in the summary above explaining why I *cannot* break this up into multiple pull requests (*Small PR's are faster and less painful for everyone involved!*).
