### PR TITLE
Generic hw_usb Transmit Handle

### DIFF
--- a/firmware/shared/src/hw/hw_usb.c
+++ b/firmware/shared/src/hw/hw_usb.c
@@ -9,6 +9,8 @@ static uint8_t            rx_queue_buf[RX_QUEUE_SIZE];
 static osMessageQueueId_t rx_queue_id = NULL;
 static USBD_HandleTypeDef hUsbDeviceFS;
 
+uint8_t (*usb_transmit_handle)(uint8_t *Buf, uint16_t Len) = NULL;
+
 static const osMessageQueueAttr_t rx_queue_attr = { .name      = "USB RX Queue",
                                                     .attr_bits = 0,
                                                     .cb_mem    = &rx_queue_control_block,
@@ -16,8 +18,9 @@ static const osMessageQueueAttr_t rx_queue_attr = { .name      = "USB RX Queue",
                                                     .mq_mem    = rx_queue_buf,
                                                     .mq_size   = sizeof(rx_queue_buf) };
 
-void hw_usb_init()
+void hw_usb_init(uint8_t (*transmit_handle)(uint8_t *Buf, uint16_t Len))
 {
+    usb_transmit_handle = transmit_handle;
     if (rx_queue_id == NULL)
     {
         rx_queue_id = osMessageQueueNew(RX_QUEUE_SIZE, sizeof(uint8_t), &rx_queue_attr);
@@ -59,10 +62,10 @@ void hw_usb_pushRxMsgToQueue(uint8_t *packet, uint32_t len)
     }
 }
 
-void hw_usb_transmit_example()
+void hw_usb_transmit_example(uint8_t (*transmit_handle)(uint8_t *Buf, uint16_t Len))
 {
     // init usb peripheral
-    hw_usb_init();
+    hw_usb_init(transmit_handle);
     osDelay(1000);
 
     int msg_count = 0;
@@ -80,10 +83,10 @@ void hw_usb_transmit_example()
     }
 }
 
-void hw_usb_recieve_example()
+void hw_usb_recieve_example(uint8_t (*transmit_handle)(uint8_t *Buf, uint16_t Len))
 {
     // init usb peripheral
-    hw_usb_init();
+    hw_usb_init(usb_transmit_handle);
 
     // dump the queue.
     for (int i = 0; true; i += 1)

--- a/firmware/shared/src/hw/hw_usb.h
+++ b/firmware/shared/src/hw/hw_usb.h
@@ -6,7 +6,7 @@
 #define RX_QUEUE_SIZE 2048
 
 // initialize the usb peripheral
-void hw_usb_init();
+void hw_usb_init(uint8_t (*transmit_handle)(uint8_t *Buf, uint16_t Len));
 
 // checks if the usb port is connected
 bool hw_usb_checkConnection();
@@ -22,7 +22,7 @@ uint8_t hw_usb_recieve();
 void hw_usb_pushRxMsgToQueue(uint8_t *packet, uint32_t len);
 
 // runs an example loop where the message "hello" is tx-ed repeatedly
-void hw_usb_transmit_example();
+void hw_usb_transmit_example(uint8_t (*transmit_handle)(uint8_t *Buf, uint16_t Len));
 
 // runs an example loop that logs all received bytes as chars
-void hw_usb_recieve_example();
+void hw_usb_recieve_example(uint8_t (*transmit_handle)(uint8_t *Buf, uint16_t Len));


### PR DESCRIPTION
### Changelist 
- Pass `transmit_handle` as an argument to `hw_usb`/`hw_usb_init`.
- Will let us pass both HS and FS handlers (ie. H7 vs. F4)

### Testing Done
None (H7Dev not working right now due to unrelated issues).

### Resolved Tickets
None.
