### PR TITLE
Clear inverter faults in VC driveStateRunOnEntry

### DIFF
--- a/can_bus/quadruna/INVL/INVL_rx.json
+++ b/can_bus/quadruna/INVL/INVL_rx.json
@@ -1,5 +1,6 @@
 {
     "messages": [
-        "VC_LeftInverterCommand"
+        "VC_LeftInverterCommand",
+        "VC_INVL_ReadWriteParamCommand"
     ]
 }

--- a/can_bus/quadruna/INVL/INVL_tx.json
+++ b/can_bus/quadruna/INVL/INVL_tx.json
@@ -943,24 +943,6 @@
             }
         }
     },
-    "DebugReadWriteParamCommand": {
-        "msg_id": 33,
-        "cycle_time": null,
-        "signals": {
-            "CommandParameterAddress": {
-                "start_bit": 0,
-                "bits": 16
-            },
-            "CommandReadWrite": {
-                "start_bit": 16,
-                "enum": "InverterReadWriteCommand"
-            },
-            "CommandData": {
-                "start_bit": 32,
-                "bits": 16
-            }
-        }
-    },
     "DebugReadWriteParamResponse": {
         "msg_id": 34,
         "cycle_time": null,

--- a/can_bus/quadruna/INVR/INVR_rx.json
+++ b/can_bus/quadruna/INVR/INVR_rx.json
@@ -1,5 +1,6 @@
 {
     "messages": [
-        "VC_RightInverterCommand"
+        "VC_RightInverterCommand",
+        "VC_INVR_ReadWriteParamCommand"
     ]
 }

--- a/can_bus/quadruna/INVR/INVR_tx.json
+++ b/can_bus/quadruna/INVR/INVR_tx.json
@@ -939,24 +939,6 @@
             }
         }
     },
-    "DebugReadWriteParamCommand": {
-        "msg_id": 83,
-        "cycle_time": null,
-        "signals": {
-            "CommandParameterAddress": {
-                "start_bit": 0,
-                "bits": 16
-            },
-            "CommandReadWrite": {
-                "start_bit": 16,
-                "enum": "InverterReadWriteCommand"
-            },
-            "CommandData": {
-                "start_bit": 32,
-                "bits": 16
-            }
-        }
-    },
     "DebugReadWriteParamResponse": {
         "msg_id": 84,
         "cycle_time": null,

--- a/can_bus/quadruna/VC/VC_tx.json
+++ b/can_bus/quadruna/VC/VC_tx.json
@@ -84,6 +84,27 @@
             }
         }
     },
