### PR TITLE
Remove Vscode Prelaunch Tasks for Tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
         "build_fw_dev/firmware/quadruna/VC/quadruna_VC_boot.elf",
         "build_fw_dev/firmware/quadruna/VC/quadruna_VC_app.elf",
       ],
-      // "preLaunchTask": "Build Embedded: VC (Quadruna)",
+      "preLaunchTask": "Build Embedded: VC (Quadruna)",
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
@@ -44,7 +44,7 @@
         "build_fw_dev/firmware/quadruna/BMS/quadruna_BMS_boot.elf",
         "build_fw_dev/firmware/quadruna/BMS/quadruna_BMS_app.elf",
       ],
-      // "preLaunchTask": "Build Embedded: BMS (Quadruna)",
+      "preLaunchTask": "Build Embedded: BMS (Quadruna)",
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
@@ -78,7 +78,7 @@
         "build_fw_dev/firmware/quadruna/FSM/quadruna_FSM_boot.elf",
         "build_fw_dev/firmware/quadruna/FSM/quadruna_FSM_app.elf",
       ],
-      // "preLaunchTask": "Build Embedded: FSM (Quadruna)",
+      "preLaunchTask": "Build Embedded: FSM (Quadruna)",
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
@@ -112,7 +112,7 @@
         "build_fw_dev/firmware/quadruna/RSM/quadruna_RSM_boot.elf",
         "build_fw_dev/firmware/quadruna/RSM/quadruna_RSM_app.elf",
       ],
-      // "preLaunchTask": "Build Embedded: RSM (Quadruna)",
+      "preLaunchTask": "Build Embedded: RSM (Quadruna)",
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
@@ -147,7 +147,7 @@
         "build_fw_dev/firmware/quadruna/CRIT/quadruna_CRIT_boot.elf",
         "build_fw_dev/firmware/quadruna/CRIT/quadruna_CRIT_app.elf",
       ],
-      // "preLaunchTask": "Build Embedded: CRIT (Quadruna)",
+      "preLaunchTask": "Build Embedded: CRIT (Quadruna)",
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
@@ -176,7 +176,7 @@
       "name": "Debug Embedded: f4dev",
       "cwd": "${workspaceRoot}",
       "executable": "build_fw_dev/firmware/dev/f4dev/f4dev.elf",
-      // "preLaunchTask": "Build Embedded: f4dev",
+      "preLaunchTask": "Build Embedded: f4dev",
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
@@ -209,7 +209,7 @@
         "build_fw_dev/firmware/boot/h7boot/h7dev_boot.elf",
         "build_fw_dev/firmware/dev/h7dev/h7dev_app.elf",
       ],
-      // "preLaunchTask": "Build Embedded: h7dev",
+      "preLaunchTask": "Build Embedded: h7dev",
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,14 +11,14 @@
         "build_fw_dev/firmware/quadruna/VC/quadruna_VC_app.elf",
       ],
       // "preLaunchTask": "Build Embedded: VC (Quadruna)",
-
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
       "servertype": "jlink",
       "serverpath": "JLinkGDBServerCL",
       "serverArgs": [
-        "-speed", "4000"
+        "-speed",
+        "4000"
       ],
       "device": "STM32H733VG",
       "interface": "swd",
@@ -45,14 +45,14 @@
         "build_fw_dev/firmware/quadruna/BMS/quadruna_BMS_app.elf",
       ],
       // "preLaunchTask": "Build Embedded: BMS (Quadruna)",
-
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
       "servertype": "jlink",
       "serverpath": "JLinkGDBServerCL",
       "serverArgs": [
-        "-speed", "4000"
+        "-speed",
+        "4000"
       ],
       "device": "STM32H733VG",
       "interface": "swd",
@@ -79,14 +79,14 @@
         "build_fw_dev/firmware/quadruna/FSM/quadruna_FSM_app.elf",
       ],
       // "preLaunchTask": "Build Embedded: FSM (Quadruna)",
-
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
       "servertype": "jlink",
       "serverpath": "JLinkGDBServerCL",
       "serverArgs": [
-        "-speed", "4000"
+        "-speed",
+        "4000"
       ],
       "device": "STM32F412RG",
       "interface": "swd",
@@ -113,14 +113,14 @@
         "build_fw_dev/firmware/quadruna/RSM/quadruna_RSM_app.elf",
       ],
       // "preLaunchTask": "Build Embedded: RSM (Quadruna)",
