### PR TITLE
Regen Pedal Remap and Hysteresis Derate

### DIFF
--- a/can_bus/quadruna/VC/VC_tx.json
+++ b/can_bus/quadruna/VC/VC_tx.json
@@ -705,26 +705,44 @@
   },
   "ImuData": {
     "msg_id": 225,
-    "cycle_time": 10,
-    "description": "Linear Acceleration x, y and z direction from the IMU",
+    "cycle_time": 100,
+    "description": "Linear Acceleration and Angular Velocity in x, y and z direction from the IMU",
     "signals": {
       "ImuAccelerationX": {
-        "resolution": 0.001,
-        "min": -50,
-        "max": 50,
-        "unit": "m/s^2"
+        "resolution": 0.1,
+        "min": 0,
+        "max": 20,
+        "unit": "m/s"
       },
       "ImuAccelerationY": {
-        "resolution": 0.001,
-        "min": -50,
-        "max": 50,
-        "unit": "m/s^2"
+        "resolution": 0.1,
+        "min": 0,
+        "max": 20,
+        "unit": "m/s"
       },
       "ImuAccelerationZ": {
-        "resolution": 0.001,
-        "min": -50,
-        "max": 50,
-        "unit": "m/s^2"
+        "resolution": 0.1,
+        "min": 0,
+        "max": 20,
+        "unit": "m/s"
+      },
+      "ImuAngularVelocityRoll": {
+        "resolution": 0.1,
+        "min": -360,
+        "max": 360,
+        "unit": "deg/s"
+      },
+      "ImuAngularVelocityPitch": {
+        "resolution": 0.1,
+        "min": -360,
+        "max": 360,
+        "unit": "deg/s"
+      },
+      "ImuAngularVelocityYaw": {
+        "resolution": 0.1,
+        "min": -360,
+        "max": 360,
+        "unit": "deg/s"
       }
     }
   },
@@ -801,9 +819,9 @@
     "description": "Pedal percentage info",
     "signals": {
       "MappedPedalPercentage": {
-        "min": -1,
-        "max": 1,
-        "resolution": 0.01,
+        "min": -100,
+        "max": 100,
+        "resolution": 0.1,
         "unit": "%"
       }
     }

--- a/can_bus/quadruna/VC/VC_tx.json
+++ b/can_bus/quadruna/VC/VC_tx.json
@@ -705,44 +705,26 @@
   },
   "ImuData": {
     "msg_id": 225,
-    "cycle_time": 100,
-    "description": "Linear Acceleration and Angular Velocity in x, y and z direction from the IMU",
+    "cycle_time": 10,
+    "description": "Linear Acceleration x, y and z direction from the IMU",
     "signals": {
       "ImuAccelerationX": {
-        "resolution": 0.1,
-        "min": 0,
-        "max": 20,
-        "unit": "m/s"
+        "resolution": 0.001,
+        "min": -50,
+        "max": 50,
+        "unit": "m/s^2"
       },
       "ImuAccelerationY": {
-        "resolution": 0.1,
-        "min": 0,
-        "max": 20,
-        "unit": "m/s"
+        "resolution": 0.001,
+        "min": -50,
+        "max": 50,
+        "unit": "m/s^2"
       },
       "ImuAccelerationZ": {
-        "resolution": 0.1,
-        "min": 0,
-        "max": 20,
-        "unit": "m/s"
-      },
-      "ImuAngularVelocityRoll": {
-        "resolution": 0.1,
-        "min": -360,
-        "max": 360,
-        "unit": "deg/s"
-      },
-      "ImuAngularVelocityPitch": {
-        "resolution": 0.1,
-        "min": -360,
-        "max": 360,
-        "unit": "deg/s"
-      },
-      "ImuAngularVelocityYaw": {
-        "resolution": 0.1,
-        "min": -360,
-        "max": 360,
-        "unit": "deg/s"
+        "resolution": 0.001,
+        "min": -50,
+        "max": 50,
+        "unit": "m/s^2"
       }
     }
   },

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -149,16 +149,20 @@ static void driveStateRunOnTick100Hz(void)
         app_canTx_VC_BuzzerOn_set(false);
     }
 
