### PR TITLE
No SD SOC

### DIFF
--- a/firmware/quadruna/BMS/src/app/app_soc.c
+++ b/firmware/quadruna/BMS/src/app/app_soc.c
@@ -1,0 +1,174 @@
+#include "app_soc.h"
+#include "app_math.h"
+#include "app_tractiveSystem.h"
+#include "lut/app_cellVoltageToSocLut.h"
+// #include "io_sd.h"
+
+// #ifdef TARGET_EMBEDDED
+// #include "hw_sd.h"
+// #include "hw_crc.h"
+// #endif
+
+#include <stdint.h>
+#include <float.h>
+#include <string.h>
+#include <math.h>
+
+#define MS_TO_S (0.001)
+#define SOC_TIMER_DURATION (110U)
+
+#define NUM_SOC_BYTES (4U)
+#define NUM_SOC_CRC_BYTES (4U)
+
+#define DEFAULT_SOC_ADDR (0U)
+#define SD_SECTOR_SIZE (512)
+// Macro to convert a uint8_t array to a uint32_t variable
+#define ARRAY_TO_UINT32(array) \
+    (((uint32_t)(array)[0] << 24) | ((uint32_t)(array)[1] << 16) | ((uint32_t)(array)[2] << 8) | ((uint32_t)(array)[3]))
+
+// Macro to convert a uint32_t variable to a uint8_t array
+#define UINT32_TO_ARRAY(value, array)          \
+    do                                         \
+    {                                          \
+        (array)[0] = (uint8_t)((value) >> 24); \
+        (array)[1] = (uint8_t)((value) >> 16); \
+        (array)[2] = (uint8_t)((value) >> 8);  \
+        (array)[3] = (uint8_t)(value);         \
+    } while (0)
+
+typedef struct
+{
+    // charge in cell in coulombs
+    double charge_c;
+
+    // Charge loss at time t-1
+    float prev_current_A;
+
+    // Indicates if SOC from SD was corrupt at startup
+    bool is_corrupt;
+
+    TimerChannel soc_timer;
+} SocStats;
+
+static SocStats stats;
+extern bool     sd_inited;
+
+#ifndef TARGET_EMBEDDED
+
+// ONLY FOR USE IN OFF-TARGET TESTING
+void app_soc_setPrevCurrent(float current)
+{
+    stats.prev_current_A = current;
+}
+
+#endif
+
+float app_soc_getSocFromOcv(float voltage)
+{
+    uint8_t lut_index = 0;
+
+    while ((voltage > ocv_soc_lut[lut_index]) && (lut_index < V_TO_SOC_LUT_SIZE))
+    {
+        lut_index++;
+    }
+
+    if (lut_index == V_TO_SOC_LUT_SIZE)
+    {
+        // Ensures that the index is in the LUT range
+        lut_index--;
+    }
+    return LUT_BASE_SOC + lut_index * 0.5f;
+}
+
+float app_soc_getOcvFromSoc(float soc_percent)
+{
+    uint8_t lut_index = 0;
+
+    while ((LUT_BASE_SOC + lut_index * 0.5f < soc_percent) && (lut_index < V_TO_SOC_LUT_SIZE))
+    {
+        lut_index++;
+    }
+
+    if (lut_index == V_TO_SOC_LUT_SIZE)
+    {
+        // Ensures that the index is in the LUT range
+        lut_index--;
+    }
+
+    return ocv_soc_lut[lut_index];
+}
+
+void app_soc_init(void)
+{
+    stats.prev_current_A = 0.0f;
+
+    // SOC assumed corrupt until proven otherwise
+    stats.is_corrupt = true;
+    stats.charge_c   = -1;
+
+    // A negative SOC value will indicate to app_soc_Create that saved SOC value is corrupted
+    float saved_soc_c = -1.0f;
+
+    app_timer_init(&stats.soc_timer, SOC_TIMER_DURATION);
+    app_canTx_BMS_SocCorrupt_set(stats.is_corrupt);
+}
+
+bool app_soc_getCorrupt(void)
+{
+    return stats.is_corrupt;
+}
+
+void app_soc_updateSocStats(void)
+{
+    // NOTE current sign is relative to current into the battery
+    double *charge_c     = &stats.charge_c;
+    float  *prev_current = &stats.prev_current_A;
+    float   current      = app_tractiveSystem_getCurrent();
+
+    double elapsed_time_s = (double)app_timer_getElapsedTime(&stats.soc_timer) * MS_TO_S;
+    app_timer_restart(&stats.soc_timer);
+
+    // Trapezoidal Rule adds integral of current time-step to previous integral value.
+    app_math_trapezoidalRule(charge_c, prev_current, current, elapsed_time_s);
+}
+
+float app_soc_getMinSocCoulombs(void)
+{
+    // return SOC in Coulombs
+    return (float)stats.charge_c;
+}
+
+float app_soc_getMinSocPercent(void)
+{
+    // return SOC in %
+    float soc_percent = ((float)stats.charge_c / SERIES_ELEMENT_FULL_CHARGE_C) * 100.0f;
+    return soc_percent;
+}
+
+float app_soc_getMinOcvFromSoc(void)
+{
+    float soc_percent = app_soc_getMinSocPercent();
+    return app_soc_getOcvFromSoc(soc_percent);
+}
+
+void app_soc_resetSocFromVoltage(void)
+{
+    const float min_cell_voltage = app_accumulator_getMinCellVoltage(NULL, NULL);
+    const float soc_percent      = app_soc_getSocFromOcv(min_cell_voltage);
+
+    // convert from percent to coulombs
+    stats.charge_c = (double)(SERIES_ELEMENT_FULL_CHARGE_C * soc_percent / 100.0f);
+
+    // Mark SOC as corrupt anytime SOC is reset
+    stats.is_corrupt = true;
+    app_canTx_BMS_SocCorrupt_set(stats.is_corrupt);
+}
+
+void app_soc_resetSocCustomValue(float soc_percent)
+{
+    stats.charge_c = (double)(soc_percent / 100.0f * SERIES_ELEMENT_FULL_CHARGE_C);
+
+    // Mark SOC as corrupt anytime SOC is reset
+    stats.is_corrupt = true;
+    app_canTx_BMS_SocCorrupt_set(stats.is_corrupt);
+}

