### PR TITLE
Spicy Charging (Overide for Brusa to charge past 336V)

### DIFF
--- a/can_bus/quadruna/Debug/Debug_tx.json
+++ b/can_bus/quadruna/Debug/Debug_tx.json
@@ -26,20 +26,23 @@
             "ChargingCurrentOverride": {
                 "bits": 1
             },
-            "ChargingVoltageOverride": {
-                "bits": 1
-            },
             "ChargingCurrentTargetValue": {
                 "resolution": 0.1,
                 "min": 0,
                 "max": 12.5,
                 "unit": "A"
             },
+            "ChargingVoltageOverride": {
+                "bits": 1
+            },
             "ChargingVoltageTargetValue": {
                 "resolution": 0.1,
                 "min": 0,
                 "max": 350.0,
                 "unit": "V"
+            },
+            "ChargingVoltageSafetyOverride": {
+                "bits": 1
             }
         }
     },

--- a/firmware/quadruna/BMS/src/app/states/app_chargeState.c
+++ b/firmware/quadruna/BMS/src/app/states/app_chargeState.c
@@ -6,9 +6,12 @@
 #define C_RATE_FOR_MAX_CHARGE (0.05f)
 #define MAX_CELL_VOLTAGE_THRESHOLD (4.15f)
 #define CURRENT_AT_MAX_CHARGE (C_RATE_FOR_MAX_CHARGE * C_RATE_TO_AMPS)
-#define MAX_CHARGING_VOLTAGE (336.0f)
+#define MAX_CHARGING_VOLTAGE_NOMINAL (336.0f)
+// Allows pack to reach max cell voltage before BRUSA faults due to max pack voltage (likely due inaccurate ADC reading
+// from BRUSA)
+#define MAX_CHARGING_VOLTAGE_OVERIDE (345.0f)
 // Each cell can handle 11.8A per the Datasheet, x3 in parallel = 35.4A, Setting as 15A for safety (limited by mains
-// current at this stage)
+// current to BRUSA at this stage)
 #define MAX_CHARGING_CURRENT (15.0f)
 
 static uint16_t canMsgEndianSwap(uint16_t can_signal)
@@ -41,6 +44,7 @@ static void chargeStateRunOnEntry(void)
     const float mains_current             = translateChargingParams(INITIAL_MAX_MAINS_CURRENT);
     const float batt_voltage              = translateChargingParams(INITIAL_CHARGING_VOLTAGE);
     const float batt_current              = translateChargingParams(INITIAL_CHARGING_CURRENT);
+
     // Setting these for run on entry right now, change later maybe.
     app_canTx_BMS_MaxMainsCurrent_set(mains_current);
     app_canTx_BMS_ChargingVoltage_set(batt_voltage);
@@ -138,7 +142,11 @@ static void chargeStateRunOnTick100Hz(void)
                                            ? app_canRx_Debug_ChargingVoltageTargetValue_get()
                                            : INITIAL_CHARGING_VOLTAGE;
 
-        if (IS_IN_RANGE(0.0f, MAX_CHARGING_VOLTAGE, charging_voltage))
+        const float max_charging_voltage = app_canRx_Debug_ChargingVoltageSafetyOverride_get()
+                                               ? MAX_CHARGING_VOLTAGE_OVERIDE
+                                               : MAX_CHARGING_VOLTAGE_NOMINAL;
+
+        if (IS_IN_RANGE(0.0f, max_charging_voltage, charging_voltage))
         {
             app_canTx_BMS_ChargingVoltage_set(translateChargingParams(charging_voltage));
         }


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
Brusa currently faults if a pack voltage of 336V is seen, and we had no way of adjusting this value over CAN. This PR adds the ability to due so with the addition of an additional CAN flag to override the safety parameters and request a voltage of up to 345V from the Brusa.

This theoretically should be no danger as the voltage requested from the Brusa is a fault threshold (IE stop charging if this voltage is seen. The BMS itself will shut off charging if a cell voltage above 4.2V is seen, and so there is no real danger of increasing this limit, but until that can be verified I wanted to implement the increased limit in a way that it must be explicitly applied.

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

None, @DJ90864 @KelmLelm @1mackenziekyle this is on you, godspeed. <img src="https://github.com/UBCFormulaElectric/Consolidated-Firmware/assets/60449481/2325e04b-8d37-4669-863f-2ee351d22445" width="24">



### Resolved Tickets
<!-- Link any tickets that this PR resolves. -->
