### PR TITLE
embedded_no_checks hotfix

### DIFF
--- a/firmware/chimera_v2/README.md
+++ b/firmware/chimera_v2/README.md
@@ -196,7 +196,6 @@ set(STM32_HAL_SRCS
 stm32f412rx_cube_library(
 "f4dev_stm32cube"
 "${STM32_HAL_SRCS}"
-"${SYSCALLS}"
 "${MD5_LOCATION}"
 TRUE
 )

--- a/firmware/dev/SSM/CMakeLists.txt
+++ b/firmware/dev/SSM/CMakeLists.txt
@@ -69,15 +69,12 @@ IF ("${TARGET}" STREQUAL "binary")
             "stm32f4xx_hal_spi.c"
     )
 
-    # Don't check cubemx srcs.
-    embedded_no_checks("${MAIN_SRCS}")
+    # Don't check syscalls.
+    embedded_no_checks("${CMAKE_CURRENT_SOURCE_DIR}/src/cubemx/Src/syscalls.c")
 
-    # Pass syscalls to the cube library so we can build without warnings.
-    set(SYSCALLS "${CMAKE_CURRENT_SOURCE_DIR}/src/cubemx/Src/syscalls.c")
     stm32f412rx_cube_library(
             "ssm_stm32cube_hal"
             "${STM32_HAL_SRCS}"
-            "${SYSCALLS}"
             "${MD5_LOCATION}"
             TRUE
     )

--- a/firmware/dev/f4dev/CMakeLists.txt
+++ b/firmware/dev/f4dev/CMakeLists.txt
@@ -44,6 +44,8 @@ IF ("${TARGET}" STREQUAL "binary")
             "${IOC_PATH}"
             "${CUBEMX_SRCS}"
     )
+    embedded_no_checks("${CMAKE_CURRENT_SOURCE_DIR}/src/cubemx/Src/syscalls.c")
+
 
     set(STM32_HAL_SRCS
             "stm32f4xx_hal_adc_ex.c"
@@ -71,12 +73,9 @@ IF ("${TARGET}" STREQUAL "binary")
             "stm32f4xx_hal_spi.c"
     )
 
-    # Pass syscalls to the cube library so we can build without warnings.
-    set(SYSCALLS "${CMAKE_CURRENT_SOURCE_DIR}/src/cubemx/Src/syscalls.c")
     stm32f412rx_cube_library(
             "f4dev_stm32cube_hal"
             "${STM32_HAL_SRCS}"
-            "${SYSCALLS}"
             "${MD5_LOCATION}"
             TRUE
     )

--- a/firmware/quintuna/RSM/CMakeLists.txt
+++ b/firmware/quintuna/RSM/CMakeLists.txt
@@ -114,7 +114,6 @@ if ("${TARGET}" STREQUAL "binary")
     stm32f412rx_cube_library(
             "quintuna_RSM_stm32cube_hal"
             "${STM32_HAL_SRCS}"
-            "${SYSCALLS}"
             "${MD5_LOCATION}"
             TRUE
     )


### PR DESCRIPTION
A few days ago I merged a fix that makes sure only specific STM files that throw warnings are hit with `embedded_no_checks`. Just noticed I forgot to change a few boards to this so just gonna merge this small fix.