--- a/firmware/quadruna/BMS/src/app/app_soc.h
+++ b/firmware/quadruna/BMS/src/app/app_soc.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "app_utils.h"
+#include "app_accumulator.h"
+#include "app_timer.h"
+
+#define STATE_OF_HEALTH (0.94f)
+#define SERIES_ELEMENT_FULL_CHARGE_C (5.9f * 3600.0f * 3.0f * STATE_OF_HEALTH)
+
+#ifndef TARGET_EMBEDDED
+/**
+ * @brief Allows specifying the prev_current member of the SocStats struct, for off-target testing only.
+ * @param current current to set
+ */
+void app_soc_setPrevCurrent(float current);
+#endif
+
+/**
+ * @brief Function to retrieve soc closest to given open circuit voltage
+ * @param voltage open circuit voltage
+ * @return soc related to open circuit voltage
+ */
+float app_soc_getSocFromOcv(float voltage);
+
+/**
+ * @brief Function to retrieve open circuit voltage closest to given soc
+ * @param soc_percent state of charge in percent
+ * @return open circuit voltage closest to given state of charge
+ */
+float app_soc_getOcvFromSoc(float soc_percent);
+
+/**
+ * @brief Initialize the SOC module.
+ */
+void app_soc_init(void);
+
+/**
+ * @brief Return if the SOC value was corrupt on startup
+ * @return corrupt status
+ */
+bool app_soc_getCorrupt(void);
+
+/**
+ * @brief Update the state of charge of all series elements using coulomb counting.
+ */
+void app_soc_updateSocStats(void);
+
+/**
+ * @brief return Coulombs of the SE with the lowest SOC
+ * @return cloulombs of lowest SOC SE
+ */
+float app_soc_getMinSocCoulombs(void);
+
+/**
+ * @brief return percent SOC of the SE with the lowest SOC
+ * @return soc % of lowest SOC SE
+ */
+float app_soc_getMinSocPercent(void);
+
+/**
+ * @brief Get the minimum series element open circuit voltage approximation given current pack SOC status
+ * @return float minimum series element open circuit voltage approximation
+ */
+float app_soc_getMinOcvFromSoc(void);
+
+/**
+ * @brief Reset SOC value based on current minimum cell voltage
+ */
+void app_soc_resetSocFromVoltage(void);
+
+/**
+ * @brief Reset SOC value with custom input
+ * @param soc_percent desired SOC in percent
+ */
+void app_soc_resetSocCustomValue(float soc_percent);