-
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
       "servertype": "jlink",
       "serverpath": "JLinkGDBServerCL",
       "serverArgs": [
-        "-speed", "4000"
+        "-speed",
+        "4000"
       ],
       "device": "STM32F412RG",
       "interface": "swd",
@@ -140,7 +140,6 @@
     {
       "name": "Debug Embedded: CRIT (Quadruna)",
       "cwd": "${workspaceRoot}",
-
       // binary config
       "executable": "build_fw_dev/firmware/quadruna/CRIT/quadruna_CRIT.hex",
       "symbolFiles": [
@@ -149,14 +148,14 @@
         "build_fw_dev/firmware/quadruna/CRIT/quadruna_CRIT_app.elf",
       ],
       // "preLaunchTask": "Build Embedded: CRIT (Quadruna)",
-
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
       "servertype": "jlink",
       "serverpath": "JLinkGDBServerCL",
       "serverArgs": [
-        "-speed", "4000"
+        "-speed",
+        "4000"
       ],
       "device": "STM32F412RG",
       "interface": "swd",
@@ -178,14 +177,14 @@
       "cwd": "${workspaceRoot}",
       "executable": "build_fw_dev/firmware/dev/f4dev/f4dev.elf",
       // "preLaunchTask": "Build Embedded: f4dev",
-
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
       "servertype": "jlink",
       "serverpath": "JLinkGDBServerCL",
       "serverArgs": [
-        "-speed", "4000"
+        "-speed",
+        "4000"
       ],
       "device": "STM32F412RG",
       "interface": "swd",
@@ -211,14 +210,14 @@
         "build_fw_dev/firmware/dev/h7dev/h7dev_app.elf",
       ],
       // "preLaunchTask": "Build Embedded: h7dev",
-
       // cortex configurations
       "request": "launch",
       "type": "cortex-debug",
       "servertype": "jlink",
       "serverpath": "JLinkGDBServerCL",
       "serverArgs": [
-        "-speed", "4000"
+        "-speed",
+        "4000"
       ],
       "device": "STM32H733VG",
       "interface": "swd",
@@ -235,7 +234,6 @@
         ]
       },
     },
-
     // ========== TESTS ==========
     {
       "name": "Debug Tests: VC (Quadruna)",
@@ -243,7 +241,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/VC/quadruna_VC_test",
       "cwd": "${workspaceRoot}",
-      // "preLaunchTask": "Build Tests: VC (Quadruna)",
+      "preLaunchTask": "Build Tests: VC (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -257,7 +255,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/BMS/quadruna_BMS_test",
       "cwd": "${workspaceRoot}",
-      // "preLaunchTask": "Build Tests: BMS (Quadruna)",
+      "preLaunchTask": "Build Tests: BMS (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -271,7 +269,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/FSM/quadruna_FSM_test",
       "cwd": "${workspaceRoot}",
-      // "preLaunchTask": "Build Tests: FSM (Quadruna)",
+      "preLaunchTask": "Build Tests: FSM (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -285,7 +283,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/RSM/quadruna_RSM_test",
       "cwd": "${workspaceRoot}",
-      // "preLaunchTask": "Build Tests: RSM (Quadruna)",
+      "preLaunchTask": "Build Tests: RSM (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -299,7 +297,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/CRIT/quadruna_CRIT_test",
       "cwd": "${workspaceRoot}",
-      // "preLaunchTask": "Build Tests: CRIT (Quadruna)",
+      "preLaunchTask": "Build Tests: CRIT (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -313,7 +311,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/shared/shared_test",
       "cwd": "${workspaceRoot}",
-      // "preLaunchTask": "Build Tests: Shared",
+      "preLaunchTask": "Build Tests: Shared",
       "linux": {
         "MIMode": "gdb"
       },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -243,7 +243,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/VC/quadruna_VC_test",
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Build Tests: VC (Quadruna)",
+      // "preLaunchTask": "Build Tests: VC (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -257,7 +257,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/BMS/quadruna_BMS_test",
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Build Tests: BMS (Quadruna)",
+      // "preLaunchTask": "Build Tests: BMS (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -271,7 +271,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/FSM/quadruna_FSM_test",
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Build Tests: FSM (Quadruna)",
+      // "preLaunchTask": "Build Tests: FSM (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -285,7 +285,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/RSM/quadruna_RSM_test",
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Build Tests: RSM (Quadruna)",
+      // "preLaunchTask": "Build Tests: RSM (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -299,7 +299,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/quadruna/CRIT/quadruna_CRIT_test",
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Build Tests: CRIT (Quadruna)",
+      // "preLaunchTask": "Build Tests: CRIT (Quadruna)",
       "linux": {
         "MIMode": "gdb"
       },
@@ -313,7 +313,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/build_fw_test/firmware/shared/shared_test",
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Build Tests: Shared",
+      // "preLaunchTask": "Build Tests: Shared",
       "linux": {
         "MIMode": "gdb"
       },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
 			"url": "/can_bus/json/schema_tx.json"
 		}
 	],
