### PR TITLE
Tune Traction Control PID based on Simulink

### DIFF
--- a/can_bus/quadruna/VC/VC_tx.json
+++ b/can_bus/quadruna/VC/VC_tx.json
@@ -443,6 +443,14 @@
                 "min": -1,
                 "max": 1,
                 "scale": 0.01
+            },
+            "CorrectionTorque":{
+                "bits": 8,
+                "offset": 0,
+                "signed": true, 
+                "min": -100,
+                "max": 100,
+                "scale": 0.1
             }
         }
     },

--- a/firmware/quadruna/VC/src/app/app_sbgEllipse.c
+++ b/firmware/quadruna/VC/src/app/app_sbgEllipse.c
@@ -5,6 +5,8 @@
 #include "app_units.h"
 #include "io_sbgEllipse.h"
 
+float vehicle_velocity = 0.0f;
+
 void app_sbgEllipse_broadcast()
 {
     /* Enable these back when you turn this on in the SBG, otherwise it's still sending
@@ -38,7 +40,7 @@ void app_sbgEllipse_broadcast()
     app_canTx_VC_VelocityEastAccuracy_set(ekf_vel_E_accuracy);
     app_canTx_VC_VelocityDownAccuracy_set(ekf_vel_D_accuracy);
 
-    const float vehicle_velocity = sqrtf(SQUARE(ekf_vel_N) + SQUARE(ekf_vel_E) + SQUARE(ekf_vel_D));
+    vehicle_velocity = sqrtf(SQUARE(ekf_vel_N) + SQUARE(ekf_vel_E) + SQUARE(ekf_vel_D));
 
     app_canTx_VC_VehicleVelocity_set(MPS_TO_KMH(vehicle_velocity));
 

--- a/firmware/quadruna/VC/src/app/app_sbgEllipse.h
+++ b/firmware/quadruna/VC/src/app/app_sbgEllipse.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <stdint.h>
+
+extern float vehicle_velocity;
+
 /*
  * Broadcast sensor outputs over CAN.
  */

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_pid.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_pid.c
@@ -6,8 +6,11 @@ void app_pid_init(PID *pid, const PID_Config *conf)
     pid->Kp         = conf->Kp;
     pid->Ki         = conf->Ki;
     pid->Kd         = conf->Kd;
+    pid->derivative_filtering_coeff = NAN; 
     pid->prev_input = 0.0f;
     pid->integral   = 0.0f;
+    pid->integral_windup_min = NAN; 
+    pid->integral_windup_max = NAN;
     pid->out_min    = conf->out_min;
     pid->out_max    = conf->out_max;
 }