--- a/firmware/quadruna/BMS/src/app/states/app_allStates.c
+++ b/firmware/quadruna/BMS/src/app/states/app_allStates.c
@@ -6,7 +6,7 @@
 #include "app_tractiveSystem.h"
 #include "app_imd.h"
 #include "app_airs.h"
-// #include "app_soc.h"
+#include "app_soc.h"
 #include "app_shdnLoop.h"
 #include "io_faultLatch.h"
 #include "io_airs.h"
@@ -39,20 +39,17 @@ void app_allStates_runOnTick1Hz(void)
         app_canTx_BMS_ChargerConnected_set(charger_is_connected);
     }
 
-    // const float min_soc = app_soc_getMinSocCoulombs();
+    const float min_soc = app_soc_getMinSocCoulombs();
 
-    // // Reset SOC from min cell voltage if soc corrupt and voltage readings settled
-    // if (min_soc < 0)
-    // {
-    //     if (globals->cell_monitor_settle_count >= NUM_CYCLES_TO_SETTLE)
-    //     {
-    //         app_soc_resetSocFromVoltage();
-    //     }
-    // }
-    // else
-    // {
-    // app_soc_writeSocToSd(min_soc);
-    // }
+    // Reset SOC from min cell voltage if soc corrupt and voltage readings settled
+    if (min_soc < 0)
+    {
+        if (globals->cell_monitor_settle_count >= NUM_CYCLES_TO_SETTLE)
+        {
+            app_soc_resetSocFromVoltage();
+        }
+    }
+
 }
 
 bool app_allStates_runOnTick100Hz(void)
@@ -148,16 +145,16 @@ bool app_allStates_runOnTick100Hz(void)
     app_airs_broadcast();
     app_shdnLoop_broadcast();
 
-    // if (io_airs_isNegativeClosed() && io_airs_isPositiveClosed())
-    // {
-    //     app_soc_updateSocStats();
-    // }
+    if (io_airs_isNegativeClosed() && io_airs_isPositiveClosed())
+    {
+        app_soc_updateSocStats();
+    }
 
     const bool acc_fault = app_accumulator_checkFaults();
     const bool ts_fault  = app_tractveSystem_checkFaults();
 
     // Update CAN signals for BMS latch statuses.
-    // app_canTx_BMS_Soc_set(app_soc_getMinSocPercent());
+    app_canTx_BMS_Soc_set(app_soc_getMinSocPercent());
     app_canTx_BMS_BmsOk_set(io_faultLatch_getCurrentStatus(globals->config->bms_ok_latch));
     app_canTx_BMS_ImdOk_set(io_faultLatch_getCurrentStatus(globals->config->imd_ok_latch));
     app_canTx_BMS_BspdOk_set(io_faultLatch_getCurrentStatus(globals->config->bspd_ok_latch));

