### PR TITLE
Compiler Optimizations for Third Party Libraries

### DIFF
--- a/firmware/cmake/embedded.cmake
+++ b/firmware/cmake/embedded.cmake
@@ -105,14 +105,14 @@ function(embedded_object_library
                 PUBLIC
                 ${LIB_INCLUDE_DIRS}
         )
-        target_compile_options(${LIB_NAME} PRIVATE ${SHARED_GNU_COMPILER_CHECKS} -O0)
+        target_compile_options(${LIB_NAME} PRIVATE ${SHARED_GNU_COMPILER_CHECKS} -Os)
     ELSE ()
         target_include_directories(${LIB_NAME} PUBLIC ${LIB_INCLUDE_DIRS})
         target_compile_options(${LIB_NAME} PRIVATE ${SHARED_GNU_COMPILER_CHECKS_STRICT})
         if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-            target_compile_options(${ELF_NAME} PRIVATE -O0)
+            target_compile_options(${LIB_NAME} PRIVATE -O0)
         else ()
-            target_compile_options(${ELF_NAME} PRIVATE -Os)
+            target_compile_options(${LIB_NAME} PRIVATE -Os)
         endif ()
     ENDIF ()
 


### PR DESCRIPTION
### Changelist 
- The non third party path referenced `${ELF_NAME}` which isn't a parameter of this function (it's only defined locally in embedded_binary) :(
- Changed the optimization flag to optimize-for-size `-Os` instead of unoptimized `-O0`.
  - The optimizations could fuck with the debugger but this is only for JCAN and HAL, so maybe it's okay.
  - Could consider doing something less extreme like `-Og` instead.

### Testing Done
No optimization:
<img width="385" height="97" alt="Screenshot 2026-07-12 at 1 35 14 PM" src="https://github.com/user-attachments/assets/824a51fe-938e-4785-97c6-b82ca3c7ff93" />

With optimization:
<img width="398" height="108" alt="Screenshot 2026-07-12 at 1 33 57 PM" src="https://github.com/user-attachments/assets/7b69e83a-d992-401f-82d9-a1a72ac8ff51" />