### PR TITLE
`JLinkGDBServerCLExe` -> `JLinkGDBServer` on MacOS to enable Brew Installs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
         "serverpath": "JLinkGDBServerCLExe",
       },
       "osx": {
-        "serverpath": "JLinkGDBServerCLExe",
+        "serverpath": "JLinkGDBServer",
       },
       "windows": {
         "serverpath": "JLinkGDBServerCL",
@@ -61,7 +61,7 @@
         "serverpath": "JLinkGDBServerCLExe",
       },
       "osx": {
-        "serverpath": "JLinkGDBServerCLExe",
+        "serverpath": "JLinkGDBServer",
       },
       "windows": {
         "serverpath": "JLinkGDBServerCLExe",
@@ -103,7 +103,7 @@
         "serverpath": "JLinkGDBServerCLExe",
       },
       "osx": {
-        "serverpath": "JLinkGDBServerCLExe",
+        "serverpath": "JLinkGDBServer",
       },
       "windows": {
         "serverpath": "JLinkGDBServerCL",
@@ -145,7 +145,7 @@
         "serverpath": "JLinkGDBServerCLExe",
       },
       "osx": {
-        "serverpath": "JLinkGDBServerCLExe",
+        "serverpath": "JLinkGDBServer",
       },
       "windows": {
         "serverpath": "JLinkGDBServerCL",
@@ -188,7 +188,7 @@
         "serverpath": "JLinkGDBServerCLExe",
       },
       "osx": {
-        "serverpath": "JLinkGDBServerCLExe",
+        "serverpath": "JLinkGDBServer",
       },
       "windows": {
         "serverpath": "JLinkGDBServerCL",
@@ -268,7 +268,7 @@
         "serverpath": "JLinkGDBServerCLExe",
       },
       "osx": {
-        "serverpath": "JLinkGDBServerCLExe",
+        "serverpath": "JLinkGDBServer",
       },
       "windows": {
         "serverpath": "JLinkGDBServerCL",
@@ -309,7 +309,7 @@
         "serverpath": "JLinkGDBServerCLExe",
       },
       "osx": {
-        "serverpath": "JLinkGDBServerCLExe",
+        "serverpath": "JLinkGDBServer",
       },
       "windows": {
         "serverpath": "JLinkGDBServerCL",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -297,7 +297,7 @@
       "cwd": "${workspaceRoot}",
       "executable": "build_fw_dev/firmware/dev/h7dev/h7dev.hex",
       "symbolFiles": [
-        "build_fw_dev/firmware/boot/h7boot/h7dev_boot.elf",
+        "build_fw_dev/firmware/dev/h7dev/h7dev_boot.elf",
         "build_fw_dev/firmware/dev/h7dev/h7dev_app.elf",
       ],
       "preLaunchTask": "Build Embedded: h7dev",


### PR DESCRIPTION
### Changelist 
We now invoke `JLinkGDBServer` instead of `JLinkGDBServerCLExe` in `launch.json` for OSX. The installer from the web provides the `JLinkGDBServerCLExe` alias to `JLinkGDBServer`, but the `brew` install only provides `JLinkGDBServer`. 

Also fixes typo in path for `h7dev_boot.elf` in `launch.json`.

**This PR makes it possible to install jlink segger via `brew`**.

### Testing Done
- [x] Flashed H7Dev

### Resolved Tickets
- None