-    // regen switched pedal percentage from [0, 100] to [0.0, 1.0] to [-0.3, 0.7] and then scaled to [-1,1]
+    // change pedal percentage from [0, 100] to [0.0, 1.0]
     float apps_pedal_percentage  = app_canRx_FSM_PappsMappedPedalPercentage_get() * 0.01f;
     float sapps_pedal_percentage = app_canRx_FSM_SappsMappedPedalPercentage_get() * 0.01f;
+
+    // regen switches pedal percentage from [0.0, 1.0] to [-0.3, 0.7] and then scaled to [-1,1]
     if (regen_switch_is_on)
     {
         apps_pedal_percentage  = app_regen_pedalRemapping(apps_pedal_percentage);
         sapps_pedal_percentage = app_regen_pedalRemapping(sapps_pedal_percentage);
     }
 
-    app_canTx_VC_MappedPedalPercentage_set(apps_pedal_percentage);
+    // transmit
+    app_canTx_VC_MappedPedalPercentage_set(apps_pedal_percentage * 100.0f);
+
     if (app_faultCheck_checkSoftwareBspd(apps_pedal_percentage, sapps_pedal_percentage))
     {
         // If bspd warning is true, set torque to 0.0

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -149,11 +149,11 @@ static void driveStateRunOnTick100Hz(void)
         app_canTx_VC_BuzzerOn_set(false);
     }
 
-    // change pedal percentage from [0, 100] to [0.0, 1.0]
+    // change pedal percentage from [0.0f, 100.0f] to [0.0f, 1.0f]
     float apps_pedal_percentage  = app_canRx_FSM_PappsMappedPedalPercentage_get() * 0.01f;
     float sapps_pedal_percentage = app_canRx_FSM_SappsMappedPedalPercentage_get() * 0.01f;
 
