### PR TITLE
Fix Cell Balancing

### DIFF
--- a/firmware/quadruna/BMS/src/app/app_accumulator.c
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.c
@@ -1,6 +1,5 @@
 #include "app_accumulator.h"
-#include "states/app_balancingState.h"
-#include "states/app_initState.h"
+#include "states/app_chargeState.h"
 #include "app_canTx.h"
 #include "app_canRx.h"
 #include "app_canAlerts.h"
@@ -483,10 +482,10 @@ bool app_accumulator_checkFaults(void)
 
     const State *current_state = app_stateMachine_getCurrentState();
 
-    const bool cell_balancing_enabled = app_canRx_Debug_CellBalancingRequest_get();
+    const bool cell_balancing_enabled =
+        app_canRx_Debug_CellBalancingRequest_get() && current_state != app_chargeState_get();
 
-    const float max_cell_voltage =
-        app_canRx_Debug_CellBalancingRequest_get() ? MAX_CELL_VOLTAGE_BALANCING : MAX_CELL_VOLTAGE_NOMINAL;
+    const float max_cell_voltage = cell_balancing_enabled ? MAX_CELL_VOLTAGE_BALANCING : MAX_CELL_VOLTAGE_NOMINAL;
 
     const bool overtemp_condition =
         io_ltc6813CellTemps_getMaxTempDegC(&throwaway_segment, &throwaway_loc) > max_allowable_cell_temp;

--- a/firmware/quadruna/BMS/src/app/app_accumulator.c
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.c
@@ -483,7 +483,7 @@ bool app_accumulator_checkFaults(void)
 
     const State *current_state = app_stateMachine_getCurrentState();
 
-    const bool cell_balancing_enabled = app_canRx_Debug_CellBalancingRequest_get() && (current_state == app_initState_get() || current_state == app_balancingState_get() );
+    const bool cell_balancing_enabled = app_canRx_Debug_CellBalancingRequest_get();
 
     const float max_cell_voltage =
         app_canRx_Debug_CellBalancingRequest_get() ? MAX_CELL_VOLTAGE_BALANCING : MAX_CELL_VOLTAGE_NOMINAL;

--- a/firmware/quadruna/BMS/src/app/app_accumulator.c
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.c
@@ -482,6 +482,8 @@ bool app_accumulator_checkFaults(void)
 
     const State *current_state = app_stateMachine_getCurrentState();
 
+    // Check if balancing is enabled. For safety reasons, also check if current state is charge state, as we do not want
+    // to adjust max cell voltage thresholds if actively charging.
     const bool cell_balancing_enabled =
         app_canRx_Debug_CellBalancingRequest_get() && current_state != app_chargeState_get();
 

--- a/firmware/quadruna/BMS/src/app/app_accumulator.c
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.c
@@ -485,6 +485,9 @@ bool app_accumulator_checkFaults(void)
     const bool cell_balancing_enabled =
         app_canRx_Debug_CellBalancingRequest_get() && current_state != app_chargeState_get();
 
+    // Allows balancing of cells even if slight over-charging occurs. Occured prior to Competition 2024, where a fully
+    // charged pack with max cell V of 4.19 after charging reported as 4.21 after settling. Cause currently unknown, but
+    // this allows for these over-charged cells to be discharged back to safe limits
     const float max_cell_voltage = cell_balancing_enabled ? MAX_CELL_VOLTAGE_BALANCING : MAX_CELL_VOLTAGE_NOMINAL;
 
     const bool overtemp_condition =

--- a/firmware/quadruna/BMS/src/app/app_accumulator.c
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.c
@@ -1,4 +1,6 @@
 #include "app_accumulator.h"
+#include "states/app_balancingState.h"
+#include "states/app_initState.h"
 #include "app_canTx.h"
 #include "app_canRx.h"
 #include "app_canAlerts.h"
@@ -479,11 +481,18 @@ bool app_accumulator_checkFaults(void)
         min_allowable_cell_temp = MIN_CELL_CHARGE_TEMP_DEGC;
     }
 
+    const State *current_state = app_stateMachine_getCurrentState();
+
+    const bool cell_balancing_enabled = app_canRx_Debug_CellBalancingRequest_get() && (current_state == app_initState_get() || current_state == app_balancingState_get() );
+
+    const float max_cell_voltage =
+        app_canRx_Debug_CellBalancingRequest_get() ? MAX_CELL_VOLTAGE_BALANCING : MAX_CELL_VOLTAGE_NOMINAL;
+
     const bool overtemp_condition =
         io_ltc6813CellTemps_getMaxTempDegC(&throwaway_segment, &throwaway_loc) > max_allowable_cell_temp;
     const bool undertemp_condition =
         io_ltc6813CellTemps_getMinTempDegC(&throwaway_segment, &throwaway_loc) < min_allowable_cell_temp;
-    const bool overvoltage_condition  = data.voltage_stats.max_voltage.voltage > MAX_CELL_VOLTAGE;
+    const bool overvoltage_condition  = data.voltage_stats.max_voltage.voltage > max_cell_voltage;
     const bool undervoltage_condition = data.voltage_stats.min_voltage.voltage < MIN_CELL_VOLTAGE;
 
     const bool overtemp_fault =

