### PR TITLE
Chimera Watchdog Repair

### DIFF
--- a/firmware/quadruna/BMS/src/tasks.c
+++ b/firmware/quadruna/BMS/src/tasks.c
@@ -401,7 +401,7 @@ _Noreturn void tasks_run1kHz(void)
     static const TickType_t period_ms = 1;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
-    io_chimera_task(watchdog, period_ms);
+    io_chimera_checkerTask(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();

--- a/firmware/quadruna/CRIT/src/tasks.c
+++ b/firmware/quadruna/CRIT/src/tasks.c
@@ -509,7 +509,7 @@ _Noreturn void tasks_run1kHz(void)
     static const TickType_t period_ms = 1;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
-    io_chimera_task(watchdog, period_ms);
+    io_chimera_checkerTask(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();

--- a/firmware/quadruna/CRIT/src/tasks.c
+++ b/firmware/quadruna/CRIT/src/tasks.c
@@ -451,12 +451,11 @@ void tasks_init(void)
 
 _Noreturn void tasks_run100Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     // Setup tasks.
     static const TickType_t period_ms = 10;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_100HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -477,7 +476,7 @@ _Noreturn void tasks_run100Hz(void)
 
 _Noreturn void tasks_runCanTx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
 
     // Setup tasks.
     for (;;)
@@ -490,7 +489,7 @@ _Noreturn void tasks_runCanTx(void)
 
 _Noreturn void tasks_runCanRx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
 
     // Setup tasks.
     for (;;)
@@ -506,12 +505,11 @@ _Noreturn void tasks_runCanRx(void)
 
 _Noreturn void tasks_run1kHz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     // Setup tasks.
     static const TickType_t period_ms = 1;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -540,12 +538,11 @@ _Noreturn void tasks_run1kHz(void)
 
 _Noreturn void tasks_run1Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     // Setup tasks.
     static const TickType_t period_ms = 1000U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();

--- a/firmware/quadruna/FSM/src/tasks.c
+++ b/firmware/quadruna/FSM/src/tasks.c
@@ -229,7 +229,7 @@ _Noreturn void tasks_run1kHz(void)
     static const TickType_t period_ms = 1U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
-    io_chimera_task(watchdog, period_ms);
+    io_chimera_checkerTask(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();

--- a/firmware/quadruna/FSM/src/tasks.c
+++ b/firmware/quadruna/FSM/src/tasks.c
@@ -174,11 +174,10 @@ void tasks_init(void)
 
 _Noreturn void tasks_run1Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 1000U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -203,11 +202,10 @@ _Noreturn void tasks_run1Hz(void)
 
 _Noreturn void tasks_run100Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 10;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_100HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -228,11 +226,10 @@ _Noreturn void tasks_run100Hz(void)
 
 _Noreturn void tasks_run1kHz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 1U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -259,7 +256,7 @@ _Noreturn void tasks_run1kHz(void)
 
 _Noreturn void tasks_runCanTx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
 
     for (;;)
     {
@@ -271,7 +268,7 @@ _Noreturn void tasks_runCanTx(void)
 
 _Noreturn void tasks_runCanRx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
 
     for (;;)
     {

--- a/firmware/quadruna/RSM/src/tasks.c
+++ b/firmware/quadruna/RSM/src/tasks.c
@@ -264,7 +264,7 @@ _Noreturn void tasks_run1kHz(void)
     static const TickType_t period_ms = 1U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
-    io_chimera_task(watchdog, period_ms);
+    io_chimera_checkerTask(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();

--- a/firmware/quadruna/RSM/src/tasks.c
+++ b/firmware/quadruna/RSM/src/tasks.c
@@ -209,11 +209,10 @@ void tasks_init(void)
 
 _Noreturn void tasks_run1Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 1000U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -238,11 +237,10 @@ _Noreturn void tasks_run1Hz(void)
 
 _Noreturn void tasks_run100Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 10;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_100HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -263,11 +261,10 @@ _Noreturn void tasks_run100Hz(void)
 
 _Noreturn void tasks_run1kHz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 1U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -294,7 +291,7 @@ _Noreturn void tasks_run1kHz(void)
 
 _Noreturn void tasks_runCanTx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
 
     for (;;)
     {
@@ -306,7 +303,7 @@ _Noreturn void tasks_runCanTx(void)
 
 _Noreturn void tasks_runCanRx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
     for (;;)
     {
         CanMsg rx_msg;

--- a/firmware/quadruna/VC/src/tasks.c
+++ b/firmware/quadruna/VC/src/tasks.c
@@ -404,11 +404,10 @@ void tasks_init(void)
 
 _Noreturn void tasks_run1Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 1000U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -433,11 +432,10 @@ _Noreturn void tasks_run1Hz(void)
 
 _Noreturn void tasks_run100Hz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 10;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_100HZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -459,11 +457,10 @@ _Noreturn void tasks_run100Hz(void)
 
 _Noreturn void tasks_run1kHz(void)
 {
-    io_chimera_sleepTaskIfEnabled();
-
     static const TickType_t period_ms = 1U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
+    io_chimera_task(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();
@@ -490,7 +487,7 @@ _Noreturn void tasks_run1kHz(void)
 
 _Noreturn void tasks_runCanTx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
 
     for (;;)
     {
@@ -509,6 +506,8 @@ _Noreturn void tasks_runCanTx(void)
 
 _Noreturn void tasks_runTelem(void)
 {
+    io_chimera_block();
+
     for (;;)
     {
         io_telemMessage_broadcastMsgFromQueue();
@@ -517,7 +516,7 @@ _Noreturn void tasks_runTelem(void)
 
 _Noreturn void tasks_runCanRx(void)
 {
-    io_chimera_sleepTaskIfEnabled();
+    io_chimera_block();
 
     for (;;)
     {
@@ -533,6 +532,8 @@ _Noreturn void tasks_runCanRx(void)
 
 _Noreturn void tasks_runLogging(void)
 {
+    io_chimera_block();
+
     if (!sd_card_present)
     {
         osThreadSuspend(osThreadGetId());

--- a/firmware/quadruna/VC/src/tasks.c
+++ b/firmware/quadruna/VC/src/tasks.c
@@ -460,7 +460,7 @@ _Noreturn void tasks_run1kHz(void)
     static const TickType_t period_ms = 1U;
     WatchdogHandle         *watchdog  = hw_watchdog_allocateWatchdog();
     hw_watchdog_initWatchdog(watchdog, RTOS_TASK_1KHZ, period_ms);
-    io_chimera_task(watchdog, period_ms);
+    io_chimera_checkerTask(watchdog, period_ms);
 
     static uint32_t start_ticks = 0;
     start_ticks                 = osKernelGetTickCount();

--- a/firmware/shared/src/io/io_chimera.c
+++ b/firmware/shared/src/io/io_chimera.c
@@ -109,12 +109,8 @@ void io_chimera_init(const UART *serial_uart, uint32_t name_gpio, uint32_t name_
     }
 }
 
-void io_chimera_sleepTaskIfEnabled(void)
-{
-    if (chimera_button_pressed)
-    {
-        osDelay(osWaitForever);
-    }
+bool io_chimera_enabled(void) {
+    return chimera_button_pressed;
 }
 
 void io_chimera_msgRxCallback(void)

--- a/firmware/shared/src/io/io_chimera.c
+++ b/firmware/shared/src/io/io_chimera.c
@@ -131,9 +131,34 @@ void io_chimera_task(WatchdogHandle *watchdog, uint32_t period_ms)
     for (;;)
     {
         // Check in for timeouts for all RTOS tasks
-        hw_watchdog_checkForTimeouts();
+        // hw_watchdog_checkForTimeouts();
         const uint32_t task_start_ms = TICK_TO_MS(osKernelGetTickCount());
 
+        hw_watchdog_checkIn(watchdog);
+
+        start_ticks += period_ms;
+        osDelayUntil(start_ticks);
+    }
+}
+
+void io_chimera_checkerTask(WatchdogHandle *watchdog, uint32_t period_ms)
+{
+    // Don't run the task if chimera is not enabled.
+    if (!chimera_button_pressed)
+        return;
+
+    static uint32_t start_ticks = 0;
+    start_ticks                 = osKernelGetTickCount();
+
+    for (;;)
+    {
+        // Check in for timeouts for all RTOS tasks
+        // hw_watchdog_checkForTimeouts();
+        const uint32_t task_start_ms = TICK_TO_MS(osKernelGetTickCount());
+
+        // Watchdog check-in must be the last function called before putting the
+        // task to sleep. Prevent check in if the elapsed period is greater or
+        // equal to the period ms
         hw_watchdog_checkIn(watchdog);
 
         start_ticks += period_ms;

--- a/firmware/shared/src/io/io_chimera.h
+++ b/firmware/shared/src/io/io_chimera.h
@@ -7,4 +7,5 @@
 void io_chimera_init(const UART *serial_uart, uint32_t net_name_gpio, uint32_t net_name_adc, const Gpio *bootup_gpio);
 void io_chimera_msgRxCallback(void);
 void io_chimera_task(WatchdogHandle *watchdog, uint32_t period_ms);
+void io_chimera_checkerTask(WatchdogHandle *watchdog, uint32_t period_ms);
 void io_chimera_block();

--- a/firmware/shared/src/io/io_chimera.h
+++ b/firmware/shared/src/io/io_chimera.h
@@ -5,4 +5,4 @@
 
 void io_chimera_init(const UART *serial_uart, uint32_t net_name_gpio, uint32_t net_name_adc, const Gpio *bootup_gpio);
 void io_chimera_msgRxCallback(void);
-void io_chimera_sleepTaskIfEnabled(void);
+bool io_chimera_enabled(void);

--- a/firmware/shared/src/io/io_chimera.h
+++ b/firmware/shared/src/io/io_chimera.h
@@ -2,7 +2,9 @@
 
 #include "hw_uart.h"
 #include "hw_gpio.h"
+#include "hw_watchdog.h"
 
 void io_chimera_init(const UART *serial_uart, uint32_t net_name_gpio, uint32_t net_name_adc, const Gpio *bootup_gpio);
 void io_chimera_msgRxCallback(void);
-bool io_chimera_enabled(void);
+void io_chimera_task(WatchdogHandle *watchdog, uint32_t period_ms);
+void io_chimera_block();

--- a/validationtools/validationtools/chimera/example/test_bms.py
+++ b/validationtools/validationtools/chimera/example/test_bms.py
@@ -15,22 +15,23 @@ for port in ports:
     print(port.device)
 
 # Transmit data.
-fsm = chimera.FSM(ports[0].device)
+bms = chimera.BMS(ports[2].device)
 
-# Note: All testable FSM pin names are listed in Consolidated-Firmware/chimera/proto/FSM.proto
+# Note: All testable BMS pin names are listed in Consolidated-Firmware/chimera/proto/BMS.proto
 
 ####### WRITE YOUR SCRIPT HERE
 
 for i in range(4):
-    fsm.gpio_write("LED", True)
+    print("here")
+    bms.gpio_write("LED", True)
     print("write true", fsm.gpio_read("LED"))
     time.sleep(0.1)
-    fsm.gpio_write("LED", False)
+    bms.gpio_write("LED", False)
     print("write false", fsm.gpio_read("LED"))
     time.sleep(0.1)
 
 
 # Read ADC value: VBAT_SENSE
-print("read adc", fsm.adc_read("APPS2_3V3"))
+# print("read adc", fsm.adc_read("APPS2_3V3"))
 
 #######

--- a/validationtools/validationtools/chimera/example/test_bms.py
+++ b/validationtools/validationtools/chimera/example/test_bms.py
@@ -22,12 +22,11 @@ bms = chimera.BMS(ports[2].device)
 ####### WRITE YOUR SCRIPT HERE
 
 for i in range(4):
-    print("here")
     bms.gpio_write("LED", True)
-    print("write true", fsm.gpio_read("LED"))
+    print("write true", bms.gpio_read("LED"))
     time.sleep(0.1)
     bms.gpio_write("LED", False)
-    print("write false", fsm.gpio_read("LED"))
+    print("write false", bms.gpio_read("LED"))
     time.sleep(0.1)
 
 


### PR DESCRIPTION
### Changelist 
- Last year, when doing board bringup/chimera testing, we disabled the watchdog. Bringing back watchdog broke Chimera, since the chimera version of tasks was not petting watchdog.
- This PR removes `io_chimera_sleepIfTaskEnabled()` in favour of `io_chimera_block()` and `io_chimera_task()`.
  - `io_chimera_task` implements a simple watchdog pinging task.
  - `io_chimera_block` operates like `io_chimera_sleepIfTaskEnabled`, and sleeps the task if chimera is enabled.

### Testing Done
- [ ] Tested in BMS @DJ90864 

### Resolved Tickets