-    // regen switches pedal percentage from [0.0, 1.0] to [-0.3, 0.7] and then scaled to [-1,1]
+    // regen switches pedal percentage from [0.0f, 1.0f] to [-0.3f, 0.7f] and then scaled to [-1.0f, 1.0f]
     if (regen_switch_is_on)
     {
         apps_pedal_percentage  = app_regen_pedalRemapping(apps_pedal_percentage);

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -153,7 +153,7 @@ static void driveStateRunOnTick100Hz(void)
     float apps_pedal_percentage  = app_canRx_FSM_PappsMappedPedalPercentage_get() * 0.01f;
     float sapps_pedal_percentage = app_canRx_FSM_SappsMappedPedalPercentage_get() * 0.01f;
 
-    // regen switches pedal percentage from [0.0f, 1.0f] to [-0.3f, 0.7f] and then scaled to [-1.0f, 1.0f]
+    // regen switches pedal percentage from [0.0f, 1.0f] to [-0.2f, 0.8f] and then scaled to [-1.0f, 1.0f]
     if (regen_switch_is_on)
     {
         apps_pedal_percentage  = app_regen_pedalRemapping(apps_pedal_percentage);

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -201,6 +201,9 @@ static void driveStateRunOnExit(void)
     app_canTx_VC_INVR_CommandReadWrite_set(true);
     app_canTx_VC_INVR_CommandData_set((uint16_t)0);
 
+    // Clear mapped pedal percentage
+    app_canTx_VC_MappedPedalPercentage_set(0.0f);
+
 #ifdef TARGET_EMBEDDED
     io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();
     io_canTx_VC_INVL_ReadWriteParamCommand_sendAperiodic();

--- a/firmware/quadruna/VC/src/app/states/app_driveState.c
+++ b/firmware/quadruna/VC/src/app/states/app_driveState.c
@@ -119,11 +119,10 @@ static void driveStateRunOnTick100Hz(void)
     /* TODO: Vehicle dyanmics people need to make sure to do a check if sensor init failed
        or not before using closed loop features */
 
-    // Regen + TV LEDs and update warnings
+    // Initialize LEDs and update warnings on rising edge
     if (turn_regen_led)
     {
-        app_canTx_VC_RegenEnabled_set(true);
-        app_canTx_VC_Warning_RegenNotAvailable_set(false);
+        app_regen_init();
     }
 
     if (!regen_switch_is_on)

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
@@ -122,11 +122,12 @@ static void computeRegenTorqueRequest(
         regenAttr->derating_value = SOC_LIMIT_DERATING_VALUE;
     }
 
-    float min_motor_speed_rpm = MIN(activeDiffInputs->motor_speed_left_rpm, activeDiffInputs->motor_speed_right_rpm);
+    float min_motor_speed_kmh =
+        MOTOR_RPM_TO_KMH(MIN(activeDiffInputs->motor_speed_left_rpm, activeDiffInputs->motor_speed_right_rpm));
 
-    if (min_motor_speed_rpm < 10.0f)
+    if (min_motor_speed_kmh < 10.0f)
     {
-        regenAttr->derating_value = regenAttr->derating_value * (min_motor_speed_rpm - SPEED_MIN_kph) / SPEED_MIN_kph;
+        regenAttr->derating_value = regenAttr->derating_value * (min_motor_speed_kmh - SPEED_MIN_kph) / SPEED_MIN_kph;
     }
 
     activeDiffInputs->power_max_kW    = app_powerLimiting_computeMaxPower(powerInputs);

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
@@ -161,9 +161,18 @@ static void computeRegenTorqueRequest(
 
 float app_regen_pedalRemapping(float apps_pedal_percentage)
 {
-    apps_pedal_percentage = (apps_pedal_percentage - PEDAL_SCALE) * MAX_PEDAL_PERCENT;
-    apps_pedal_percentage = apps_pedal_percentage < 0.0f ? apps_pedal_percentage / PEDAL_SCALE
-                                                         : apps_pedal_percentage / (MAX_PEDAL_PERCENT - PEDAL_SCALE);
+    apps_pedal_percentage = (apps_pedal_percentage - PEDAL_SCALE);
 
-    return apps_pedal_percentage;
+    if (apps_pedal_percentage < 0.0f)
+    {
+        return apps_pedal_percentage / PEDAL_SCALE;
+    }
+    else if (apps_pedal_percentage < 0.1f)
+    {
+        return 0.0f;
+    }
+    else
+    {
+        return apps_pedal_percentage / (MAX_PEDAL_PERCENT - PEDAL_SCALE - 0.1f);
+    }
 }

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
@@ -122,6 +122,13 @@ static void computeRegenTorqueRequest(
         regenAttr->derating_value = SOC_LIMIT_DERATING_VALUE;
     }
 
+    float min_motor_speed_rpm = MIN(activeDiffInputs->motor_speed_left_rpm, activeDiffInputs->motor_speed_right_rpm);
+
+    if (min_motor_speed_rpm < 10.0f)
+    {
+        regenAttr->derating_value = regenAttr->derating_value * (min_motor_speed_rpm - SPEED_MIN_kph) / SPEED_MIN_kph;
+    }
+
     activeDiffInputs->power_max_kW    = app_powerLimiting_computeMaxPower(powerInputs);
     activeDiffInputs->wheel_angle_deg = app_canRx_FSM_SteeringAngle_get() * APPROX_STEERING_TO_WHEEL_ANGLE;
 
@@ -181,6 +188,6 @@ float app_regen_pedalRemapping(float apps_pedal_percentage)
     }
     else
     {
-        return apps_pedal_percentage / (MAX_PEDAL_PERCENT - PEDAL_SCALE - 0.1f);
+        return (apps_pedal_percentage - 0.1f) / (MAX_PEDAL_PERCENT - PEDAL_SCALE - 0.1f);
     }
 }

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include "math.h"
+
 #include "app_regen.h"
 #include "app_vehicleDynamicsConstants.h"
 #include "app_powerLimiting.h"
@@ -6,11 +9,9 @@
 #include "app_canTx.h"
 #include "app_units.h"
 #include "app_utils.h"
-#include <stdlib.h>
-#include "math.h"
 
 /**
- * Check if left or right wheel is greater than 5.0km/hr
+ * Stop regen < 5.0km/hr and start regen > 7.0km/hr
  * @param ActiveDifferential_Inputs struct to populate data
  * @return true if wheel speed meets this condition, false
  * otherwise
@@ -18,7 +19,7 @@
 static bool wheelSpeedInRange(ActiveDifferential_Inputs *inputs);
 
 /**
- * Check if battery cells are less than 4.0V
+ * Check if battery cells are less than 4.1V
  * @param RegenBraking_Inputs struct to populate data
  * @return true battery cells meet this condition,
  * false otherwise
@@ -37,6 +38,7 @@ static void computeRegenTorqueRequest(
     RegenBraking_Inputs       *regenAttr,
     PowerLimiting_Inputs      *powerInputs);
 
+// Global variables for regenerative braking logic
 static RegenBraking_Inputs       regenAttributes = { .enable_active_differential = true };
 static ActiveDifferential_Inputs activeDifferentialInputs;
 static PowerLimiting_Inputs      powerLimitingInputs = { .power_limit_kW = POWER_LIMIT_REGEN_kW };
@@ -50,7 +52,7 @@ void app_regen_init(void)
 
 void app_regen_run(float accelerator_pedal_percentage)
 {
-    // pedal percentage = [-1,0] for deceleration range
+    // pedal percentage = [-1.0f, 0.0f] for deceleration range
     activeDifferentialInputs.accelerator_pedal_percentage = accelerator_pedal_percentage;
     bool regen_available = app_regen_safetyCheck(&regenAttributes, &activeDifferentialInputs);
 
@@ -60,8 +62,8 @@ void app_regen_run(float accelerator_pedal_percentage)
     }
     else
     {
-        regenAttributes.left_inverter_torque_Nm  = 0.0;
-        regenAttributes.right_inverter_torque_Nm = 0.0;
+        regenAttributes.left_inverter_torque_Nm  = 0.0f;
+        regenAttributes.right_inverter_torque_Nm = 0.0f;
     }
 
     app_canTx_VC_RegenEnabled_set(regen_available);
@@ -102,10 +104,37 @@ static bool batteryLevelInRange(RegenBraking_Inputs *regenAttr)
     return regenAttr->battery_level < 4.1f;
 }
 
-void app_regen_sendTorqueRequest(float left, float right)
+static void computeRegenTorqueRequest(
+    ActiveDifferential_Inputs *activeDiffInputs,
+    RegenBraking_Inputs       *regenAttr,
+    PowerLimiting_Inputs      *powerInputs)
 {
-    app_canTx_VC_LeftInverterTorqueCommand_set(left);
-    app_canTx_VC_RightInverterTorqueCommand_set(right);
+    float pedal_percentage = activeDiffInputs->accelerator_pedal_percentage;
+
+    powerInputs->accelerator_pedal_percent = -pedal_percentage; // power limiting function requires positive pedal value
+    powerInputs->left_motor_temp_C         = app_canRx_INVL_MotorTemperature_get();
+    powerInputs->right_motor_temp_C        = app_canRx_INVR_MotorTemperature_get();
+
+    regenAttr->derating_value = 1.0f;
+
+    if (regenAttr->battery_level > 3.9f)
+    {
+        regenAttr->derating_value = SOC_LIMIT_DERATING_VALUE;
+    }
+
+    activeDiffInputs->power_max_kW    = app_powerLimiting_computeMaxPower(powerInputs);
+    activeDiffInputs->wheel_angle_deg = app_canRx_FSM_SteeringAngle_get() * APPROX_STEERING_TO_WHEEL_ANGLE;
+
+    if (regenAttr->enable_active_differential)
+    {
+        app_regen_computeActiveDifferentialTorque(activeDiffInputs, regenAttr);
+    }
+    else
+    {
+        // no power limit, no active differential
+        regenAttr->left_inverter_torque_Nm  = MAX_REGEN_Nm * pedal_percentage * regenAttr->derating_value;
+        regenAttr->right_inverter_torque_Nm = MAX_REGEN_Nm * pedal_percentage * regenAttr->derating_value;
+    }
 }
 
 void app_regen_computeActiveDifferentialTorque(ActiveDifferential_Inputs *inputs, RegenBraking_Inputs *regenAttr)
@@ -132,42 +161,10 @@ void app_regen_computeActiveDifferentialTorque(ActiveDifferential_Inputs *inputs
     regenAttr->right_inverter_torque_Nm = torque_right_Nm * scale;
 }
 
-static void computeRegenTorqueRequest(
-    ActiveDifferential_Inputs *activeDiffInputs,
-    RegenBraking_Inputs       *regenAttr,
-    PowerLimiting_Inputs      *powerInputs)
+void app_regen_sendTorqueRequest(float left, float right)
 {
-    float pedal_percentage = activeDiffInputs->accelerator_pedal_percentage;
-
-    powerInputs->accelerator_pedal_percent = -pedal_percentage; // power limiting function requires positive pedal value
-    powerInputs->left_motor_temp_C         = app_canRx_INVL_MotorTemperature_get();
-    powerInputs->right_motor_temp_C        = app_canRx_INVR_MotorTemperature_get();
-
-    regenAttr->derating_value = 1.0f;
-
-    if (regenAttr->battery_level > 3.9f)
-    {
-        regenAttr->derating_value = SOC_LIMIT_DERATING_VALUE;
-    }
-
-    // if (min_motor_speed <= 10.0f)
-    // {
-    //     regenAttr->derating_value = (min_motor_speed - SPEED_MIN_kph) / (SPEED_MIN_kph);
-    // }
-
-    activeDiffInputs->power_max_kW    = app_powerLimiting_computeMaxPower(powerInputs);
-    activeDiffInputs->wheel_angle_deg = app_canRx_FSM_SteeringAngle_get() * APPROX_STEERING_TO_WHEEL_ANGLE;
-
-    if (regenAttr->enable_active_differential)
-    {
-        app_regen_computeActiveDifferentialTorque(activeDiffInputs, regenAttr);
-    }
-    else
-    {
-        // no power limit, no active differential
-        regenAttr->left_inverter_torque_Nm  = MAX_REGEN_Nm * pedal_percentage * regenAttr->derating_value;
-        regenAttr->right_inverter_torque_Nm = MAX_REGEN_Nm * pedal_percentage * regenAttr->derating_value;
-    }
+    app_canTx_VC_LeftInverterTorqueCommand_set(left);
+    app_canTx_VC_RightInverterTorqueCommand_set(right);
 }
 
 float app_regen_pedalRemapping(float apps_pedal_percentage)

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
@@ -183,7 +183,7 @@ float app_regen_pedalRemapping(float apps_pedal_percentage)
     {
         return apps_pedal_percentage / PEDAL_SCALE;
     }
-    else if (apps_pedal_percentage < 0.1f)
+    else if (apps_pedal_percentage <= 0.1f)
     {
         return 0.0f;
     }

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.c
@@ -50,6 +50,7 @@ void app_regen_init(void)
 
 void app_regen_run(float accelerator_pedal_percentage)
 {
+    // pedal percentage = [-1,0] for deceleration range
     activeDifferentialInputs.accelerator_pedal_percentage = accelerator_pedal_percentage;
     bool regen_available = app_regen_safetyCheck(&regenAttributes, &activeDifferentialInputs);
 

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
@@ -50,7 +50,7 @@ void app_regen_computeActiveDifferentialTorque(ActiveDifferential_Inputs *inputs
  * @param apps_pedal_percentage is the FSM given pedal percentage
  * @return remap pedal percentage from [0.0, 1.0] to
  * regen range:        [0%-20%) [-0.2, 0.0) which then gets mapped [-1.0, 0.0)
- * cruising range:     [30%-40%) [0.0, 0.1) which then gets mapped to [0.0]
- * acceleration range: [40%-100%] [0.1, 0.8] which then gets mapped (0.0, 1.0]
+ * cruising range:     [20%-30%) [0.0, 0.1) which then gets mapped to [0.0]
+ * acceleration range: [30%-100%] [0.1, 0.8] which then gets mapped (0.0, 1.0]
  */
 float app_regen_pedalRemapping(float apps_pedal_percentage);

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
@@ -48,6 +48,9 @@ void app_regen_computeActiveDifferentialTorque(ActiveDifferential_Inputs *inputs
 /**
  * Remap Papps and Sapps pedal percentage
  * @param apps_pedal_percentage is the FSM given pedal percentage
- * @return remap pedal percentage from [0, 100] to [0.0, 1.0] to [-0.3, 0.7] and then scaled to [-1,1]
+ * @return remap pedal percentage from [0.0, 1.0] to
+ * regen range:        [0%-30%) [-0.3, 0.0) which then gets mapped [-1.0, 0.0)
+ * cruising range:     [30%-40%) [0.0, 0.1) which then gets mapped to [0.0]
+ * acceleration range: [40%-100%] [0.1, 1.0] which then gets mapped (0.0, 1.0]
  */
 float app_regen_pedalRemapping(float apps_pedal_percentage);

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
@@ -5,7 +5,7 @@
 #define MIN_SCALING_SPEED_kph 35.0f
 #define SPEED_MIN_kph 5.0f
 #define SOC_LIMIT_DERATING_VALUE 0.85f
-#define PEDAL_SCALE 0.3f
+#define PEDAL_SCALE 0.2f // 0.25f, 0.3f
 #define MAX_PEDAL_PERCENT 1.0f
 
 /**
@@ -49,8 +49,8 @@ void app_regen_computeActiveDifferentialTorque(ActiveDifferential_Inputs *inputs
  * Remap Papps and Sapps pedal percentage
  * @param apps_pedal_percentage is the FSM given pedal percentage
  * @return remap pedal percentage from [0.0, 1.0] to
- * regen range:        [0%-30%) [-0.3, 0.0) which then gets mapped [-1.0, 0.0)
+ * regen range:        [0%-20%) [-0.2, 0.0) which then gets mapped [-1.0, 0.0)
  * cruising range:     [30%-40%) [0.0, 0.1) which then gets mapped to [0.0]
- * acceleration range: [40%-100%] [0.1, 1.0] which then gets mapped (0.0, 1.0]
+ * acceleration range: [40%-100%] [0.1, 0.8] which then gets mapped (0.0, 1.0]
  */
 float app_regen_pedalRemapping(float apps_pedal_percentage);

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_regen.h
@@ -4,7 +4,7 @@
 
 #define MIN_SCALING_SPEED_kph 35.0f
 #define SPEED_MIN_kph 5.0f
-#define SOC_LIMIT_DERATING_VALUE 0.85f;
+#define SOC_LIMIT_DERATING_VALUE 0.85f
 #define PEDAL_SCALE 0.3f
 #define MAX_PEDAL_PERCENT 1.0f
 

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_torqueVectoring.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_torqueVectoring.c
@@ -63,9 +63,9 @@ void app_torqueVectoring_init(void)
 
 void app_torqueVectoring_run(float accelerator_pedal_percentage)
 {
+    // pedal percentage = [0,1] for acceleration range
+    accelerator_pedal_percent = accelerator_pedal_percentage;
     // Read data from CAN
-    // NOTE: Pedal percent CAN is in range 0.0-100.0%
-    accelerator_pedal_percent   = accelerator_pedal_percentage;
     wheel_speed_front_left_kph  = app_canRx_FSM_LeftWheelSpeed_get();
     wheel_speed_front_right_kph = app_canRx_FSM_RightWheelSpeed_get();
     motor_speed_left_rpm        = (float)app_canRx_INVL_MotorSpeed_get();

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_torqueVectoring.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_torqueVectoring.c
@@ -63,7 +63,7 @@ void app_torqueVectoring_init(void)
 
 void app_torqueVectoring_run(float accelerator_pedal_percentage)
 {
-    // pedal percentage = [0,1] for acceleration range
+    // pedal percentage = [0.0f, 1.0f] for acceleration range
     accelerator_pedal_percent = accelerator_pedal_percentage;
     // Read data from CAN
     wheel_speed_front_left_kph  = app_canRx_FSM_LeftWheelSpeed_get();

--- a/firmware/quadruna/VC/test/vehicle_dynamics/test_regen.cpp
+++ b/firmware/quadruna/VC/test/vehicle_dynamics/test_regen.cpp
@@ -243,7 +243,7 @@ TEST_F(TestRegen, regular_run_regen_and_switch_disable_during_drive_state)
 
     ASSERT_FALSE(app_canAlerts_VC_Warning_RegenNotAvailable_get());
     ASSERT_TRUE(app_canTx_VC_RegenEnabled_get());
-    ASSERT_TRUE(app_canTx_VC_MappedPedalPercentage_get() == -1.0f);
+    ASSERT_TRUE(app_canTx_VC_MappedPedalPercentage_get() == -100.0f);
 
     app_canRx_CRIT_RegenSwitch_update(SWITCH_OFF);
 

--- a/firmware/quadruna/VC/test/vehicle_dynamics/test_regen.cpp
+++ b/firmware/quadruna/VC/test/vehicle_dynamics/test_regen.cpp
@@ -403,3 +403,49 @@ TEST_F(TestRegen, hysterisis_derate)
     ASSERT_TRUE(alert == false);
     ASSERT_TRUE(enabled == true);
 }
+
+TEST_F(TestRegen, pedal_remap)
+{
+    // accelerating range
+    float pedal_remap  = app_regen_pedalRemapping(100);
+    float actual_pedal = 1.0f;
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+
+    pedal_remap  = app_regen_pedalRemapping(80);
+    actual_pedal = (0.8f - 0.1f) / 0.7f;
+
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+
+    pedal_remap  = app_regen_pedalRemapping(50);
+    actual_pedal = (0.5f - 0.1f) / 0.7f;
+
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+
+    // cruising range
+    pedal_remap  = app_regen_pedalRemapping(30);
+    actual_pedal = 0.0f;
+
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+
+    pedal_remap  = app_regen_pedalRemapping(25);
+    actual_pedal = 0.0f;
+
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+
+    // regen range
+
+    pedal_remap  = app_regen_pedalRemapping(19);
+    actual_pedal = (0.19f - 0.2f) / 0.2f;
+
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+
+    pedal_remap  = app_regen_pedalRemapping(5);
+    actual_pedal = (0.05f - 0.2f) / 0.2f;
+
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+
+    pedal_remap  = app_regen_pedalRemapping(0);
+    actual_pedal = -1.0f;
+
+    ASSERT_FLOAT_EQ(actual_pedal, pedal_remap);
+}


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->
- regen range 20% of pedal, cruising range 10%, acceleration range 70%
- change app_canTx_VC_MappedPedalPercentage to -100% to 100% for better readability
- clean up regen code and clarify some things in drive state
### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

### Resolved Tickets
<!-- Link any tickets that this PR resolves. -->
[FIRM-156](https://ubcformulaelectric.atlassian.net/jira/software/c/projects/FIRM/boards/37?selectedIssue=FIRM-156)

[FIRM-156]: https://ubcformulaelectric.atlassian.net/browse/FIRM-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