+    "INVL_ReadWriteParamCommand": {
+        "msg_id": 33, 
+        "cycle_time": null,
+        "signals": {
+            "INVL_CommandParameterAddress": {
+                "start_bit": 0, 
+                "bits": 16,
+                "start_value": 20
+            },
+            "INVL_CommandReadWrite": {
+                "start_bit": 16, 
+                "enum": "InverterReadWriteCommand",
+                "start_value": 1
+            },
+            "INVL_CommandData": {
+                "start_bit": 32, 
+                "bits": 16,
+                "start_value": 0
+            }
+        }
+    },
     "RightInverterCommand": {
         "msg_id": 82,
         "cycle_time": 10,
@@ -139,6 +160,27 @@
                 "min": -3276.8,
                 "max": 3276.7,
                 "unit": "Nm",
+                "start_value": 0
+            }
+        }
+    },
+    "INVR_ReadWriteParamCommand": {
+        "msg_id": 83, 
+        "cycle_time": null,
+        "signals": {
+            "INVR_CommandParameterAddress": {
+                "start_bit": 0, 
+                "bits": 16,
+                "start_value": 20
+            },
+            "INVR_CommandReadWrite": {
+                "start_bit": 16, 
+                "enum": "InverterReadWriteCommand",
+                "start_value": 1
+            },
+            "INVR_CommandData": {
+                "start_bit": 32, 
+                "bits": 16,
                 "start_value": 0
             }
         }

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -5,6 +5,8 @@
 #include "states/app_driveState.h"
 #include "states/app_inverterOnState.h"
 
+#include "io_canTx.h"
+
 #include "app_canTx.h"
 #include "app_canRx.h"
 #include "app_vehicleDynamicsConstants.h"
@@ -68,10 +70,12 @@ static void driveStateRunOnEntry(void)
     app_canTx_VC_INVL_CommandReadWrite_set(1);
     app_canTx_VC_INVL_CommandParameterAddress_set(20);
     app_canTx_VC_INVL_CommandData_set(0);
+    io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
 
     app_canTx_VC_INVR_CommandReadWrite_set(1);
     app_canTx_VC_INVR_CommandParameterAddress_set(20);
     app_canTx_VC_INVR_CommandData_set(0);
+    io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
 
     // Enable buzzer on transition to drive, and start 2s timer.
     app_timer_init(&buzzer_timer, BUZZER_ON_DURATION_MS);

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -67,15 +67,15 @@ void transmitTorqueRequests(float apps_pedal_percentage)
 static void driveStateRunOnEntry(void)
 {
     // Clear latched inverter faults
-    app_canTx_VC_INVL_CommandReadWrite_set(1);
-    app_canTx_VC_INVL_CommandParameterAddress_set(20);
-    app_canTx_VC_INVL_CommandData_set(0);
+    app_canTx_VC_INVL_CommandParameterAddress_set((uint16_t)20);
+    app_canTx_VC_INVL_CommandReadWrite_set(true);
+    app_canTx_VC_INVL_CommandData_set((uint16_t)0);
     io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
     io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
 
-    app_canTx_VC_INVR_CommandReadWrite_set(1);
-    app_canTx_VC_INVR_CommandParameterAddress_set(20);
-    app_canTx_VC_INVR_CommandData_set(0);
+    app_canTx_VC_INVR_CommandParameterAddress_set((uint16_t)20);
+    app_canTx_VC_INVR_CommandReadWrite_set(true);
+    app_canTx_VC_INVR_CommandData_set((uint16_t)0);
     io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
     io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
 

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -111,9 +111,7 @@ static void driveStateRunOnTick100Hz(void)
     const bool all_states_ok       = !(any_board_has_fault || inverter_has_fault);
 
     const bool start_switch_off          = app_canRx_CRIT_StartSwitch_get() == SWITCH_OFF;
-    // TODO km: remove
-    // const bool bms_not_in_drive          = app_canRx_BMS_State_get() != BMS_DRIVE_STATE;
-    const bool bms_not_in_drive          = false;
+    const bool bms_not_in_drive          = app_canRx_BMS_State_get() != BMS_DRIVE_STATE;
     bool       exit_drive_to_init        = bms_not_in_drive;
     bool       exit_drive_to_inverter_on = !all_states_ok || start_switch_off;
 

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -65,13 +65,13 @@ void transmitTorqueRequests(float apps_pedal_percentage)
 static void driveStateRunOnEntry(void)
 {
     // Clear latched inverter faults
-    app_canTx_INVL_DebugReadWriteCommand_CommandReadWrite_set(1);
-    app_canTx_INVL_DebugReadWriteCommand_CommandParameterAddress_set(20);
-    app_canTx_INVL_DebugReadWriteCommand_CommandData_set(0);
+    app_canTx_VC_INVL_CommandReadWrite_set(1);
+    app_canTx_VC_INVL_CommandParameterAddress_set(20);
+    app_canTx_VC_INVL_CommandData_set(0);
 
-    app_canTx_INVR_DebugReadWriteCommand_CommandReadWrite_set(1);
-    app_canTx_INVR_DebugReadWriteCommand_CommandParameterAddress_set(20);
-    app_canTx_INVR_DebugReadWriteCommand_CommandData_set(0);
+    app_canTx_VC_INVR_CommandReadWrite_set(1);
+    app_canTx_VC_INVR_CommandParameterAddress_set(20);
+    app_canTx_VC_INVR_CommandData_set(0);
 
     // Enable buzzer on transition to drive, and start 2s timer.
     app_timer_init(&buzzer_timer, BUZZER_ON_DURATION_MS);

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -66,18 +66,6 @@ void transmitTorqueRequests(float apps_pedal_percentage)
 
 static void driveStateRunOnEntry(void)
 {
-    // Clear latched inverter faults
-    app_canTx_VC_INVL_CommandParameterAddress_set((uint16_t)20);
-    app_canTx_VC_INVL_CommandReadWrite_set(true);
-    app_canTx_VC_INVL_CommandData_set((uint16_t)0);
-    io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
-    io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
-
-    app_canTx_VC_INVR_CommandParameterAddress_set((uint16_t)20);
-    app_canTx_VC_INVR_CommandReadWrite_set(true);
-    app_canTx_VC_INVR_CommandData_set((uint16_t)0);
-    io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
-    io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
 
     // Enable buzzer on transition to drive, and start 2s timer.
     app_timer_init(&buzzer_timer, BUZZER_ON_DURATION_MS);
@@ -123,7 +111,9 @@ static void driveStateRunOnTick100Hz(void)
     const bool all_states_ok       = !(any_board_has_fault || inverter_has_fault);
 
     const bool start_switch_off          = app_canRx_CRIT_StartSwitch_get() == SWITCH_OFF;
-    const bool bms_not_in_drive          = app_canRx_BMS_State_get() != BMS_DRIVE_STATE;
+    // TODO km: remove
+    // const bool bms_not_in_drive          = app_canRx_BMS_State_get() != BMS_DRIVE_STATE;
+    const bool bms_not_in_drive          = false;
     bool       exit_drive_to_init        = bms_not_in_drive;
     bool       exit_drive_to_inverter_on = !all_states_ok || start_switch_off;
 
@@ -183,6 +173,19 @@ static void driveStateRunOnExit(void)
 
     app_canTx_VC_LeftInverterTorqueCommand_set(0.0f);
     app_canTx_VC_RightInverterTorqueCommand_set(0.0f);
+
+    // Clear latched inverter faults
+    app_canTx_VC_INVL_CommandParameterAddress_set((uint16_t)20);
+    app_canTx_VC_INVL_CommandReadWrite_set(true);
+    app_canTx_VC_INVL_CommandData_set((uint16_t)0);
+    io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
+    io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
+
+    app_canTx_VC_INVR_CommandParameterAddress_set((uint16_t)20);
+    app_canTx_VC_INVR_CommandReadWrite_set(true);
+    app_canTx_VC_INVR_CommandData_set((uint16_t)0);
+    io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
+    io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
 
     // Disable buzzer on exit drive.
     io_efuse_setChannel(EFUSE_CHANNEL_BUZZER, false);

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -64,6 +64,15 @@ void transmitTorqueRequests(float apps_pedal_percentage)
 
 static void driveStateRunOnEntry(void)
 {
+    // Clear latched inverter faults
+    app_canTx_INVL_DebugReadWriteCommand_CommandReadWrite_set(1);
+    app_canTx_INVL_DebugReadWriteCommand_CommandParameterAddress_set(20);
+    app_canTx_INVL_DebugReadWriteCommand_CommandData_set(0);
+
+    app_canTx_INVR_DebugReadWriteCommand_CommandReadWrite_set(1);
+    app_canTx_INVR_DebugReadWriteCommand_CommandParameterAddress_set(20);
+    app_canTx_INVR_DebugReadWriteCommand_CommandData_set(0);
+
     // Enable buzzer on transition to drive, and start 2s timer.
     app_timer_init(&buzzer_timer, BUZZER_ON_DURATION_MS);
     app_timer_restart(&buzzer_timer);

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -71,10 +71,12 @@ static void driveStateRunOnEntry(void)
     app_canTx_VC_INVL_CommandParameterAddress_set(20);
     app_canTx_VC_INVL_CommandData_set(0);
     io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
+    io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
 
     app_canTx_VC_INVR_CommandReadWrite_set(1);
     app_canTx_VC_INVR_CommandParameterAddress_set(20);
     app_canTx_VC_INVR_CommandData_set(0);
+    io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
     io_canTx_VC_INVR_ReadWriteParamCommand_sendAperiodic();
 
     // Enable buzzer on transition to drive, and start 2s timer.


### PR DESCRIPTION
### Changelist 
Self-explanatory.

### Testing Done
None - should be tested on car if possible, also for unit tests: Is it possible to simulate an inverter fault so that we can ensure that re-entering drive state clears it? 

### Resolved Tickets
<!-- Link any tickets that this PR resolves. -->