-	"cmake.configureOnEdit": true,
-	"cmake.configureOnOpen": true,
+	"cmake.configureOnEdit": false,
+	"cmake.configureOnOpen": false,
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,5 +26,111 @@
                 "cwd": "${workspaceFolder}/scripts/utilities/"
             }
         },
+        {
+            "label": "CMake: Load",
+            "detail": "CMake Generate step",
+            "group": "build",
+            "type": "cmake",
+            "command": "configure",
+            "preset": "${command:cmake.activeConfigurePresetName}"
+        },
+        {
+            "label": "CMake: Clean",
+            "detail": "CMake template clean task",
+            "group": "build",
+            "type": "cmake",
+            "command": "clean",
+            "preset": "${command:cmake.activeBuildPresetName}"
+        },
+        {
+            "label": "Build Embedded: BMS (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_BMS.hex"
+            ]
+        },
+        {
+            "label": "Build Embedded: CRIT (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_CRIT.hex"
+            ]
+        },
+        {
+            "label": "Build Embedded: FSM (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_FSM.hex"
+            ]
+        },
+        {
+            "label": "Build Embedded: RSM (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_RSM.hex"
+            ]
+        },
+        {
+            "label": "Build Embedded: VC (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_VC.hex"
+            ]
+        },
+        {
+            "label": "Build Tests: BMS (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_BMS_test"
+            ]
+        },
+        {
+            "label": "Build Tests: CRIT (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_CRIT_test"
+            ]
+        },
+        {
+            "label": "Build Tests: FSM (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_FSM_test"
+            ]
+        },
+        {
+            "label": "Build Tests: RSM (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_RSM_test"
+            ]
+        },
+        {
+            "label": "Build Tests: VC (Quadruna)",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "quadruna_VC_test"
+            ]
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -88,6 +88,24 @@
             ]
         },
         {
+            "label": "Build Embedded: f4dev",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "f4dev.hex"
+            ]
+        },
+        {
+            "label": "Build Embedded: h7dev",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "h7dev.hex"
+            ]
+        },
+        {
             "label": "Build Tests: BMS (Quadruna)",
             "group": "build",
             "type": "cmake",
@@ -132,5 +150,14 @@
                 "quadruna_VC_test"
             ]
         },