--- a/firmware/quadruna/BMS/src/app/states/app_allStates.c
+++ b/firmware/quadruna/BMS/src/app/states/app_allStates.c
@@ -49,7 +49,6 @@ void app_allStates_runOnTick1Hz(void)
             app_soc_resetSocFromVoltage();
         }
     }
-
 }
 
 bool app_allStates_runOnTick100Hz(void)

--- a/firmware/quadruna/BMS/src/app/states/app_initState.c
+++ b/firmware/quadruna/BMS/src/app/states/app_initState.c
@@ -1,6 +1,7 @@
 #include "states/app_allStates.h"
 #include "app_utils.h"
 #include "app_imd.h"
+#include "app_soc.h"
 #include "io_faultLatch.h"
 #include "io_airs.h"
 #include "app_inverterOnState.h"
@@ -28,14 +29,14 @@ static void initStateRunOnTick1Hz(void)
     app_allStates_runOnTick1Hz();
 
     // // ONLY RUN THIS WHEN CELLS HAVE HAD TIME TO SETTLE
-    // if (app_canRx_Debug_ResetSoc_MinCellV_get())
-    // {
-    //     app_soc_resetSocFromVoltage();
-    // }
-    // else if (app_canRx_Debug_ResetSoc_CustomEnable_get())
-    // {
-    //     app_soc_resetSocCustomValue(app_canRx_Debug_ResetSoc_CustomVal_get());
-    // }
+    if (app_canRx_Debug_ResetSoc_MinCellV_get())
+    {
+        app_soc_resetSocFromVoltage();
+    }
+    else if (app_canRx_Debug_ResetSoc_CustomEnable_get())
+    {
+        app_soc_resetSocCustomValue(app_canRx_Debug_ResetSoc_CustomVal_get());
+    }
 }
 
 static void initStateRunOnTick100Hz(void)

--- a/firmware/quadruna/BMS/src/tasks.c
+++ b/firmware/quadruna/BMS/src/tasks.c
@@ -39,7 +39,7 @@
 #include "app_commitInfo.h"
 #include "app_thermistors.h"
 #include "app_accumulator.h"
-// #include "app_soc.h"
+#include "app_soc.h"
 #include "app_globals.h"
 #include "states/app_initState.h"
 #include "states/app_inverterOnState.h"
@@ -339,7 +339,7 @@ void tasks_init(void)
     // Re-enable if auxiliary thermistors installed
     // app_thermistors_init();
 
-    // app_soc_init();
+    app_soc_init();
     app_globals_init(&globals_config);
     app_stateMachine_init(app_initState_get());
 

--- a/firmware/quadruna/BMS/test/test_bmsBaseStateMachineTest.h
+++ b/firmware/quadruna/BMS/test/test_bmsBaseStateMachineTest.h
@@ -34,7 +34,7 @@ extern "C"
 
 #include "app_thermistors.h"
 #include "app_accumulator.h"
-// #include "app_soc.h"
+#include "app_soc.h"
 #include "app_globals.h"
 }
 
@@ -55,10 +55,10 @@ class BmsBaseStateMachineTest : public BaseStateMachineTest
         app_accumulator_init();
         app_tractiveSystem_init();
         app_thermistors_init();
-        // app_soc_init();
+        app_soc_init();
         app_globals_init(&globals_config);
 
-        // app_soc_resetSocCustomValue(100.0f);
+        app_soc_resetSocCustomValue(100.0f);
 
         // Set initial voltages to nominal value
         fake_io_ltc6813CellVoltages_readVoltages_returns(true);


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

Add back SOC in most basic form, resets based on min cell voltage on initial startup. Not accurate when power cycled when cells are not settled.

SD should be re-enabled and set to run in its own low-priority task in the future.

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

Off-target tests pass. Will test at charging before endurance.

### Resolved Tickets
<!-- Link any tickets that this PR resolves. -->
