### PR TITLE
Fakes for IO JSONCAN

### DIFF
--- a/firmware/cmake/shared.cmake
+++ b/firmware/cmake/shared.cmake
@@ -68,6 +68,9 @@ function(jsoncan_embedded_library BOARD CAR JSONCAN_DIR)
 endfunction()
 
 function(jsoncan_library BOARD CAR JSONCAN_DIR)
+    set(JSONCAN_LIB "${CAR}_${BOARD}_jsoncan")
+    set(JSONCAN_FAKES_LIB "${CAR}_${BOARD}_jsoncan_fakes")
+
     jsoncan_sources(
             ${BOARD}
             ${JSONCAN_DIR}
@@ -75,8 +78,18 @@ function(jsoncan_library BOARD CAR JSONCAN_DIR)
             ${CAR}
     )
     add_library(
-            "${CAR}_${BOARD}_jsoncan" INTERFACE
+        "${JSONCAN_LIB}" INTERFACE
     )
-    target_sources("${CAR}_${BOARD}_jsoncan" INTERFACE ${CAN_SRCS})
-    target_include_directories("${CAR}_${BOARD}_jsoncan" INTERFACE "${CAN_INCLUDE_DIRS}")
+    target_sources("${JSONCAN_LIB}" INTERFACE ${CAN_SRCS})
+    target_include_directories("${JSONCAN_LIB}" INTERFACE "${CAN_INCLUDE_DIRS}")
+
+    set(HEADERS_TO_FAKE
+        "${JSONCAN_DIR}/io/io_canTx.h"
+        "${JSONCAN_DIR}/io/io_canRx.h"
+    )
+    create_fake_library(
+        "${JSONCAN_FAKES_LIB}"
+        "${HEADERS_TO_FAKE}"
+    )
+    target_link_libraries("${JSONCAN_LIB}" INTERFACE "${JSONCAN_FAKES_LIB}")
 endfunction()


### PR DESCRIPTION
### Changelist 
<!-- Give a list of the changes covered in this PR. This will help both you and the reviewer keep this PR within scope. -->

Generate fake functions for for IO JSONCAN using Fakegen. Used for testing any code that needs to invoke `io_canTx_*` or `io_canRx_*`.

### Testing Done
<!-- Outline the testing that was done to demonstrate the changes are solid. This could be unit tests, integration tests, testing on the car, etc. Include relevant code snippets, screenshots, etc as needed. -->

- [x] CI passes