+        {
+            "label": "Build Tests: Shared",
+            "group": "build",
+            "type": "cmake",
+            "command": "build",
+            "targets": [
+                "shared_test"
+            ]
+        }
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 # Generates a comple_commands.json file which helps with VSCode intellisense
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+message("🛠️ Build Type: ${CMAKE_BUILD_TYPE}")
 
 # Globally accessible paths
 set(REPO_ROOT_DIR ${CMAKE_SOURCE_DIR})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,69 +1,69 @@
 {
-    "version": 6,
-    "configurePresets": [
-        {
-            "name": "default",
-            "hidden": true
-        },
-        {
-            "name": "FW Dev",
-            "description": "Development build for the Firmware, including debug information and no optimizations.",
-            "inherits": "default",
-            "toolchainFile": "${sourceDir}/gcc-arm-none-eabi.cmake",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "PLATFORM": "firmware",
-                "TARGET": "binary",
-                "HANDLE_DEPS": "OFF",
-                "USE_COMMIT_INFO": "MINIMAL",
-                "NO_VENV": "ON"
-            },
-            "binaryDir": "build_fw_dev"
-        },
-        {
-            "name": "FW Deploy",
-            "description": "Deployment build for the Firmware, including optimizations and no debug information.",
-            "inherits": "default",
-            "toolchainFile": "${sourceDir}/gcc-arm-none-eabi.cmake",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "PLATFORM": "firmware",
-                "TARGET": "binary",
-                "HANDLE_DEPS": "OFF",
-                "USE_COMMIT_INFO": "ON",
-                "NO_VENV": "ON"
-            },
-            "binaryDir": "build_fw_deploy"
-        },
-        {
-            "name": "FW Deploy CI",
-            "inherits": "FW Deploy",
-            "cacheVariables": {
-                "FIX_FORMATTING": "OFF"
-            },
-            "generator": "Unix Makefiles"
-        },
-        {
-            "name": "FW Test",
-            "description": "Test build for the Firmware, including debug information and no optimizations.",
-            "inherits": "default",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "PLATFORM": "firmware",
-                "TARGET": "test",
-                "HANDLE_DEPS": "OFF",
-                "NO_VENV": "ON"
-            },
-            "binaryDir": "build_fw_test"
-        },
-        {
-            "name": "FW Test CI",
-            "inherits": "FW Test",
-            "cacheVariables": {
-                "FIX_FORMATTING": "OFF"
-            },
-            "generator": "Unix Makefiles"
-        }
-    ],
-    "buildPresets": []
+	"version": 6,
+	"configurePresets": [
+		{
+			"name": "default",
+			"hidden": true
+		},
+		{
+			"name": "FW Dev",
+			"description": "Development build for the Firmware, including debug information and no optimizations.",
+			"inherits": "default",
+			"toolchainFile": "${sourceDir}/gcc-arm-none-eabi.cmake",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug",
+				"PLATFORM": "firmware",
+				"TARGET": "binary",
+				"HANDLE_DEPS": "OFF",
+				"USE_COMMIT_INFO": "MINIMAL",
+				"NO_VENV": "ON"
+			},
+			"binaryDir": "build_fw_dev"
+		},
+		{
+			"name": "FW Deploy",
+			"description": "Deployment build for the Firmware, including optimizations and no debug information.",
+			"inherits": "default",
+			"toolchainFile": "${sourceDir}/gcc-arm-none-eabi.cmake",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Release",
+				"PLATFORM": "firmware",
+				"TARGET": "binary",
+				"HANDLE_DEPS": "OFF",
+				"USE_COMMIT_INFO": "ON",
+				"NO_VENV": "ON"
+			},
+			"binaryDir": "build_fw_deploy"
+		},
+		{
+			"name": "FW Deploy CI",
+			"inherits": "FW Deploy",
+			"cacheVariables": {
+				"FIX_FORMATTING": "OFF"
+			},
+			"generator": "Unix Makefiles"
+		},
+		{
+			"name": "FW Test",
+			"description": "Test build for the Firmware, including debug information and no optimizations.",
+			"inherits": "default",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug",
+				"PLATFORM": "firmware",
+				"TARGET": "test",
+				"HANDLE_DEPS": "OFF",
+				"NO_VENV": "ON"
+			},
+			"binaryDir": "build_fw_test"
+		},
+		{
+			"name": "FW Test CI",
+			"inherits": "FW Test",
+			"cacheVariables": {
+				"FIX_FORMATTING": "OFF"
+			},
+			"generator": "Unix Makefiles"
+		}
+	],
+	"buildPresets": []
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,7 +31,7 @@
                 "TARGET": "binary",
                 "HANDLE_DEPS": "OFF",
                 "USE_COMMIT_INFO": "ON",
-                "NO_VENV":  "ON"
+                "NO_VENV": "ON"
             },
             "binaryDir": "build_fw_deploy"
         },
@@ -52,7 +52,7 @@
                 "PLATFORM": "firmware",
                 "TARGET": "test",
                 "HANDLE_DEPS": "OFF",
-                "NO_VENV":  "ON"
+                "NO_VENV": "ON"
             },
             "binaryDir": "build_fw_test"
         },
@@ -65,6 +65,5 @@
             "generator": "Unix Makefiles"
         }
     ],
-    "buildPresets": [
-    ]
+    "buildPresets": []
 }


### PR DESCRIPTION
### Changelist 
- Removed prelaunch tasks from tests. This was causing an error to be thrown since we no longer use Vscode tasks.

### Testing Done
- Ran tests with no warnings in Vscode.

### Resolved Tickets
- https://ubcformulaelectric.atlassian.net/browse/FIRM-94
- [FIRM-99](https://ubcformulaelectric.atlassian.net/browse/FIRM-99)

[FIRM-99]: https://ubcformulaelectric.atlassian.net/browse/FIRM-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