--- a/firmware/quadruna/BMS/src/app/app_accumulator.h
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.h
@@ -16,9 +16,13 @@
 #define MAX_CELL_CHARGE_TEMP_DEGC (45.0f)
 #define MIN_CELL_DISCHARGE_TEMP_DEGC (-20.0f)
 #define MIN_CELL_CHARGE_TEMP_DEGC (0.0f)
-#define MAX_CELL_VOLTAGE (4.2f)
+#define MAX_CELL_VOLTAGE_NOMINAL (4.2f)
 #define MIN_CELL_VOLTAGE (3.0f)
 #define C_RATE_TO_AMPS (17.7f)
+
+// When balancing with fully charged pack, voltage readings can temporarily be higher than 4.2V as voltage readings
+// settle after discharging
+#define MAX_CELL_VOLTAGE_BALANCING (4.25f)
 
 // Fault debounce durations.
 #define UNDER_VOLTAGE_DEBOUNCE_DURATION_MS (500U)

--- a/firmware/quadruna/BMS/src/app/app_accumulator.h
+++ b/firmware/quadruna/BMS/src/app/app_accumulator.h
@@ -20,8 +20,9 @@
 #define MIN_CELL_VOLTAGE (3.0f)
 #define C_RATE_TO_AMPS (17.7f)
 
-// When balancing with fully charged pack, voltage readings can temporarily be higher than 4.2V as voltage readings
-// settle after discharging
+// Allows balancing of cells even if slight over-charging occurs. Occured prior to Competition 2024, where a fully
+// charged pack with max cell V of 4.19 after charging reported as 4.21 after settling. Cause currently unknown, but
+// this allows for these over-charged cells to be discharged back to safe limits
 #define MAX_CELL_VOLTAGE_BALANCING (4.25f)
 
 // Fault debounce durations.

--- a/firmware/quadruna/BMS/src/app/states/app_allStates.c
+++ b/firmware/quadruna/BMS/src/app/states/app_allStates.c
@@ -87,6 +87,7 @@ bool app_allStates_runOnTick100Hz(void)
                 if (balancing_enabled)
                 {
                     iso_spi_task_state = RUN_CELL_BALANCING;
+                    app_accumulator_calculateCellsToBalance();
                 }
             }
 

--- a/firmware/quadruna/BMS/test/test_faults.cpp
+++ b/firmware/quadruna/BMS/test/test_faults.cpp
@@ -24,7 +24,7 @@ TEST_F(BmsFaultTest, check_state_transition_to_fault_state_from_all_states_overv
                 ASSERT_FALSE(app_canAlerts_BMS_Fault_CellOvervoltage_get());
 
                 // Set cell voltage critically high.
-                fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE + 0.1f);
+                fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE_NOMINAL + 0.1f);
                 LetTimePass(OVER_VOLTAGE_DEBOUNCE_DURATION_MS);
 
                 if (debounce_expires[i])
@@ -39,7 +39,7 @@ TEST_F(BmsFaultTest, check_state_transition_to_fault_state_from_all_states_overv
                     ASSERT_TRUE(app_canAlerts_BMS_Fault_CellOvervoltage_get());
 
                     // Clear fault, should transition back to init
-                    fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE - 0.1f);
+                    fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE_NOMINAL - 0.1f);
                     LetTimePass(20);
                     ASSERT_EQ(app_initState_get(), app_stateMachine_getCurrentState());
                     ASSERT_FALSE(app_canAlerts_BMS_Fault_CellOvervoltage_get());
@@ -47,7 +47,7 @@ TEST_F(BmsFaultTest, check_state_transition_to_fault_state_from_all_states_overv
                 else
                 {
                     // Clear fault before it expires, fault should not set.
-                    fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE - 0.1f);
+                    fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE_NOMINAL - 0.1f);
                     LetTimePass(10);
                     ASSERT_EQ(app_initState_get(), app_stateMachine_getCurrentState());
                     ASSERT_FALSE(app_canAlerts_BMS_Fault_CellOvervoltage_get());
@@ -535,7 +535,7 @@ TEST_F(BmsFaultTest, check_state_transition_to_fault_disables_bms_ok)
     ASSERT_EQ(fake_io_faultLatch_setCurrentStatus_callCountForArgs(&bms_ok_latch, false), 0);
 
     // Set cell voltage critically high and confirm fault is set
-    fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE + 0.1f);
+    fake_io_ltc6813CellVoltages_getCellVoltage_returnsForAnyArgs(MAX_CELL_VOLTAGE_NOMINAL + 0.1f);
     LetTimePass(OVER_VOLTAGE_DEBOUNCE_DURATION_MS + 10);
     ASSERT_EQ(app_faultState_get(), app_stateMachine_getCurrentState());
 


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
In the extreme case of an over-charged pack, cell-balancing cannot be performed to bring the pack back into spec. This PR adjusts the MAX_CELL_VOLTAGE threshold depending on if balancing is enabled or not, allowing a slightly over-charged pack to be brought back below 4.2v per cell through discharging.

Also fixes bug in the isoSPI state machinecaused by recent change with OWC.

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

Tested on pack

### Resolved Tickets
<!-- Link any tickets that this PR resolves. -->
