### PR TITLE
JSONCAN Schema cycle_time

### DIFF
--- a/can_bus/quadruna/INVL/INVL_tx.json
+++ b/can_bus/quadruna/INVL/INVL_tx.json
@@ -696,6 +696,7 @@
     },
     "DebugReadWriteParamCommand": {
         "msg_id": 33, 
+        "cycle_time": null,
         "signals": {
             "CommandParameterAddress": {
                 "start_bit": 0, 
@@ -713,6 +714,7 @@
     },
     "DebugReadWriteParamResponse": {
         "msg_id": 34, 
+        "cycle_time": null,
         "signals": {
             "ResponseParameterAddress": {
                 "start_bit": 0, 

--- a/can_bus/quadruna/RSM/RSM_tx.json
+++ b/can_bus/quadruna/RSM/RSM_tx.json
@@ -84,6 +84,7 @@
 	},
 	"LoadCell":{
 		"msg_id" : 409,
+		"cycle_time": null,
 		"description" : "Mechanical load on load cell",
 		"signals" : {
 			"LoadCell3" : {

--- a/can_bus/thruna/INVL/INVL_tx.json
+++ b/can_bus/thruna/INVL/INVL_tx.json
@@ -1,6 +1,6 @@
 {
     "Temperatures1": {
-        "msg_id": 50,
+        "msg_id": 0,
         "cycle_time": 100,
         "signals": {
             "ModuleATemperature": {
@@ -46,7 +46,7 @@
         }
     },
     "Temperatures2": {
-        "msg_id": 51,
+        "msg_id": 1,
         "cycle_time": 100,
         "signals": {
             "ControlBoardTemperature": {
@@ -92,7 +92,7 @@
         }
     },
     "Temperatures3": {
-        "msg_id": 52,
+        "msg_id": 2,
         "cycle_time": 100,
         "signals": {
             "Rtd4Temperature": {
@@ -138,7 +138,7 @@
         }
     },
     "MotorPositionInfo": {
-        "msg_id": 55,
+        "msg_id": 5,
         "cycle_time": 10,
         "signals": {
             "MotorAngle": {
@@ -184,7 +184,7 @@
         }
     },
     "CurrentInfo": {
-        "msg_id": 56,
+        "msg_id": 6,
         "cycle_time": 10,
         "signals": {
             "PhaseACurrent": {
@@ -230,7 +230,7 @@
         }
     },
     "VoltageInfo": {
-        "msg_id": 57,
+        "msg_id": 7,
         "cycle_time": 10,
         "signals": {
             "DcBusVoltage": {
@@ -276,7 +276,7 @@
         }
     },
     "InternalVoltages": {
-        "msg_id": 59,
+        "msg_id": 9,
         "cycle_time": 100,
         "signals": {
             "ReferenceVoltage_1V5": {
@@ -322,7 +322,7 @@
         }
     },
     "InternalStates": {
-        "msg_id": 60,
+        "msg_id": 10,
         "cycle_time": 10,
         "signals": {
             "VsmState": {
@@ -421,245 +421,245 @@
         }
     },
     "FaultCodes": {
-        "msg_id": 61,
+        "msg_id": 11,
         "cycle_time": 10,
         "signals": {
             "Post_HardwareGateDesaturationFault": {
-                "start_bit": 0,
+                "start_bit": 0, 
                 "bits": 1
             },
             "Post_HwOverCurrentFault": {
-                "start_bit": 1,
+                "start_bit": 1, 
                 "bits": 1
             },
             "Post_AcceleratorShorted": {
-                "start_bit": 2,
+                "start_bit": 2, 
                 "bits": 1
             },
             "Post_AcceleratorOpen": {
-                "start_bit": 3,
+                "start_bit": 3, 
                 "bits": 1
             },
             "Post_CurrentSensorLow": {
-                "start_bit": 4,
+                "start_bit": 4, 
                 "bits": 1
             },
             "Post_CurrentSensorHigh": {
-                "start_bit": 5,
+                "start_bit": 5, 
                 "bits": 1
             },
             "Post_ModuleTempreatureLow": {
-                "start_bit": 6,
+                "start_bit": 6, 
                 "bits": 1
             },
             "Post_ModuleTemperatureHigh": {
-                "start_bit": 7,
+                "start_bit": 7, 
                 "bits": 1
             },
             "Post_ControlPcbTemperatureLow": {
-                "start_bit": 8,
+                "start_bit": 8, 
                 "bits": 1
             },
             "Post_ControlPcbTemperatureHigh": {
-                "start_bit": 9,
+                "start_bit": 9, 
                 "bits": 1
             },
             "Post_GateDrivePcbTemperatureLow": {
-                "start_bit": 10,
+                "start_bit": 10, 
                 "bits": 1
             },
             "Post_GateDrivePcbTemperatureHigh": {
-                "start_bit": 11,
+                "start_bit": 11, 
                 "bits": 1
             },
             "Post_5VSenseVoltageLow": {
-                "start_bit": 12,
+                "start_bit": 12, 
                 "bits": 1
             },
             "Post_5VSenseVoltageHigh": {
-                "start_bit": 13,
+                "start_bit": 13, 
                 "bits": 1
             },
             "Post_12VSenseVoltageLow": {
-                "start_bit": 14,
+                "start_bit": 14, 
                 "bits": 1
             },
             "Post_12VSenseVoltageHigh": {
-                "start_bit": 15,
+                "start_bit": 15, 
                 "bits": 1
             },
             "Post_2V5SenseVoltageLow": {
-                "start_bit": 16,
+                "start_bit": 16, 
                 "bits": 1
             },
             "Post_2V5SenseVoltageHigh": {
-                "start_bit": 17,
+                "start_bit": 17, 
                 "bits": 1
             },
             "Post_1V5SenseVoltageLow": {
-                "start_bit": 18,
+                "start_bit": 18, 
                 "bits": 1
             },
             "Post_1V5SenseVoltageHigh": {
-                "start_bit": 19,
+                "start_bit": 19, 
                 "bits": 1
             },
             "Post_DcBusVoltageHigh": {
-                "start_bit": 20,
+                "start_bit": 20, 
                 "bits": 1
             },
             "Post_DcBusVoltageLow": {
-                "start_bit": 21,
+                "start_bit": 21, 
                 "bits": 1
             },
             "Post_PrechargeTimeout": {
-                "start_bit": 22,
+                "start_bit": 22, 
                 "bits": 1
             },
             "Post_PrechargeVoltageFailure": {
-                "start_bit": 23,
+                "start_bit": 23, 
                 "bits": 1
             },
             "Post_EepromChecksumInvalid": {
-                "start_bit": 24,
+                "start_bit": 24, 
                 "bits": 1
             },
             "Post_EepromDataOutOfRange": {
-                "start_bit": 25,
+                "start_bit": 25, 
                 "bits": 1
             },
             "Post_EepromUpdateRequired": {
-                "start_bit": 26,
+                "start_bit": 26, 
                 "bits": 1
             },
             "Post_HardwareDcBusOverVoltageDuringInitialization": {
-                "start_bit": 27,
+                "start_bit": 27, 
                 "bits": 1
             },
             "Post_GateDriverInitialization": {
-                "start_bit": 28,
+                "start_bit": 28, 
                 "bits": 1
             },
             "Post_BrakeShorted": {
-                "start_bit": 30,
+                "start_bit": 30, 
                 "bits": 1
             },
             "Post_BrakeOpen": {
-                "start_bit": 31,
+                "start_bit": 31, 
                 "bits": 1
             },
             "Run_MotorOverSpeedFault": {
-                "start_bit": 32,
+                "start_bit": 32, 
                 "bits": 1
             },
             "Run_OverCurrentFault": {
-                "start_bit": 33,
+                "start_bit": 33, 
                 "bits": 1
             },
             "Run_OverVoltageFault": {
-                "start_bit": 34,
+                "start_bit": 34, 
                 "bits": 1
             },
             "Run_InverterOverTemperatureFault": {
-                "start_bit": 35,
+                "start_bit": 35, 
                 "bits": 1
             },
             "Run_AcceleratorInputShortedFault": {
-                "start_bit": 36,
+                "start_bit": 36, 
                 "bits": 1
             },
             "Run_AcceleratorInputOpenFault": {
-                "start_bit": 37,
+                "start_bit": 37, 
                 "bits": 1
             },
             "Run_DirectionCommandFault": {
-                "start_bit": 38,
+                "start_bit": 38, 
                 "bits": 1
             },
             "Run_InverterResponseTimeoutFault": {
-                "start_bit": 39,
+                "start_bit": 39, 
                 "bits": 1
             },
             "Run_HardwareGateDesaturationFault": {
-                "start_bit": 40,
+                "start_bit": 40, 
                 "bits": 1
             },
             "Run_HardwareOverCurrentFault": {
-                "start_bit": 41,
+                "start_bit": 41, 
                 "bits": 1
             },
             "Run_UnderVoltageFault": {
-                "start_bit": 42,
+                "start_bit": 42, 
                 "bits": 1
             },
             "Run_CanCommandMessageLostFault": {
-                "start_bit": 43,
+                "start_bit": 43, 
                 "bits": 1
             },
             "Run_MotorOverTemperature": {
-                "start_bit": 44,
+                "start_bit": 44, 
                 "bits": 1
             },
             "Run_BrakeInputShortedFault": {
-                "start_bit": 48,
+                "start_bit": 48, 
                 "bits": 1
             },
             "Run_BrakeInputOpenFault": {
-                "start_bit": 49,
+                "start_bit": 49, 
                 "bits": 1
             },
             "Run_ModuleAOverTemperatureFault": {
-                "start_bit": 50,
+                "start_bit": 50, 
                 "bits": 1
             },
             "Run_ModuleBOverTemperatureFault": {
-                "start_bit": 51,
+                "start_bit": 51, 
                 "bits": 1
             },
             "Run_ModuleCOverTemperatureFault": {
-                "start_bit": 52,
+                "start_bit": 52, 
                 "bits": 1
             },
             "Run_PcbOverTemperatureFault": {
-                "start_bit": 53,
+                "start_bit": 53, 
                 "bits": 1
             },
             "Run_GateDriveBoard1OverTemperatureFault": {
-                "start_bit": 54,
+                "start_bit": 54, 
                 "bits": 1
             },
             "Run_GateDriveBoard2OverTemperatureFault": {
-                "start_bit": 55,
+                "start_bit": 55, 
                 "bits": 1
             },
             "Run_GateDriveBoard3OverTemperatureFault": {
-                "start_bit": 56,
+                "start_bit": 56, 
                 "bits": 1
             },
             "Run_CurrentSensorFault": {
-                "start_bit": 57,
+                "start_bit": 57, 
                 "bits": 1
             },
             "Run_GateDriverOverVoltage": {
-                "start_bit": 58,
+                "start_bit": 58, 
                 "bits": 1
             },
             "Run_HardwareDcBusOverVoltageGen3": {
-                "start_bit": 59,
+                "start_bit": 59, 
                 "bits": 1
             },
             "Run_HardwareDcBusOverVoltageGen5": {
-                "start_bit": 60,
+                "start_bit": 60, 
                 "bits": 1
             },
             "Run_ResolverNotConnected": {
-                "start_bit": 62,
+                "start_bit": 62, 
                 "bits": 1
             }
         }
     },
     "TorqueAndTimerInfo": {
-        "msg_id": 62,
+        "msg_id": 12,
         "cycle_time": 10,
         "signals": {
             "CommandedTorque": {
@@ -695,7 +695,7 @@
         }
     },
     "DebugReadWriteParamCommand": {
-        "msg_id": 83, 
+        "msg_id": 33, 
         "cycle_time": null,
         "signals": {
             "CommandParameterAddress": {
@@ -713,8 +713,7 @@
         }
     },
     "DebugReadWriteParamResponse": {
-        "msg_id": 84, 
-        "cycle_time": null,
+        "msg_id": 34, 
         "signals": {
             "ResponseParameterAddress": {
                 "start_bit": 0, 

--- a/can_bus/thruna/INVL/INVL_tx.json
+++ b/can_bus/thruna/INVL/INVL_tx.json
@@ -714,6 +714,7 @@
     },
     "DebugReadWriteParamResponse": {
         "msg_id": 34, 
+        "cycle_time": null,
         "signals": {
             "ResponseParameterAddress": {
                 "start_bit": 0, 

--- a/can_bus/thruna/INVR/INVR_tx.json
+++ b/can_bus/thruna/INVR/INVR_tx.json
@@ -714,7 +714,6 @@
     },
     "DebugReadWriteParamResponse": {
         "msg_id": 84, 
-        "cycle_time": null,
         "signals": {
             "ResponseParameterAddress": {
                 "start_bit": 0, 

--- a/can_bus/thruna/INVR/INVR_tx.json
+++ b/can_bus/thruna/INVR/INVR_tx.json
@@ -714,6 +714,7 @@
     },
     "DebugReadWriteParamResponse": {
         "msg_id": 84, 
+        "cycle_time": null,
         "signals": {
             "ResponseParameterAddress": {
                 "start_bit": 0, 

--- a/scripts/code_generation/jsoncan/docs/2_tx_schema.md
+++ b/scripts/code_generation/jsoncan/docs/2_tx_schema.md
@@ -25,7 +25,7 @@ Define a  message as below:
 }
 ```
 
-If `cycle_time` is not specified, the message will be aperiodic and you will have to transmit the message manually. 
+`cycle_time` is mandatory and if null, the message will be aperiodic and you will have to transmit the message manually. 
 
 `allowed_modes` defines which modes the message will be transmitted in. You can enable/disable the different modes to choose which messages are being sent at runtime.
 If `allowed_modes` is not included, then the message will only be sent if the default mode is enabled.

--- a/scripts/code_generation/jsoncan/src/json_parsing/json_can_parsing.py
+++ b/scripts/code_generation/jsoncan/src/json_parsing/json_can_parsing.py
@@ -212,7 +212,7 @@ class JsonCanParser:
         """
         msg_id = msg_json_data["msg_id"]
         description, _ = self._get_optional_value(msg_json_data, "description", "")
-        msg_cycle_time, _ = self._get_optional_value(msg_json_data, "cycle_time", None)
+        msg_cycle_time = msg_json_data["cycle_time"]
         msg_modes, _ = self._get_optional_value(
             msg_json_data, "allowed_modes", [self._bus_cfg.default_mode]
         )

--- a/scripts/code_generation/jsoncan/src/json_parsing/schema_validation.py
+++ b/scripts/code_generation/jsoncan/src/json_parsing/schema_validation.py
@@ -65,7 +65,7 @@ tx_msg_schema = Schema(
         "signals": {
             str: tx_signal_schema,
         },
-        Optional("cycle_time"): Or(int, lambda x: x >= 0),
+        "cycle_time": Or(int, None, lambda x: x >= 0),
         Optional("num_bytes"): Or(int, lambda x: x >= 0 and x <= 8),
         Optional("description"): str,
         Optional("allowed_modes"): [str]


### PR DESCRIPTION
### Changelist 
Now required to have `cycle_time = null` to indicate that a message is aperiodic. 

### Testing Done
No testing needed