@@ -22,8 +25,23 @@ void app_pid_init(PID *pid, const PID_Config *conf)
 float app_pid_compute(PID *pid, float setpoint, float input)
 {
     pid->error = setpoint - input;
-    pid->integral += pid->error;
-    pid->derivative = (input - pid->prev_input);
+
+    if(app_gaurd_init(pid)){ // if initialized implement the gaurd
+        if(pid->integral_windup_max > pid->integral && pid->integral > pid->integral_windup_min){
+            pid->integral += pid->error;
+        }
+    } 
+    else{
+        pid->integral += pid->error;
+    }
+
+    if(app_filter_init(pid)){
+        pid->derivative = pid->derivative_filtering_coeff * (pid->derivative / (1 + pid->derivative_filtering_coeff));
+    }
+    else{
+        pid->derivative = (input - pid->prev_input);
+    }
+
     pid->prev_input = input;
     float output    = pid->Kp * pid->error + pid->Ki * pid->integral - pid->Kd * pid->derivative;
 
@@ -35,4 +53,12 @@ void app_pid_requestReset(PID *pid)
 {
     pid->prev_input = 0.0f;
     pid->integral   = 0.0f;
+}
+
+bool app_gaurd_init(PID *pid){
+    return (pid->integral_windup_max != NAN && pid->integral_windup_min != NAN); 
+}
+
+bool app_filter_init(PID *pid){
+    return (pid->derivative_filtering_coeff != NAN); 
 }

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_pid.h
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_pid.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "stdbool.h"
 
 typedef struct
 {
@@ -7,7 +8,10 @@ typedef struct
     float Kd;
     float error;
     float derivative;
+    float derivative_filtering_coeff; 
     float integral;
+    float integral_windup_min;
+    float integral_windup_max;
     float prev_input;
     float out_min;
     float out_max;
@@ -27,3 +31,7 @@ void app_pid_init(PID *pid, const PID_Config *conf);
 float app_pid_compute(PID *pid, float setpoint, float input);
 
 void app_pid_requestReset(PID *pid);
+
+bool app_gaurd_init(PID *pid); 
+
+bool app_filter_init(PID *pid);

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_pid.h
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_pid.h
@@ -32,6 +32,4 @@ float app_pid_compute(PID *pid, float setpoint, float input);
 
 void app_pid_requestReset(PID *pid);
 
-bool app_gaurd_init(PID *pid); 
-
-bool app_filter_init(PID *pid);
+bool app_guard_init(PID *pid); 

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_tractionControl.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_tractionControl.c
@@ -26,13 +26,16 @@ void app_tractionControl_computeTorque(TractionControl_Inputs *inputs, TractionC
     // NOTE: we want to map K to a vlaue that we can multiple with input torque. K is based on the slip error 
     // we want to map it to torque error, we also want to  make sure we use the torque associated to the wheel from which slip max was taken
 
-    if( slip_ratio_max == slip_ratio_left){
-        correction_torque = k *(wheel_speed_front_left_rpm) + wheel_speed_front_left_rpm; // this will give us err torque
+   if (slip_ratio_max == slip_ratio_left) {
+    correction_torque = k * inputs->torque_left_Nm;    
+    outputs->torque_left_final_Nm  = inputs->torque_left_Nm + correction_torque;
+    outputs->torque_right_final_Nm = inputs->torque_right_Nm;  
     }
     else {
-         correction_torque = k *(wheel_speed_front_right_rpm) + wheel_speed_front_right_rpm;
+    correction_torque = k * inputs->torque_right_Nm; 
+    outputs->torque_right_final_Nm = inputs->torque_right_Nm + correction_torque;
+    outputs->torque_left_final_Nm  = inputs->torque_left_Nm; 
     }
-
     // Send debug messages over CAN
     app_canTx_VC_SlipRatioLeft_set(slip_ratio_left);
     app_canTx_VC_SlipRatioRight_set(slip_ratio_right);
@@ -42,10 +45,6 @@ void app_tractionControl_computeTorque(TractionControl_Inputs *inputs, TractionC
     app_canTx_VC_PIDSlipRatioDerivative_set(pid->derivative);
     app_canTx_VC_PIDSlipRatioIntegral_set(pid->integral);
 
-    // NOTE: k strictly in range [-1 0] to prevent exceeding power limit
-
-    outputs->torque_left_final_Nm  =  inputs->torque_left_Nm + correction_torque; 
-    outputs->torque_right_final_Nm =  inputs->torque_right_Nm + correction_torque;
 }
 
 float app_tractionControl_computeSlip(float motor_speed_rpm, float front_wheel_speed_rpm)

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_tractionControl.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_tractionControl.c
@@ -21,18 +21,31 @@ void app_tractionControl_computeTorque(TractionControl_Inputs *inputs, TractionC
 
     float slip_ratio_max = fmaxf(slip_ratio_left, slip_ratio_right);
     float k              = app_pid_compute(pid, SLIP_RATIO_IDEAL, slip_ratio_max);
+    static float correction_torque; 
+
+    // NOTE: we want to map K to a vlaue that we can multiple with input torque. K is based on the slip error 
+    // we want to map it to torque error, we also want to  make sure we use the torque associated to the wheel from which slip max was taken
+
+    if( slip_ratio_max == slip_ratio_left){
+        correction_torque = k *(wheel_speed_front_left_rpm) + wheel_speed_front_left_rpm; // this will give us err torque
+    }
+    else {
+         correction_torque = k *(wheel_speed_front_right_rpm) + wheel_speed_front_right_rpm;
+    }
 
     // Send debug messages over CAN
     app_canTx_VC_SlipRatioLeft_set(slip_ratio_left);
     app_canTx_VC_SlipRatioRight_set(slip_ratio_right);
     app_canTx_VC_PIDSlipRatioOutput_set(k);
+    app_canTx_VC_CorrectionTorque_set(correction_torque);
     app_canTx_VC_PIDSlipRatioError_set(pid->error);
     app_canTx_VC_PIDSlipRatioDerivative_set(pid->derivative);
     app_canTx_VC_PIDSlipRatioIntegral_set(pid->integral);
 
     // NOTE: k strictly in range [-1 0] to prevent exceeding power limit
-    outputs->torque_left_final_Nm  = (1.0f + k) * inputs->torque_left_Nm;
-    outputs->torque_right_final_Nm = (1.0f + k) * inputs->torque_right_Nm;
+
+    outputs->torque_left_final_Nm  =  inputs->torque_left_Nm + correction_torque; 
+    outputs->torque_right_final_Nm =  inputs->torque_right_Nm + correction_torque;
 }
 
 float app_tractionControl_computeSlip(float motor_speed_rpm, float front_wheel_speed_rpm)

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_vehicleDynamicsConstants.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_vehicleDynamicsConstants.c
@@ -7,8 +7,8 @@ const PID_Config PID_POWER_CORRECTION_CONFIG = { .Kp      = 0.1f,
                                                  .out_max = 1.0f,
                                                  .out_min = -1.0f };
 
-const PID_Config PID_TRACTION_CONTROL_CONFIG = { .Kp      = 82.11f,
-                                                 .Ki      = 16.08f,
-                                                 .Kd      = 1.95f,
+const PID_Config PID_TRACTION_CONTROL_CONFIG = { .Kp      = 30.3f,  // old: 82.11
+                                                 .Ki      = 3.0f,   // old: 16.08
+                                                 .Kd      = 1.5f,   // old : 1.95
                                                  .out_max = 1.0f,
                                                  .out_min = -1.0f };

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_vehicleDynamicsConstants.c
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_vehicleDynamicsConstants.c
@@ -1,13 +1,14 @@
 #include "app_vehicleDynamicsConstants.h"
 
+
 const PID_Config PID_POWER_CORRECTION_CONFIG = { .Kp      = 0.1f,
                                                  .Ki      = 0.0f,
                                                  .Kd      = 0.0f,
                                                  .out_max = 1.0f,
                                                  .out_min = -1.0f };
 
-const PID_Config PID_TRACTION_CONTROL_CONFIG = { .Kp      = 0.0001f,
-                                                 .Ki      = 0.01f,
-                                                 .Kd      = 0.0f,
+const PID_Config PID_TRACTION_CONTROL_CONFIG = { .Kp      = 82.11f,
+                                                 .Ki      = 16.08f,
+                                                 .Kd      = 1.95f,
                                                  .out_max = 1.0f,
                                                  .out_min = -1.0f };

--- a/firmware/quadruna/VC/src/app/vehicle_dynamics/app_vehicleDynamicsConstants.h
+++ b/firmware/quadruna/VC/src/app/vehicle_dynamics/app_vehicleDynamicsConstants.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "app_pid.h"
-
 // Constants
 
 #define SMALL_EPSILON .000001f // to avoid divide by zero error


### PR DESCRIPTION
### Changelist 
      - added can message for correction torque for visibility
      - implemented clamp based windup guard and derivative noise filtering in pid compute
      -  added wind up and noise filtering inputs to PID struct
      - mapped error slip to error torque for controller to be outputting a correction torque rather than a correction slip 
      - applied PID constants in config (not sure if we want to keep this const if we want it to dynamically change)

### Testing Done
- needs to be done 

### Resolved Tickets
<!-- Link any tickets that this PR resolves. -->
