### PR TITLE
fix tiling query and source stringify

### DIFF
--- a/software/tracksight/rust_backend/Cargo.toml
+++ b/software/tracksight/rust_backend/Cargo.toml
@@ -33,3 +33,4 @@ if-addrs = "0.15.0"
 moka = { version = "0.12.15", features=["future"] }
 chrono = "0.4.44"
 num-traits = "0.2.19"
+strum = { version = "0.26", features = ["derive"] }

--- a/software/tracksight/rust_backend/src/tasks/can_data/influx_util.rs
+++ b/software/tracksight/rust_backend/src/tasks/can_data/influx_util.rs
@@ -2,11 +2,12 @@ use futures::stream;
 use influxdb2::{Client, api::write::TimestampPrecision, models::{DataPoint, data_point::DataPointError}};
 use jsoncan_rust::can_database::DecodedSignal;
 use serde::{Deserialize, Serialize};
+use strum::Display;
 
 use crate::config::CONFIG;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Display, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[strum(serialize_all = "lowercase")]
 pub enum InfluxSignalSource {
     Radio,
     SdCard,
@@ -30,11 +31,10 @@ pub async fn flush_buffer(buffer: &mut Vec<DataPoint>, client: &Client) {
  * helper to build InfluxDB data point
  */
 pub fn build_data_point(decoded_signal: DecodedSignal, source: InfluxSignalSource) -> Result<DataPoint, DataPointError> {
-    let source_str = serde_json::to_string(&source).unwrap();
     DataPoint::builder(&CONFIG.influxdb_measurement)
         .field("_value", decoded_signal.value)
         .tag("signal_name", &decoded_signal.name)
-        .tag("source", source_str)
+        .tag("source", source.to_string())
         .timestamp(decoded_signal.timestamp.unwrap_or_default() as i64)
         .build()
 }

--- a/software/tracksight/rust_backend/src/tasks/client_api/sd_utils.rs
+++ b/software/tracksight/rust_backend/src/tasks/client_api/sd_utils.rs
@@ -1,6 +1,5 @@
 use std::{fs, path::Path, sync::Arc};
 
-use axum::http::StatusCode;
 use influxdb2::models::DataPoint;
 use jsoncan_rust::can_database::CanDatabase;
 use logfs::{LogFsErr, logfs::{LogFs, LogFsUnixDisk}};
@@ -87,12 +86,12 @@ pub async fn dump_sd_file(
 
         let mut file = match logfs.open(&path, logfs::LogFsOpenFlags_LOGFS_OPEN_RD_ONLY) {
             Ok(f) => f,
-            Err(err) => return Err(SdCardDumpError::FileNotFound),
+            Err(_) => return Err(SdCardDumpError::FileNotFound),
         };
 
         match file.read(None) {
             Ok(d) => d,
-            Err(err) => return Err(SdCardDumpError::FileReadError),
+            Err(_) => return Err(SdCardDumpError::FileReadError),
         }
         // logfs and file are dropped here, before any await
     };

--- a/software/tracksight/rust_backend/src/tasks/client_api/signal_api_handler.rs
+++ b/software/tracksight/rust_backend/src/tasks/client_api/signal_api_handler.rs
@@ -168,6 +168,10 @@ async fn metadata(Query(SignalNameParam { mut name } ): Query<SignalNameParam>, 
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct SourceQuery {
+    pub source: Option<String>,
+}
 
 /**
  * Gets signal values, timestamp, and name.
@@ -177,7 +181,7 @@ async fn metadata(Query(SignalNameParam { mut name } ): Query<SignalNameParam>, 
  */
 async fn signal_tiles(
     Path((signal, start, end)): Path<(String, String, String)>, 
-    Query((source,)): Query<(Option<String>,)>,
+    Query(SourceQuery{ source }): Query<SourceQuery>,
     State(state): State<AppState>
 ) -> impl IntoResponse {
     // todo optionally check if signal name is valid
@@ -228,11 +232,6 @@ struct SessionStarts {
     pub time: DateTime<FixedOffset>,
 }
 
-#[derive(Debug, Deserialize)]
-struct SessionQuery {
-    pub source: Option<String>,
-}
-
 /**
  * Returns list of paired times as milliseconds since UNIX time based on when car turns on
  * Takes start and end time of search range as RFC3339 format
@@ -240,7 +239,7 @@ struct SessionQuery {
  */
 async fn signal_sessions(
     Path((start, end)): Path<(String, String)>,
-    Query(SessionQuery { source }): Query<SessionQuery>,
+    Query(SourceQuery { source }): Query<SourceQuery>,
     State(state): State<AppState>
 ) -> impl IntoResponse {
     let (start_utc, end_utc) = 
@@ -254,7 +253,7 @@ async fn signal_sessions(
 
     let source_str = match source {
         Some(s) => {
-            if let Ok(e) = from_str::<InfluxSignalSource>(&s) {
+            if let Ok(_) = from_str::<InfluxSignalSource>(&s) {
                 s
             } else {
                 return (StatusCode::BAD_REQUEST, "Bad source!".to_string());

--- a/software/tracksight/rust_backend/src/tasks/client_api/signal_tile.rs
+++ b/software/tracksight/rust_backend/src/tasks/client_api/signal_tile.rs
@@ -131,7 +131,7 @@ pub async fn get_signals(
         tile_starts.push(tile_start_utc);
         tile_start_utc = tile_start_utc + Duration::from_millis(tile_duration_ms);
     }
-    let source_str = serde_json::to_string(&source).unwrap();
+    let source_str = source.to_string();
 
     let get_tile_query = |tile_start: &DateTime<Utc>| -> String {
         let tile_start_str = tile_start.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
@@ -145,6 +145,7 @@ pub async fn get_signals(
         |> filter(fn: (r) => r["source"] == "{source_str}")"#
         , &CONFIG.influxdb_bucket, &CONFIG.influxdb_measurement)
     };
+    
     
     // track current time in ms to prevent caching currently written tiles
     let curr_time_ms = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as i64;
@@ -180,7 +181,7 @@ pub async fn get_signals(
                         value: point.value,
                         measurement: CONFIG.influxdb_measurement.clone(),
                         signal_name: signal.clone(),
-                        source: serde_json::to_string(&source).unwrap()
+                        source: source.to_string()
                     })
                 }).collect::<Vec<InfluxSignalRow>>();
                 tile_queries.push(Box::pin(ready(Ok(signal_rows))));


### PR DESCRIPTION
so basically, `serde_json::to_string` adds literal quotations to the string, which breaks the query. also adding the source query struct (rahhh i wanted inline so bad) to signal tiling endpoint